### PR TITLE
Support multiple contacts for primitive shape collision

### DIFF
--- a/include/fcl/collision_data.h
+++ b/include/fcl/collision_data.h
@@ -55,6 +55,28 @@ namespace fcl
 /// @brief Type of narrow phase GJK solver
 enum GJKSolverType {GST_LIBCCD, GST_INDEP};
 
+/// @brief Minimal contact information returned by collision
+struct ContactPoint
+{
+  /// @brief Contact normal, pointing from o1 to o2
+  Vec3f normal;
+
+  /// @brief Contact position, in world space
+  Vec3f pos;
+
+  /// @brief Penetration depth
+  FCL_REAL penetration_depth;
+
+  /// @brief Constructor
+  ContactPoint(const Vec3f& n_, const Vec3f& p_, FCL_REAL d_) : normal(n_),
+                                                                pos(p_),
+                                                                penetration_depth(d_)
+  {}
+};
+
+/// @brief Return true if _cp1's penentration depth is greater than _cp2's.
+bool comparePenDepth(const ContactPoint& _cp1, const ContactPoint& _cp2);
+
 /// @brief Contact information returned by collision
 struct Contact
 {

--- a/include/fcl/traversal/traversal_node_octree.h
+++ b/include/fcl/traversal/traversal_node_octree.h
@@ -297,14 +297,14 @@ private:
         Transform3f box_tf;
         constructBox(bv1, tf1, box, box_tf);
 
-        if(solver->shapeIntersect(box, box_tf, s, tf2, NULL, NULL, NULL))
+        if(solver->shapeIntersect(box, box_tf, s, tf2, NULL))
         {
           AABB overlap_part;
           AABB aabb1, aabb2;
           computeBV<AABB, Box>(box, box_tf, aabb1);
           computeBV<AABB, S>(s, tf2, aabb2);
           aabb1.overlap(aabb2, overlap_part);
-	  cresult->addCostSource(CostSource(overlap_part, tree1->getOccupancyThres() * s.cost_density), crequest->num_max_cost_sources);          
+          cresult->addCostSource(CostSource(overlap_part, tree1->getOccupancyThres() * s.cost_density), crequest->num_max_cost_sources);
         }
       }
 
