### PR TITLE
Fix template specialization problem that caused link errors in Visual Studio 2010

### DIFF
--- a/src/ccd/motion.cpp
+++ b/src/ccd/motion.cpp
@@ -525,5 +525,6 @@ Quaternion3f InterpMotion::absoluteRotation(FCL_REAL dt) const
   return delta_t * tf1.getQuatRotation();
 }
 
+template class TBVMotionBoundVisitor<RSS>;
 
 }


### PR DESCRIPTION
I have fixed a similar problem in FCL before when I ported it to Windows. Recent changes in DART have introduced such a problem again.

Visual Studio (unlike GCC it seems) does not implement a template specialization of a class if template specializations of member functions are provided. I just added a line to force a template specialization for the class.
