### PR TITLE
fix boost/cstdint.hpp datatypes

### DIFF
--- a/include/fcl/data_types.h
+++ b/include/fcl/data_types.h
@@ -44,10 +44,10 @@ namespace fcl
 {
 
 typedef double FCL_REAL;
-typedef uint64_t FCL_INT64;
-typedef int64_t FCL_UINT64;
-typedef uint32_t FCL_UINT32;
-typedef int32_t FCL_INT32;
+typedef boost::uint64_t FCL_INT64;
+typedef boost::int64_t FCL_UINT64;
+typedef boost::uint32_t FCL_UINT32;
+typedef boost::int32_t FCL_INT32;
 
 /// @brief Triangle with 3 indices for points
 class Triangle


### PR DESCRIPTION
Quoting the boost documentation:

<boost/cstdint.hpp> - Provides typedef's based on the 1999 C Standard header
<stdint.h>, wrapped in namespace boost.

This invalid usage seems to break with glibc 2.18.