@@ -325,7 +325,7 @@ private:
           bool is_intersect = false;
           if(!crequest->enable_contact)
           {
-            if(solver->shapeIntersect(box, box_tf, s, tf2, NULL, NULL, NULL))
+            if(solver->shapeIntersect(box, box_tf, s, tf2, NULL))
             {
               is_intersect = true;
               if(cresult->numContacts() < crequest->num_max_contacts)
@@ -334,15 +334,26 @@ private:
           }
           else
           {
-            Vec3f contact;
-            FCL_REAL depth;
-            Vec3f normal;
-
-            if(solver->shapeIntersect(box, box_tf, s, tf2, &contact, &depth, &normal))
+            std::vector<ContactPoint> contacts;
+            if(solver->shapeIntersect(box, box_tf, s, tf2, &contacts))
             {
               is_intersect = true;
-              if(cresult->numContacts() < crequest->num_max_contacts)
-                cresult->addContact(Contact(tree1, &s, root1 - tree1->getRoot(), Contact::NONE, contact, normal, depth));
+              const size_t free_space = crequest->num_max_contacts - cresult->numContacts();
+              size_t num_adding_contacts;
+
+              // If the free space is not enough to add all the new contacts, then contacts of greater penetration are added first.
+              if (free_space < contacts.size())
+              {
+                std::partial_sort(contacts.begin(), contacts.end() + free_space, contacts.end(), comparePenDepth);
+                num_adding_contacts = free_space;
+              }
+              else
+              {
+                num_adding_contacts = contacts.size();
+              }
+
+              for(size_t i = 0; i < num_adding_contacts; ++i)
+                cresult->addContact(Contact(tree1, &s, root1 - tree1->getRoot(), Contact::NONE, contacts[i].pos, contacts[i].normal, contacts[i].penetration_depth));
             }
           }
 
@@ -369,7 +380,7 @@ private:
           Transform3f box_tf;
           constructBox(bv1, tf1, box, box_tf);
 
-          if(solver->shapeIntersect(box, box_tf, s, tf2, NULL, NULL, NULL))
+          if(solver->shapeIntersect(box, box_tf, s, tf2, NULL))
           {
             AABB overlap_part;
             AABB aabb1, aabb2;
@@ -892,14 +903,26 @@ private:
           constructBox(bv1, tf1, box1, box1_tf);
           constructBox(bv2, tf2, box2, box2_tf);
 
-          Vec3f contact;
-          FCL_REAL depth;
-          Vec3f normal;
-          if(solver->shapeIntersect(box1, box1_tf, box2, box2_tf, &contact, &depth, &normal))
+          std::vector<ContactPoint> contacts;
+          if(solver->shapeIntersect(box1, box1_tf, box2, box2_tf, &contacts))
           {
             is_intersect = true;
-            if(cresult->numContacts() < crequest->num_max_contacts)
-              cresult->addContact(Contact(tree1, tree2, root1 - tree1->getRoot(), root2 - tree2->getRoot(), contact, normal, depth));
+            const size_t free_space = crequest->num_max_contacts - cresult->numContacts();
+            size_t num_adding_contacts;
+
+            // If the free space is not enough to add all the new contacts, then contacts of greater penetration are added first.
+            if (free_space < contacts.size())
+            {
+              std::partial_sort(contacts.begin(), contacts.end() + free_space, contacts.end(), comparePenDepth);
+              num_adding_contacts = free_space;
+            }
+            else
+            {
+              num_adding_contacts = contacts.size();
+            }
+
+            for(size_t i = 0; i < num_adding_contacts; ++i)
+              cresult->addContact(Contact(tree1, tree2, root1 - tree1->getRoot(), root2 - tree2->getRoot(), contacts[i].pos, contacts[i].normal, contacts[i].penetration_depth));
           }
         }
 

--- a/include/fcl/traversal/traversal_node_shapes.h
+++ b/include/fcl/traversal/traversal_node_shapes.h
@@ -38,6 +38,8 @@
 #ifndef FCL_TRAVERSAL_NODE_SHAPES_H
 #define FCL_TRAVERSAL_NODE_SHAPES_H
 
+#include <algorithm>
+
 #include "fcl/collision_data.h"
 #include "fcl/traversal/traversal_node_base.h"
 #include "fcl/narrowphase/narrowphase.h"
@@ -48,7 +50,6 @@
 
 namespace fcl
 {
-
 
 /// @brief Traversal node for collision between two shapes
 template<typename S1, typename S2, typename NarrowPhaseSolver>
@@ -77,18 +78,31 @@ public:
       bool is_collision = false;
       if(request.enable_contact)
       {
-        Vec3f contact_point, normal;
-        FCL_REAL penetration_depth;
-        if(nsolver->shapeIntersect(*model1, tf1, *model2, tf2, &contact_point, &penetration_depth, &normal))
+        std::vector<ContactPoint> contacts;
+        if(nsolver->shapeIntersect(*model1, tf1, *model2, tf2, &contacts))
         {
           is_collision = true;
-          if(request.num_max_contacts > result->numContacts())
-            result->addContact(Contact(model1, model2, Contact::NONE, Contact::NONE, contact_point, normal, penetration_depth));
+          const size_t free_space = request.num_max_contacts - result->numContacts();
+          size_t num_adding_contacts;
+
+          // If the free space is not enough to add all the new contacts, then contacts of greater penetration are added first.
+          if (free_space < contacts.size())
+          {
+            std::partial_sort(contacts.begin(), contacts.end() + free_space, contacts.end(), comparePenDepth);
+            num_adding_contacts = free_space;
+          }
+          else
+          {
+            num_adding_contacts = contacts.size();
+          }
+
+          for(size_t i = 0; i < num_adding_contacts; ++i)
+            result->addContact(Contact(model1, model2, Contact::NONE, Contact::NONE, contacts[i].pos, contacts[i].normal, contacts[i].penetration_depth));
         }
       }
       else
       {
-        if(nsolver->shapeIntersect(*model1, tf1, *model2, tf2, NULL, NULL, NULL))
+        if(nsolver->shapeIntersect(*model1, tf1, *model2, tf2, NULL))
         {
           is_collision = true;
           if(request.num_max_contacts > result->numContacts())
@@ -108,7 +122,7 @@ public:
     }
     else if((!model1->isFree() && !model2->isFree()) && request.enable_cost)
     {
-      if(nsolver->shapeIntersect(*model1, tf1, *model2, tf2, NULL, NULL, NULL))
+      if(nsolver->shapeIntersect(*model1, tf1, *model2, tf2, NULL))
       {
         AABB aabb1, aabb2;
         computeBV<AABB, S1>(*model1, tf1, aabb1);

--- a/src/broadphase/broadphase_dynamic_AABB_tree.cpp
+++ b/src/broadphase/broadphase_dynamic_AABB_tree.cpp
@@ -746,7 +746,7 @@ void DynamicAABBTreeCollisionManager::collide(CollisionObject* obj, void* cdata,
     {
       if(!octree_as_geometry_collide)
       {
-        const OcTree* octree = static_cast<const OcTree*>(obj->getCollisionGeometry());
+        const OcTree* octree = static_cast<const OcTree*>(obj->collisionGeometry().get());
         details::dynamic_AABB_tree::collisionRecurse(dtree.getRoot(), octree, octree->getRoot(), octree->getRootBV(), obj->getTransform(), cdata, callback); 
       }
       else
@@ -770,7 +770,7 @@ void DynamicAABBTreeCollisionManager::distance(CollisionObject* obj, void* cdata
     {
       if(!octree_as_geometry_distance)
       {
-        const OcTree* octree = static_cast<const OcTree*>(obj->getCollisionGeometry());
+        const OcTree* octree = static_cast<const OcTree*>(obj->collisionGeometry().get());
         details::dynamic_AABB_tree::distanceRecurse(dtree.getRoot(), octree, octree->getRoot(), octree->getRootBV(), obj->getTransform(), cdata, callback, min_dist);
       }
       else

--- a/src/broadphase/broadphase_dynamic_AABB_tree_array.cpp
+++ b/src/broadphase/broadphase_dynamic_AABB_tree_array.cpp
@@ -771,7 +771,7 @@ void DynamicAABBTreeCollisionManager_Array::collide(CollisionObject* obj, void* 
     {
       if(!octree_as_geometry_collide)
       {
-        const OcTree* octree = static_cast<const OcTree*>(obj->getCollisionGeometry());
+        const OcTree* octree = static_cast<const OcTree*>(obj->collisionGeometry().get());
         details::dynamic_AABB_tree_array::collisionRecurse(dtree.getNodes(), dtree.getRoot(), octree, octree->getRoot(), octree->getRootBV(), obj->getTransform(), cdata, callback); 
       }
       else
@@ -795,7 +795,7 @@ void DynamicAABBTreeCollisionManager_Array::distance(CollisionObject* obj, void*
     {
       if(!octree_as_geometry_distance)
       {
-        const OcTree* octree = static_cast<const OcTree*>(obj->getCollisionGeometry());
+        const OcTree* octree = static_cast<const OcTree*>(obj->collisionGeometry().get());
         details::dynamic_AABB_tree_array::distanceRecurse(dtree.getNodes(), dtree.getRoot(), octree, octree->getRoot(), octree->getRootBV(), obj->getTransform(), cdata, callback, min_dist);
       }
       else

--- a/src/collision_data.cpp
+++ b/src/collision_data.cpp
@@ -39,6 +39,11 @@
 namespace fcl
 {
 
+bool comparePenDepth(const ContactPoint& _cp1, const ContactPoint& _cp2)
+{
+  return (_cp1.penetration_depth > _cp2.penetration_depth);
+}
+
 bool CollisionRequest::isSatisfied(const CollisionResult& result) const
 {
   return (!enable_cost) && result.isCollision() && (num_max_contacts <= result.numContacts());

--- a/test/test_fcl_collision.cpp
+++ b/test/test_fcl_collision.cpp
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(OBB_Box_test)
     GJKSolver_libccd solver;
 
     bool overlap_obb = obb1.overlap(obb2);
-    bool overlap_box = solver.shapeIntersect(box1, box1_tf, box2, box2_tf, NULL, NULL, NULL);
+    bool overlap_box = solver.shapeIntersect(box1, box1_tf, box2, box2_tf, NULL);
     
     BOOST_CHECK(overlap_obb == overlap_box);
   }
@@ -154,7 +154,7 @@ BOOST_AUTO_TEST_CASE(OBB_shape_test)
       computeBV(sphere, transforms[i], obb2);
  
       bool overlap_obb = obb1.overlap(obb2);
-      bool overlap_sphere = solver.shapeIntersect(box1, box1_tf, sphere, transforms[i], NULL, NULL, NULL);
+      bool overlap_sphere = solver.shapeIntersect(box1, box1_tf, sphere, transforms[i], NULL);
       BOOST_CHECK(overlap_obb >= overlap_sphere);
     }
 
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(OBB_shape_test)
       computeBV(capsule, transforms[i], obb2);
       
       bool overlap_obb = obb1.overlap(obb2);
-      bool overlap_capsule = solver.shapeIntersect(box1, box1_tf, capsule, transforms[i], NULL, NULL, NULL);
+      bool overlap_capsule = solver.shapeIntersect(box1, box1_tf, capsule, transforms[i], NULL);
       BOOST_CHECK(overlap_obb >= overlap_capsule);
     }
 
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(OBB_shape_test)
       computeBV(cone, transforms[i], obb2);
       
       bool overlap_obb = obb1.overlap(obb2);
-      bool overlap_cone = solver.shapeIntersect(box1, box1_tf, cone, transforms[i], NULL, NULL, NULL);
+      bool overlap_cone = solver.shapeIntersect(box1, box1_tf, cone, transforms[i], NULL);
       BOOST_CHECK(overlap_obb >= overlap_cone);
     }
 
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(OBB_shape_test)
       computeBV(cylinder, transforms[i], obb2);
       
       bool overlap_obb = obb1.overlap(obb2);
-      bool overlap_cylinder = solver.shapeIntersect(box1, box1_tf, cylinder, transforms[i], NULL, NULL, NULL);
+      bool overlap_cylinder = solver.shapeIntersect(box1, box1_tf, cylinder, transforms[i], NULL);
       BOOST_CHECK(overlap_obb >= overlap_cylinder);
     }
   }

--- a/test/test_fcl_geometric_shapes.cpp
+++ b/test/test_fcl_geometric_shapes.cpp
@@ -51,6 +51,16 @@ FCL_REAL extents [6] = {0, 0, 0, 10, 10, 10};
 GJKSolver_libccd solver1;
 GJKSolver_indep solver2;
 
+void getContactInfo(const std::vector<ContactPoint>& contacts, size_t index,
+                    Vec3f& contact, Vec3f& normal, FCL_REAL& depth)
+{
+  assert(index < contacts.size());
+
+  contact = contacts[index].pos;
+  normal = contacts[index].normal;
+  depth = contacts[index].penetration_depth;
+}
+
 #define BOOST_CHECK_FALSE(p) BOOST_CHECK(!(p))
 
 BOOST_AUTO_TEST_CASE(gjkcache)
@@ -126,73 +136,73 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_spheresphere)
   CollisionResult result;
   bool res;
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(40, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(40, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(40, 0, 0)), request, result) > 0);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(40, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(40, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(40, 0, 0)), request, result) > 0);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(30, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(30, 0, 0)), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(30, 0, 0)), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(30.01, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(30.01, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(30.01, 0, 0)), request, result) > 0);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(29.9, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(29.9, 0, 0)), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(29.9, 0, 0)), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(29.9, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(29.9, 0, 0)), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(29.9, 0, 0)), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform, NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform, NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform, request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(-29.9, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(-29.9, 0, 0)), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(-29.9, 0, 0)), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(-29.9, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(-29.9, 0, 0)), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(-29.9, 0, 0)), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(-30, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(-30, 0, 0)), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(-30, 0, 0)), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(-30.01, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(-30.01, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(-30.01, 0, 0)), request, result) > 0);
@@ -211,27 +221,33 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_boxbox)
   CollisionRequest request;
   CollisionResult result;
 
