### PR TITLE
Fix segfault when registering empty object vector to [~]CollisionManager

### DIFF
--- a/src/broadphase/broadphase_SaP.cpp
+++ b/src/broadphase/broadphase_SaP.cpp
@@ -89,6 +89,8 @@ void SaPCollisionManager::unregisterObject(CollisionObject* obj)
 
 void SaPCollisionManager::registerObjects(const std::vector<CollisionObject*>& other_objs)
 {
+  if(other_objs.empty()) return;
+
   if(size() > 0)
     BroadPhaseCollisionManager::registerObjects(other_objs);
   else
@@ -272,6 +274,8 @@ void SaPCollisionManager::registerObject(CollisionObject* obj)
 
 void SaPCollisionManager::setup()
 {
+  if(size() == 0) return;
+
   FCL_REAL scale[3];
   scale[0] = (velist[0].back())->getVal(0) - velist[0][0]->getVal(0);
   scale[1] = (velist[1].back())->getVal(1) - velist[1][0]->getVal(1);;

--- a/src/broadphase/broadphase_dynamic_AABB_tree.cpp
+++ b/src/broadphase/broadphase_dynamic_AABB_tree.cpp
@@ -634,6 +634,8 @@ bool selfDistanceRecurse(DynamicAABBTreeCollisionManager::DynamicAABBNode* root,
 
 void DynamicAABBTreeCollisionManager::registerObjects(const std::vector<CollisionObject*>& other_objs)
 {
+  if(other_objs.empty()) return;
+
   if(size() > 0)
   {
     BroadPhaseCollisionManager::registerObjects(other_objs);

--- a/src/broadphase/broadphase_dynamic_AABB_tree_array.cpp
+++ b/src/broadphase/broadphase_dynamic_AABB_tree_array.cpp
@@ -657,6 +657,8 @@ bool distanceRecurse(DynamicAABBTreeCollisionManager_Array::DynamicAABBNode* nod
 
 void DynamicAABBTreeCollisionManager_Array::registerObjects(const std::vector<CollisionObject*>& other_objs)
 {
+  if(other_objs.empty()) return;
+
   if(size() > 0)
   {
     BroadPhaseCollisionManager::registerObjects(other_objs);

--- a/test/test_fcl_broadphase.cpp
+++ b/test/test_fcl_broadphase.cpp
@@ -149,6 +149,26 @@ BOOST_AUTO_TEST_CASE(test_core_bf_broad_phase_self_distance)
   broad_phase_self_distance_test(200, 5000);
 }
 
+/// check broad phase collision for empty collision object set and quaries
+BOOST_AUTO_TEST_CASE(test_core_bf_broad_phase_collision_empty)
+{
+  broad_phase_collision_test(2000, 0, 0, 10, false, false);
+  broad_phase_collision_test(2000, 0, 1000, 10, false, false);
+  broad_phase_collision_test(2000, 100, 0, 10, false, false);
+
+  broad_phase_collision_test(2000, 0, 0, 10, false, true);
+  broad_phase_collision_test(2000, 0, 1000, 10, false, true);
+  broad_phase_collision_test(2000, 100, 0, 10, false, true);
+
+  broad_phase_collision_test(2000, 0, 0, 10, true, false);
+  broad_phase_collision_test(2000, 0, 1000, 10, true, false);
+  broad_phase_collision_test(2000, 100, 0, 10, true, false);
+
+  broad_phase_collision_test(2000, 0, 0, 10, true, true);
+  broad_phase_collision_test(2000, 0, 1000, 10, true, true);
+  broad_phase_collision_test(2000, 100, 0, 10, true, true);
+}
+
 /// check broad phase collision and self collision, only return collision or not
 BOOST_AUTO_TEST_CASE(test_core_bf_broad_phase_collision_binary)
 {

--- a/test/test_fcl_broadphase.cpp
+++ b/test/test_fcl_broadphase.cpp
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(test_core_bf_broad_phase_self_distance)
   broad_phase_self_distance_test(200, 5000);
 }
 
-/// check broad phase collision for empty collision object set and quaries
+/// check broad phase collision for empty collision object set and queries
 BOOST_AUTO_TEST_CASE(test_core_bf_broad_phase_collision_empty)
 {
   broad_phase_collision_test(2000, 0, 0, 10, false, false);


### PR DESCRIPTION
Three broad-phase collision managers (`DynamicAABBTreeCollisionManager`, `DynamicAABBTreeCollisionManager_Array`, and `SaPCollisionManager`) don't take into account a case of attempting to register collision objects with empty vector, which is also reported by #41. This pull request fixes it.