+  Vec3f contact;
+  FCL_REAL depth;
+  Vec3f normal;
+  std::vector<ContactPoint> contacts;
   bool res;
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL, NULL, NULL);
+  const double tolerance = 1e-6;
+
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform, NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform, NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform, request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(15, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(15, 0, 0)), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(15, 0, 0)), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(15.01, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(15.01, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(15.01, 0, 0)), request, result) > 0);
@@ -239,17 +255,47 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_boxbox)
 
   Quaternion3f q;
   q.fromAxisAngle(Vec3f(0, 0, 1), (FCL_REAL)3.140 / 6);
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(q), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(q), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(q), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(q), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(q), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(q), request, result) > 0);
   BOOST_CHECK(res);
+
+
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(0, 0, 30)), &contacts);
+  BOOST_CHECK(res);
+  BOOST_CHECK(contacts.size() == 4);
+
+  Vec3f p1(-5, -5, 25);
+  Vec3f p2(-5, +5, 25);
+  Vec3f p3(+5, +5, 25);
+  Vec3f p4(+5, -5, 25);
+
+  getContactInfo(contacts, 0, contact, normal, depth);
+  BOOST_CHECK(std::abs(depth) < tolerance);
+  BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)));
+  BOOST_CHECK(contact.equal(Vec3f(-5, -5, 25)));
+
+  getContactInfo(contacts, 1, contact, normal, depth);
+  BOOST_CHECK(std::abs(depth) < tolerance);
+  BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)));
+  BOOST_CHECK(contact.equal(Vec3f(-5, 5, 25)));
+
+  getContactInfo(contacts, 2, contact, normal, depth);
+  BOOST_CHECK(std::abs(depth) < tolerance);
+  BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)));
+  BOOST_CHECK(contact.equal(Vec3f(5, 5, 25)));
+
+  getContactInfo(contacts, 3, contact, normal, depth);
+  BOOST_CHECK(std::abs(depth) < tolerance);
+  BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)));
+  BOOST_CHECK(contact.equal(Vec3f(5, -5, 25)));
 }
 
 BOOST_AUTO_TEST_CASE(shapeIntersection_spherebox)
@@ -266,38 +312,38 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_spherebox)
 
   bool res;
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform, NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform, NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform, request, result) > 0);
   BOOST_CHECK(res);
 
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(22.5, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(22.5, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(22.5, 0, 0)), request, result) > 0);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(22.501, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(22.501, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(22.501, 0, 0)), request, result) > 0);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(22.4, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(22.4, 0, 0)), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(22.4, 0, 0)), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(22.4, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(22.4, 0, 0)), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(22.4, 0, 0)), request, result) > 0);
@@ -318,37 +364,37 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_cylindercylinder)
 
   bool res;
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform, NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform, NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform, request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(9.9, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(9.9, 0, 0)), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(9.9, 0, 0)), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(9.9, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(9.9, 0, 0)), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(9.9, 0, 0)), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(10, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(10, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(10, 0, 0)), request, result) > 0);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(10.01, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(10.01, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(10.01, 0, 0)), request, result) > 0);
@@ -369,49 +415,49 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_conecone)
 
   bool res;
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform, NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform, NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform, request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(9.9, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(9.9, 0, 0)), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(9.9, 0, 0)), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(9.9, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(9.9, 0, 0)), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(9.9, 0, 0)), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(10.001, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(10.001, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(10.001, 0, 0)), request, result) > 0);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(10.001, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(10.001, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(10.001, 0, 0)), request, result) > 0);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(0, 0, 9.9)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(0, 0, 9.9)), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(0, 0, 9.9)), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(0, 0, 9.9)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(0, 0, 9.9)), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(0, 0, 9.9)), request, result) > 0);
@@ -432,61 +478,61 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_conecylinder)
 
   bool res;
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform, NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform, NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform, request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(9.9, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(9.9, 0, 0)), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(9.9, 0, 0)), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(9.9, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(9.9, 0, 0)), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(9.9, 0, 0)), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(10.01, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(10.01, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(10, 0, 0)), request, result) > 0);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(10.01, 0, 0)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(10.01, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(10.01, 0, 0)), request, result) > 0);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(0, 0, 9.9)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(0, 0, 9.9)), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(0, 0, 9.9)), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(0, 0, 9.9)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(0, 0, 9.9)), NULL);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(0, 0, 9.9)), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(0, 0, 10.01)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(0, 0, 10.01)), NULL);
   BOOST_CHECK_FALSE(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(0, 0, 10)), request, result) > 0);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(0, 0, 10.01)), NULL, NULL, NULL);
+  res = solver1.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(0, 0, 10.01)), NULL);
   BOOST_CHECK_FALSE(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(0, 0, 10.01)), request, result) > 0);
@@ -535,57 +581,73 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacesphere)
   Vec3f contact;
   FCL_REAL depth;
   Vec3f normal;
+  std::vector<ContactPoint> contacts;
   bool res;
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(-5, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(-5, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 15) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(-2.5, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 15) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(-2.5, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(-7.5, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(-7.5, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-10.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-10.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-10.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-10.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(10.1, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(10.1, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 20.1) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0.05, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(10.1, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(10.1, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 20.1) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
@@ -603,55 +665,67 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planesphere)
   Vec3f contact;
   FCL_REAL depth;
   Vec3f normal;
+  std::vector<ContactPoint> contacts;
   bool res;
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)) || normal.equal(Vec3f(1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))) || normal.equal(transform.getQuatRotation().transform(Vec3f(1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(5, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(5, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(-5, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(-5, 0, 0))));
 
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-10.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-10.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-10.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-10.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(10.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(10.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(10.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(10.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 }
 
@@ -666,63 +740,79 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacebox)
   Vec3f contact;
   FCL_REAL depth;
   Vec3f normal;
+  std::vector<ContactPoint> contacts;
   bool res;
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(-1.25, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(-1.25, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(1.25, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(1.25, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 3.75) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(-0.625, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(1.25, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(1.25, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 3.75) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(-0.625, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-1.25, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-1.25, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 1.25) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(-1.875, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-1.25, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-1.25, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 1.25) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(-1.875, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(2.51, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(2.51, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5.01) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0.005, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(2.51, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(2.51, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5.01) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0.005, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-2.51, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-2.51, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-2.51, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-2.51, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, Transform3f(transform.getQuatRotation()), hs, Transform3f(), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(transform.getQuatRotation()), hs, Transform3f(), &contacts);
   BOOST_CHECK(res);
 }
 
@@ -737,57 +827,69 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planebox)
   Vec3f contact;
   FCL_REAL depth;
   Vec3f normal;
+  std::vector<ContactPoint> contacts;
   bool res;
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)) || normal.equal(Vec3f(1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))) || normal.equal(transform.getQuatRotation().transform(Vec3f(1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(1.25, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(1.25, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 1.25) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(1.25, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(1.25, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(1.25, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 1.25) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(1.25, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-1.25, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-1.25, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 1.25) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(-1.25, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-1.25, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-1.25, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 1.25) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(-1.25, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(2.51, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(2.51, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(2.51, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(2.51, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-2.51, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-2.51, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-2.51, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-2.51, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, Transform3f(transform.getQuatRotation()), hs, Transform3f(), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(transform.getQuatRotation()), hs, Transform3f(), &contacts);
   BOOST_CHECK(res);
 }
 
@@ -802,60 +904,76 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacecapsule)
   Vec3f contact;
   FCL_REAL depth;
   Vec3f normal;
+  std::vector<ContactPoint> contacts;
   bool res;
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(-2.5, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(-2.5, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(-1.25, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(-1.25, 0, 0))));
   
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(-3.75, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(-3.75, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(5.1, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(5.1, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10.1) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0.05, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(5.1, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(5.1, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10.1) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0.05, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-5.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-5.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-5.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-5.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
 
@@ -863,58 +981,75 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacecapsule)
 
   hs = Halfspace(Vec3f(0, 1, 0), 0);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, -1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, -2.5, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, -1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, -2.5, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, -1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, -1.25, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, -1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, -1.25, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, -1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, -3.75, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, -1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, -3.75, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 5.1, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 5.1, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10.1) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, -1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0.05, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 5.1, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 5.1, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10.1) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, -1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0.05, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -5.1, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -5.1, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -5.1, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -5.1, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
 
@@ -922,58 +1057,74 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacecapsule)
 
   hs = Halfspace(Vec3f(0, 0, 1), 0);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, -5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, -1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, -5))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 12.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, -3.75)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 12.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, -1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, -3.75))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, -6.25)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, -1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, -6.25))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 10.1)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 10.1)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 20.1) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, 0.05)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 10.1)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 10.1)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 20.1) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, -1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, 0.05))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -10.1)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -10.1)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -10.1)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -10.1)), &contacts);
   BOOST_CHECK_FALSE(res);
 }
 
@@ -988,54 +1139,66 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecapsule)
   Vec3f contact;
   FCL_REAL depth;
   Vec3f normal;
+  std::vector<ContactPoint> contacts;
   bool res;
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)) || normal.equal(Vec3f(1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))) || normal.equal(transform.getQuatRotation().transform(Vec3f(1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(2.5, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(2.5, 0, 0))));
   
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(-2.5, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(-2.5, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(5.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(5.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(5.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(5.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-5.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-5.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-5.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-5.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
 
@@ -1043,52 +1206,64 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecapsule)
 
   hs = Plane(Vec3f(0, 1, 0), 0);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, -1, 0)) || normal.equal(Vec3f(0, 1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, -1, 0))) || normal.equal(transform.getQuatRotation().transform(Vec3f(0, 1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, 2.5, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 2.5, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, -1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, -2.5, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, -1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, -2.5, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 5.1, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 5.1, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 5.1, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 5.1, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -5.1, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -5.1, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -5.1, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -5.1, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
 
@@ -1096,52 +1271,64 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecapsule)
 
   hs = Plane(Vec3f(0, 0, 1), 0);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)) || normal.equal(Vec3f(0, 0, 1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, -1))) || normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, 1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, 1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, 2.5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, 1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, 2.5))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, -2.5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, -1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, -2.5))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 10.1)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 10.1)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 10.1)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 10.1)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -10.1)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -10.1)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -10.1)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -10.1)), &contacts);
   BOOST_CHECK_FALSE(res);
 }
 
@@ -1156,60 +1343,76 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacecylinder)
   Vec3f contact;
   FCL_REAL depth;
   Vec3f normal;
+  std::vector<ContactPoint> contacts;
   bool res;
   
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(-2.5, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(-2.5, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(-1.25, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(-1.25, 0, 0))));
   
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(-3.75, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(-3.75, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(5.1, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(5.1, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10.1) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0.05, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(5.1, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(5.1, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10.1) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0.05, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-5.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-5.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-5.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-5.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
 
@@ -1217,58 +1420,74 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacecylinder)
 
   hs = Halfspace(Vec3f(0, 1, 0), 0);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, -1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, -2.5, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, -1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, -2.5, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, -1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, -1.25, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, -1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, -1.25, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, -1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, -3.75, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, -1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, -3.75, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 5.1, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 5.1, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10.1) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, -1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0.05, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 5.1, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 5.1, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10.1) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, -1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0.05, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -5.1, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -5.1, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -5.1, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -5.1, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
 
@@ -1276,58 +1495,74 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacecylinder)
 
   hs = Halfspace(Vec3f(0, 0, 1), 0);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, -2.5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, -1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, -2.5))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, -1.25)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, -1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, -1.25))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, -3.75)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, -1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, -3.75))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 5.1)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 5.1)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10.1) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, 0.05)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 5.1)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 5.1)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10.1) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, -1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, 0.05))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -5.1)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -5.1)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -5.1)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -5.1)), &contacts);
   BOOST_CHECK_FALSE(res);
 }
 
@@ -1342,54 +1577,66 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecylinder)
   Vec3f contact;
   FCL_REAL depth;
   Vec3f normal;
+  std::vector<ContactPoint> contacts;
   bool res;
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)) || normal.equal(Vec3f(1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))) || normal.equal(transform.getQuatRotation().transform(Vec3f(1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(2.5, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(2.5, 0, 0))));
   
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(-2.5, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(-2.5, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(5.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(5.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(5.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(5.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-5.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-5.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-5.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-5.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
 
@@ -1397,52 +1644,64 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecylinder)
 
   hs = Plane(Vec3f(0, 1, 0), 0);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, -1, 0)) || normal.equal(Vec3f(0, 1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, -1, 0))) || normal.equal(transform.getQuatRotation().transform(Vec3f(0, 1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, 2.5, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 2.5, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, -1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, -2.5, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, -1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, -2.5, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 5.1, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 5.1, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 5.1, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 5.1, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -5.1, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -5.1, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -5.1, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -5.1, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
 
@@ -1450,52 +1709,64 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecylinder)
 
   hs = Plane(Vec3f(0, 0, 1), 0);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)) || normal.equal(Vec3f(0, 0, 1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, -1))) || normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, 1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, 1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, 2.5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, 1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, 2.5))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, -2.5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, -1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, -2.5))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 10.1)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 10.1)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 10.1)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 10.1)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -10.1)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -10.1)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -10.1)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -10.1)), &contacts);
   BOOST_CHECK_FALSE(res);
 }
 
@@ -1511,60 +1782,76 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacecone)
   Vec3f contact;
   FCL_REAL depth;
   Vec3f normal;
+  std::vector<ContactPoint> contacts;
   bool res;
   
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(-2.5, 0, -5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(-2.5, 0, -5))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(-1.25, 0, -5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(-1.25, 0, -5))));
   
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(-3.75, 0, -5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(-3.75, 0, -5))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(5.1, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(5.1, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10.1) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0.05, 0, -5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(5.1, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(5.1, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10.1) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0.05, 0, -5))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-5.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-5.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-5.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-5.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
 
@@ -1572,58 +1859,74 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacecone)
 
   hs = Halfspace(Vec3f(0, 1, 0), 0);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, -1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, -2.5, -5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, -1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, -2.5, -5))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, -1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, -1.25, -5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, -1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, -1.25, -5))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, -1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, -3.75, -5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, -1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, -3.75, -5))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 5.1, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 5.1, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10.1) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, -1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0.05, -5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 5.1, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 5.1, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10.1) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, -1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0.05, -5))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -5.1, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -5.1, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -5.1, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -5.1, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
 
@@ -1631,58 +1934,74 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_halfspacecone)
 
   hs = Halfspace(Vec3f(0, 0, 1), 0);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, -2.5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, -1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, -2.5))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, -1.25)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 7.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, -1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, -1.25))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, -3.75)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, -1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, -3.75))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 5.1)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 5.1)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10.1) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, 0.05)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 5.1)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 5.1)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 10.1) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, -1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, 0.05))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -5.1)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -5.1)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -5.1)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -5.1)), &contacts);
   BOOST_CHECK_FALSE(res);
 }
 
@@ -1697,54 +2016,66 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecone)
   Vec3f contact;
   FCL_REAL depth;
   Vec3f normal;
+  std::vector<ContactPoint> contacts;
   bool res;
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)) || normal.equal(Vec3f(1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))) || normal.equal(transform.getQuatRotation().transform(Vec3f(1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(2.5, 0, -2.5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(2.5, 0, -2.5))));
   
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(-1, 0, 0)));
   BOOST_CHECK(contact.equal(Vec3f(-2.5, 0, -2.5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-2.5, 0, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-2.5, 0, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(-1, 0, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(-2.5, 0, -2.5))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(5.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(5.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(5.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(5.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-5.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(-5.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-5.1, 0, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(-5.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
 
@@ -1752,52 +2083,64 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecone)
 
   hs = Plane(Vec3f(0, 1, 0), 0);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, -1, 0)) || normal.equal(Vec3f(0, 1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, -1, 0))) || normal.equal(transform.getQuatRotation().transform(Vec3f(0, 1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, 2.5, -2.5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 2.5, -2.5))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, -1, 0)));
   BOOST_CHECK(contact.equal(Vec3f(0, -2.5, -2.5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -2.5, 0)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -2.5, 0)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, -1, 0))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, -2.5, -2.5))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 5.1, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 5.1, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 5.1, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 5.1, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -5.1, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, -5.1, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -5.1, 0)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, -5.1, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
 
@@ -1805,52 +2148,64 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_planecone)
 
   hs = Plane(Vec3f(0, 0, 1), 0);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)) || normal.equal(Vec3f(0, 0, 1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, 0)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform, &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform, &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, -1))) || normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, 1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, 0))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, 1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, 2.5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, 1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, 2.5))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(Vec3f(0, 0, -1)));
   BOOST_CHECK(contact.equal(Vec3f(0, 0, -2.5)));
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -2.5)), &contact, &depth, &normal);
+  contacts.clear();
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -2.5)), &contacts);
+  getContactInfo(contacts, 0, contact, normal, depth);
   BOOST_CHECK(res);
   BOOST_CHECK(std::abs(depth - 2.5) < 0.001);
   BOOST_CHECK(normal.equal(transform.getQuatRotation().transform(Vec3f(0, 0, -1))));
   BOOST_CHECK(contact.equal(transform.transform(Vec3f(0, 0, -2.5))));
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 10.1)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, 10.1)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 10.1)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, 10.1)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -10.1)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, Transform3f(), hs, Transform3f(Vec3f(0, 0, -10.1)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -10.1)), &contact, &depth, &normal);
+  res = solver1.shapeIntersect(s, transform, hs, transform * Transform3f(Vec3f(0, 0, -10.1)), &contacts);
   BOOST_CHECK_FALSE(res);
 }
 
@@ -2143,114 +2498,102 @@ BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_spheresphere)
   CollisionRequest request;
   CollisionResult result;
 
-  Vec3f contact;
-  FCL_REAL penetration_depth;
-  Vec3f normal;  
+  std::vector<ContactPoint> contacts;
   bool res;
 
   request.gjk_solver_type = GST_INDEP; // use indep GJK solver
 
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(40, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(40, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res); 
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(40, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(40, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(40, 0, 0)), request, result) > 0);
   BOOST_CHECK_FALSE(res);
 
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(40, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(40, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(40, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(40, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(40, 0, 0)), request, result) > 0);
   BOOST_CHECK_FALSE(res);
 
-
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(30, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(30, 0, 0)), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(30, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(30, 0, 0)), &contacts);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(30, 0, 0)), request, result) > 0);
   BOOST_CHECK(res);
 
-
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(30.01, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(30.01, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(30.01, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(30.01, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(30.01, 0, 0)), request, result) > 0);
   BOOST_CHECK_FALSE(res);
 
-
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(29.9, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(29.9, 0, 0)), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(29.9, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(29.9, 0, 0)), &contacts);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(29.9, 0, 0)), request, result) > 0);
   BOOST_CHECK(res);
 
-
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(29.9, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(29.9, 0, 0)), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(29.9, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(29.9, 0, 0)), &contacts);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(29.9, 0, 0)), request, result) > 0);
   BOOST_CHECK(res);
 
-
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), &contacts);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(), request, result) > 0);
   BOOST_CHECK(res);
 
-
-  res = solver2.shapeIntersect(s1, transform, s2, transform, NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, transform, s2, transform, NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform, &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, transform, s2, transform, &contacts);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform, request, result) > 0);
   BOOST_CHECK(res);
 
-
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(-29.9, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(-29.9, 0, 0)), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(-29.9, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(-29.9, 0, 0)), &contacts);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(-29.9, 0, 0)), request, result) > 0);
   BOOST_CHECK(res);
 
-
-
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(-29.9, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(-29.9, 0, 0)), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(-29.9, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(-29.9, 0, 0)), &contacts);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(-29.9, 0, 0)), request, result) > 0);
   BOOST_CHECK(res);
 
-
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(-30, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(-30, 0, 0)), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(-30, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(-30, 0, 0)), &contacts);
   BOOST_CHECK(res);
   result.clear();
   res = (collide(&s1, Transform3f(), &s2, Transform3f(Vec3f(-30, 0, 0)), request, result) > 0);
   BOOST_CHECK(res);
 
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(-30.01, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(-30.01, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(-30.01, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(-30.01, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
   result.clear();
   res = (collide(&s1, transform, &s2, transform * Transform3f(Vec3f(-30.01, 0, 0)), request, result) > 0);
@@ -2265,41 +2608,39 @@ BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_boxbox)
   Transform3f transform;
   generateRandomTransform(extents, transform);
 
-  Vec3f contact;
-  FCL_REAL penetration_depth;
-  Vec3f normal;  
+  std::vector<ContactPoint> contacts;
   bool res;
 
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), &contact, &penetration_depth, &normal);
-  BOOST_CHECK(res);
-
-  res = solver2.shapeIntersect(s1, transform, s2, transform, NULL, NULL, NULL);
-  BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform, &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), &contacts);
   BOOST_CHECK(res);
 
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(15, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, transform, s2, transform, NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(15, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, transform, s2, transform, &contacts);
   BOOST_CHECK(res);
 
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(15.01, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(15, 0, 0)), NULL);
+  BOOST_CHECK(res);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(15, 0, 0)), &contacts);
+  BOOST_CHECK(res);
+
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(15.01, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(15.01, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(15.01, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
   Quaternion3f q;
   q.fromAxisAngle(Vec3f(0, 0, 1), (FCL_REAL)3.140 / 6);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(q), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(q), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(q), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(q), &contacts);
   BOOST_CHECK(res);
   
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(q), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(q), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(q), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(q), &contacts);
   BOOST_CHECK(res);
 }
 
@@ -2311,39 +2652,37 @@ BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_spherebox)
   Transform3f transform;
   generateRandomTransform(extents, transform);
 
-  Vec3f contact;
-  FCL_REAL penetration_depth;
-  Vec3f normal;  
+  std::vector<ContactPoint> contacts;
   bool res;
 
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), &contact, &penetration_depth, &normal);
-  BOOST_CHECK(res);
-
-  res = solver2.shapeIntersect(s1, transform, s2, transform, NULL, NULL, NULL);
-  BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform, &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), &contacts);
   BOOST_CHECK(res);
 
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(22.5, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, transform, s2, transform, NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(22.5, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, transform, s2, transform, &contacts);
   BOOST_CHECK(res);
 
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(22.51, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(22.5, 0, 0)), NULL);
+  BOOST_CHECK(res);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(22.5, 0, 0)), &contacts);
+  BOOST_CHECK(res);
+
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(22.51, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(22.51, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(22.51, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(22.4, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(22.4, 0, 0)), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(22.4, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(22.4, 0, 0)), &contacts);
   BOOST_CHECK(res);
 
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(22.4, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(22.4, 0, 0)), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(22.4, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(22.4, 0, 0)), &contacts);
   BOOST_CHECK(res);
 }
 
@@ -2355,39 +2694,37 @@ BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_cylindercylinder)
   Transform3f transform;
   generateRandomTransform(extents, transform);
 
-  Vec3f contact;
-  FCL_REAL penetration_depth;
-  Vec3f normal;  
+  std::vector<ContactPoint> contacts;
   bool res;
 
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), &contact, &penetration_depth, &normal);
-  BOOST_CHECK(res);
-
-  res = solver2.shapeIntersect(s1, transform, s2, transform, NULL, NULL, NULL);
-  BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform, &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), &contacts);
   BOOST_CHECK(res);
 
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(9.9, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, transform, s2, transform, NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(9.9, 0, 0)), &contact, &penetration_depth, &normal);
-  BOOST_CHECK(res);
-
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(9.9, 0, 0)), NULL, NULL, NULL);
-  BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(9.9, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, transform, s2, transform, &contacts);
   BOOST_CHECK(res);
 
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(10, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(9.9, 0, 0)), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(10, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(9.9, 0, 0)), &contacts);
   BOOST_CHECK(res);
 
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(10.1, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(9.9, 0, 0)), NULL);
+  BOOST_CHECK(res);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(9.9, 0, 0)), &contacts);
+  BOOST_CHECK(res);
+
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(10, 0, 0)), NULL);
+  BOOST_CHECK(res);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(10, 0, 0)), &contacts);
+  BOOST_CHECK(res);
+
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(10.1, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(10.1, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(10.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 }
 
@@ -2399,49 +2736,47 @@ BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_conecone)
   Transform3f transform;
   generateRandomTransform(extents, transform);
 
-  Vec3f contact;
-  FCL_REAL penetration_depth;
-  Vec3f normal;  
+  std::vector<ContactPoint> contacts;
   bool res;
 
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), &contact, &penetration_depth, &normal);
-  BOOST_CHECK(res);
-
-  res = solver2.shapeIntersect(s1, transform, s2, transform, NULL, NULL, NULL);
-  BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform, &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), &contacts);
   BOOST_CHECK(res);
 
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(9.9, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, transform, s2, transform, NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(9.9, 0, 0)), &contact, &penetration_depth, &normal);
-  BOOST_CHECK(res);
-
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(9.9, 0, 0)), NULL, NULL, NULL);
-  BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(9.9, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, transform, s2, transform, &contacts);
   BOOST_CHECK(res);
 
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(10.1, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(9.9, 0, 0)), NULL);
+  BOOST_CHECK(res);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(9.9, 0, 0)), &contacts);
+  BOOST_CHECK(res);
+
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(9.9, 0, 0)), NULL);
+  BOOST_CHECK(res);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(9.9, 0, 0)), &contacts);
+  BOOST_CHECK(res);
+
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(10.1, 0, 0)), NULL);
   BOOST_CHECK_FALSE(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(10.1, 0, 0)), &contact, &penetration_depth, &normal);
-  BOOST_CHECK_FALSE(res);
-
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(10.1, 0, 0)), NULL, NULL, NULL);
-  BOOST_CHECK_FALSE(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(10.1, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(10.1, 0, 0)), &contacts);
   BOOST_CHECK_FALSE(res);
 
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(0, 0, 9.9)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(10.1, 0, 0)), NULL);
+  BOOST_CHECK_FALSE(res);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(10.1, 0, 0)), &contacts);
+  BOOST_CHECK_FALSE(res);
+
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(0, 0, 9.9)), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(0, 0, 9.9)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(0, 0, 9.9)), &contacts);
   BOOST_CHECK(res);
 
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(0, 0, 9.9)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(0, 0, 9.9)), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(0, 0, 9.9)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(0, 0, 9.9)), &contacts);
   BOOST_CHECK(res);
 }
 
@@ -2453,59 +2788,57 @@ BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_conecylinder)
   Transform3f transform;
   generateRandomTransform(extents, transform);
 
-  Vec3f contact;
-  FCL_REAL penetration_depth;
-  Vec3f normal;  
+  std::vector<ContactPoint> contacts;
   bool res;
 
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), &contact, &penetration_depth, &normal);
-  BOOST_CHECK(res);
-
-  res = solver2.shapeIntersect(s1, transform, s2, transform, NULL, NULL, NULL);
-  BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform, &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(), &contacts);
   BOOST_CHECK(res);
 
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(9.9, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, transform, s2, transform, NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(9.9, 0, 0)), &contact, &penetration_depth, &normal);
-  BOOST_CHECK(res);
-
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(9.9, 0, 0)), NULL, NULL, NULL);
-  BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(9.9, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, transform, s2, transform, &contacts);
   BOOST_CHECK(res);
 
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(10, 0, 0)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(9.9, 0, 0)), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(10, 0, 0)), &contact, &penetration_depth, &normal);
-  BOOST_CHECK(res);
-
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(10, 0, 0)), NULL, NULL, NULL);
-  BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(10, 0, 0)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(9.9, 0, 0)), &contacts);
   BOOST_CHECK(res);
 
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(0, 0, 9.9)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(9.9, 0, 0)), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(0, 0, 9.9)), &contact, &penetration_depth, &normal);
-  BOOST_CHECK(res);
-
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(0, 0, 9.9)), NULL, NULL, NULL);
-  BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(0, 0, 9.9)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(9.9, 0, 0)), &contacts);
   BOOST_CHECK(res);
 
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(0, 0, 10)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(10, 0, 0)), NULL);
   BOOST_CHECK(res);
-  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(0, 0, 10)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(10, 0, 0)), &contacts);
   BOOST_CHECK(res);
 
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(0, 0, 10.1)), NULL, NULL, NULL);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(10, 0, 0)), NULL);
+  BOOST_CHECK(res);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(10, 0, 0)), &contacts);
+  BOOST_CHECK(res);
+
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(0, 0, 9.9)), NULL);
+  BOOST_CHECK(res);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(0, 0, 9.9)), &contacts);
+  BOOST_CHECK(res);
+
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(0, 0, 9.9)), NULL);
+  BOOST_CHECK(res);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(0, 0, 9.9)), &contacts);
+  BOOST_CHECK(res);
+
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(0, 0, 10)), NULL);
+  BOOST_CHECK(res);
+  res = solver2.shapeIntersect(s1, Transform3f(), s2, Transform3f(Vec3f(0, 0, 10)), &contacts);
+  BOOST_CHECK(res);
+
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(0, 0, 10.1)), NULL);
   BOOST_CHECK_FALSE(res);
-  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(0, 0, 10.1)), &contact, &penetration_depth, &normal);
+  res = solver2.shapeIntersect(s1, transform, s2, transform * Transform3f(Vec3f(0, 0, 10.1)), &contacts);
   BOOST_CHECK_FALSE(res);
 }
 

--- a/test/test_fcl_sphere_capsule.cpp
+++ b/test/test_fcl_sphere_capsule.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(Sphere_Capsule_Intersect_test_separated_z)
 	Capsule capsule (50, 200.);
 	Transform3f capsule_transform (Vec3f (0., 0., 200));
 
-	BOOST_CHECK (!solver.shapeIntersect(sphere1, sphere1_transform, capsule, capsule_transform, NULL, NULL, NULL));
+  BOOST_CHECK (!solver.shapeIntersect(sphere1, sphere1_transform, capsule, capsule_transform, NULL));
 }
 
 BOOST_AUTO_TEST_CASE(Sphere_Capsule_Intersect_test_separated_z_negative)
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(Sphere_Capsule_Intersect_test_separated_z_negative)
 	Capsule capsule (50, 200.);
 	Transform3f capsule_transform (Vec3f (0., 0., -200));
 
-	BOOST_CHECK (!solver.shapeIntersect(sphere1, sphere1_transform, capsule, capsule_transform, NULL, NULL, NULL));
+  BOOST_CHECK (!solver.shapeIntersect(sphere1, sphere1_transform, capsule, capsule_transform, NULL));
 }
 
 BOOST_AUTO_TEST_CASE(Sphere_Capsule_Intersect_test_separated_x)
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(Sphere_Capsule_Intersect_test_separated_x)
 	Capsule capsule (50, 200.);
 	Transform3f capsule_transform (Vec3f (150., 0., 0.));
 
-	BOOST_CHECK (!solver.shapeIntersect(sphere1, sphere1_transform, capsule, capsule_transform, NULL, NULL, NULL));
+  BOOST_CHECK (!solver.shapeIntersect(sphere1, sphere1_transform, capsule, capsule_transform, NULL));
 }
 
 BOOST_AUTO_TEST_CASE(Sphere_Capsule_Intersect_test_separated_capsule_rotated)
@@ -102,30 +102,32 @@ BOOST_AUTO_TEST_CASE(Sphere_Capsule_Intersect_test_separated_capsule_rotated)
 	rotation.setEulerZYX (M_PI * 0.5, 0., 0.);
 	Transform3f capsule_transform (rotation, Vec3f (150., 0., 0.));
 
-	BOOST_CHECK (!solver.shapeIntersect(sphere1, sphere1_transform, capsule, capsule_transform, NULL, NULL, NULL));
+  BOOST_CHECK (!solver.shapeIntersect(sphere1, sphere1_transform, capsule, capsule_transform, NULL));
 }
 
 BOOST_AUTO_TEST_CASE(Sphere_Capsule_Intersect_test_penetration_z)
 {
-	GJKSolver_libccd solver;
+  GJKSolver_libccd solver;
 
-	Sphere sphere1 (50);
-	Transform3f sphere1_transform;
-	sphere1_transform.setTranslation (Vec3f (0., 0., -50));
+  Sphere sphere1 (50);
+  Transform3f sphere1_transform;
+  sphere1_transform.setTranslation (Vec3f (0., 0., -50));
 
-	Capsule capsule (50, 200.);
-	Transform3f capsule_transform (Vec3f (0., 0., 125));
+  Capsule capsule (50, 200.);
+  Transform3f capsule_transform (Vec3f (0., 0., 125));
 
-	FCL_REAL penetration = 0.;
-	Vec3f contact_point;
-	Vec3f normal;
+  std::vector<ContactPoint> contacts;
 
-	bool is_intersecting = solver.shapeIntersect(sphere1, sphere1_transform, capsule, capsule_transform, &contact_point, &penetration, &normal);
+  bool is_intersecting = solver.shapeIntersect(sphere1, sphere1_transform, capsule, capsule_transform, &contacts);
 
-	BOOST_CHECK (is_intersecting);
-	BOOST_CHECK (penetration == 25.);
-	BOOST_CHECK (Vec3f (0., 0., 1.).equal(normal));
-	BOOST_CHECK (Vec3f (0., 0., 0.).equal(contact_point));
+  FCL_REAL penetration = contacts[0].penetration_depth;
+  Vec3f contact_point = contacts[0].pos;
+  Vec3f normal = contacts[0].normal;
+
+  BOOST_CHECK (is_intersecting);
+  BOOST_CHECK (penetration == 25.);
+  BOOST_CHECK (Vec3f (0., 0., 1.).equal(normal));
+  BOOST_CHECK (Vec3f (0., 0., 0.).equal(contact_point));
 }
 
 BOOST_AUTO_TEST_CASE(Sphere_Capsule_Intersect_test_penetration_z_rotated)
@@ -141,11 +143,13 @@ BOOST_AUTO_TEST_CASE(Sphere_Capsule_Intersect_test_penetration_z_rotated)
 	rotation.setEulerZYX (M_PI * 0.5, 0., 0.);
 	Transform3f capsule_transform (rotation, Vec3f (0., 50., 75));
 
-	FCL_REAL penetration = 0.;
-	Vec3f contact_point;
-	Vec3f normal;
+  std::vector<ContactPoint> contacts;
 
-	bool is_intersecting = solver.shapeIntersect(sphere1, sphere1_transform, capsule, capsule_transform, &contact_point, &penetration, &normal);
+  bool is_intersecting = solver.shapeIntersect(sphere1, sphere1_transform, capsule, capsule_transform, &contacts);
+
+  FCL_REAL penetration = contacts[0].penetration_depth;
+  Vec3f contact_point = contacts[0].pos;
+  Vec3f normal = contacts[0].normal;
 
 	BOOST_CHECK (is_intersecting);
 	BOOST_CHECK_CLOSE (25, penetration, solver.collision_tolerance);


### PR DESCRIPTION
This pull request enables FCL to return multiple contacts per primitive-primitive collision. This feature is essential when FCL is used in physics simulation. For example, if we want to stack a primitive shape on another primitive shape in presence of gravity, multiple contacts are required to support the upper object. Single contact will make it unstable.

As I known, the most low level collision object types in FCL are triangle and primitive shapes. Depending on the kind of primitive shape, FCL uses different collision algorithms. Here is the category of collision algorithms in FCL: 
1. triangle-triangle algorithm
2. primitiveShape-triangle algorithms
3. general (convex) primitiveShape-primitiveShape algorithm using libccd
4. bunch of fast algorithms for specific primitiveShape-primitiveShape combination

All the collision algorithms returns single contact point. If a mesh and other collision object are colliding, multiple contacts can be detected because a mesh consists of many of triangles. The problem is the case that two primitive shapes are colliding. Although the algorithm for specific primitive shapes combination (e.g, box-box), it had to pick a single contact or average them because of the limitation of API. So I propose to change the API to be able to return multiple contacts as:
```cpp
// Previous API
template<typename S1, typename S2>
bool shapeIntersect(const S1& s1, const Transform3f& tf1, const S2& s2, const Transform3f& tf2, Vec3f* contact_points, FCL_REAL* penetration_depth, Vec3f* normal*) const FCL_DEPRECATED;

// Proposing API
template<typename S1, typename S2>
bool shapeIntersect(const S1& s1, const Transform3f& tf1, const S2& s2, const Transform3f& tf2, std::vector<ContactPoint>*) const;
```

As of now, box-box collision algorithm is the only one can detect multiple contacts. Other collision algorithm for different combination of primitive shapes needs to be implemented. This will be done in following pull requests.

Since the previous API, which is exposed to the user, is just marked as deprecated instead of removed, this PR doesn't hurt the backward compatibility. With this new API, [all the unit tests (those were not broken as itself) are passing](https://travis-ci.org/dartsim/fcl).

This pull request also fixes #15.