### PR TITLE
Fix failure in building point cloud models for OBB/RSS/kIOS/OBBRSS (issue #67)

### DIFF
--- a/include/fcl/octree.h
+++ b/include/fcl/octree.h
@@ -54,7 +54,7 @@ namespace fcl
 class OcTree : public CollisionGeometry
 {
 private:
-  boost::shared_ptr<const octomap::OcTree> tree;
+  boost::shared_ptr<octomap::OcTree> tree;
 
   FCL_REAL default_occupancy;
 
@@ -70,7 +70,7 @@ public:
   typedef octomap::OcTreeNode OcTreeNode;
 
   /// @brief construct octree with a given resolution
-  OcTree(FCL_REAL resolution) : tree(boost::shared_ptr<const octomap::OcTree>(new octomap::OcTree(resolution)))                               
+  OcTree(FCL_REAL resolution) : tree(boost::shared_ptr<octomap::OcTree>(new octomap::OcTree(resolution)))
   {
     default_occupancy = tree->getOccupancyThres();
 
@@ -80,7 +80,7 @@ public:
   }
 
   /// @brief construct octree from octomap
-  OcTree(const boost::shared_ptr<const octomap::OcTree>& tree_) : tree(tree_)
+  OcTree(const boost::shared_ptr<octomap::OcTree>& tree_) : tree(tree_)
   {
     default_occupancy = tree->getOccupancyThres();
 
@@ -95,6 +95,12 @@ public:
     aabb_local = getRootBV();
     aabb_center = aabb_local.center();
     aabb_radius = (aabb_local.min_ - aabb_center).length();
+  }
+
+  /// @brief get the underlying octree structure
+  boost::shared_ptr<octomap::OcTree> getTree()
+  {
+    return tree;
   }
 
   /// @brief get the bounding volume for the root

--- a/src/BVH/BVH_model.cpp
+++ b/src/BVH/BVH_model.cpp
@@ -124,20 +124,23 @@ int BVHModel<BV>::beginModel(int num_tris_, int num_vertices_)
     num_vertices_allocated = num_vertices = num_tris_allocated = num_tris = num_bvs_allocated = num_bvs = 0;
   }
 
-  if(num_tris_ <= 0) num_tris_ = 8;
+  if(num_tris_ < 0) num_tris_ = 8;
   if(num_vertices_ <= 0) num_vertices_ = 8;
 
   num_vertices_allocated = num_vertices_;
   num_tris_allocated = num_tris_;
 
-  tri_indices = new Triangle[num_tris_allocated];
-  vertices = new Vec3f[num_vertices_allocated];
-
-  if(!tri_indices)
+  if(num_tris_ > 0)
   {
-    std::cerr << "BVH Error! Out of memory for tri_indices array on BeginModel() call!" << std::endl;
-    return BVH_ERR_MODEL_OUT_OF_MEMORY;
+    tri_indices = new Triangle[num_tris_allocated];
+    if(!tri_indices)
+    {
+      std::cerr << "BVH Error! Out of memory for tri_indices array on BeginModel() call!" << std::endl;
+      return BVH_ERR_MODEL_OUT_OF_MEMORY;
+    }
   }
+
+  vertices = new Vec3f[num_vertices_allocated];
   if(!vertices)
   {
     std::cerr << "BVH Error! Out of memory for vertices array on BeginModel() call!" << std::endl;
@@ -222,6 +225,10 @@ int BVHModel<BV>::addTriangle(const Vec3f& p1, const Vec3f& p2, const Vec3f& p3)
 
   if(num_tris >= num_tris_allocated)
   {
+    if(num_tris_allocated == 0)
+    {
+      num_tris_allocated = 1;
+    }
     Triangle* temp = new Triangle[num_tris_allocated * 2];
     if(!temp)
     {
@@ -315,6 +322,10 @@ int BVHModel<BV>::addSubModel(const std::vector<Vec3f>& ps, const std::vector<Tr
 
   if(num_tris + num_tris_to_add - 1 >= num_tris_allocated)
   {
+    if(num_tris_allocated == 0)
+    {
+      num_tris_allocated = 1;
+    }
     Triangle* temp = new Triangle[num_tris_allocated * 2 + num_tris_to_add - 1];
     if(!temp)
     {

--- a/src/BVH/BVH_model.cpp
+++ b/src/BVH/BVH_model.cpp
@@ -39,6 +39,7 @@
 #include "fcl/BV/BV.h"
 #include <iostream>
 #include <string.h>
+#include <new>
 
 namespace fcl
 {
@@ -132,7 +133,7 @@ int BVHModel<BV>::beginModel(int num_tris_, int num_vertices_)
 
   if(num_tris_ > 0)
   {
-    tri_indices = new Triangle[num_tris_allocated];
+    tri_indices = new(std::nothrow) Triangle[num_tris_allocated];
     if(!tri_indices)
     {
       std::cerr << "BVH Error! Out of memory for tri_indices array on BeginModel() call!" << std::endl;
@@ -140,7 +141,7 @@ int BVHModel<BV>::beginModel(int num_tris_, int num_vertices_)
     }
   }
 
-  vertices = new Vec3f[num_vertices_allocated];
+  vertices = new(std::nothrow) Vec3f[num_vertices_allocated];
   if(!vertices)
   {
     std::cerr << "BVH Error! Out of memory for vertices array on BeginModel() call!" << std::endl;
@@ -171,7 +172,7 @@ int BVHModel<BV>::addVertex(const Vec3f& p)
 
   if(num_vertices >= num_vertices_allocated)
   {
-    Vec3f* temp = new Vec3f[num_vertices_allocated * 2];
+    Vec3f* temp = new(std::nothrow) Vec3f[num_vertices_allocated * 2];
     if(!temp)
     {
       std::cerr << "BVH Error! Out of memory for vertices array on addVertex() call!" << std::endl;
@@ -201,7 +202,7 @@ int BVHModel<BV>::addTriangle(const Vec3f& p1, const Vec3f& p2, const Vec3f& p3)
 
   if(num_vertices + 2 >= num_vertices_allocated)
   {
-    Vec3f* temp = new Vec3f[num_vertices_allocated * 2 + 2];
+    Vec3f* temp = new(std::nothrow) Vec3f[num_vertices_allocated * 2 + 2];
     if(!temp)
     {
       std::cerr << "BVH Error! Out of memory for vertices array on addTriangle() call!" << std::endl;
@@ -261,7 +262,7 @@ int BVHModel<BV>::addSubModel(const std::vector<Vec3f>& ps)
 
   if(num_vertices + num_vertices_to_add - 1 >= num_vertices_allocated)
   {
-    Vec3f* temp = new Vec3f[num_vertices_allocated * 2 + num_vertices_to_add - 1];
+    Vec3f* temp = new(std::nothrow) Vec3f[num_vertices_allocated * 2 + num_vertices_to_add - 1];
     if(!temp)
     {
       std::cerr << "BVH Error! Out of memory for vertices array on addSubModel() call!" << std::endl;
@@ -296,7 +297,7 @@ int BVHModel<BV>::addSubModel(const std::vector<Vec3f>& ps, const std::vector<Tr
 
   if(num_vertices + num_vertices_to_add - 1 >= num_vertices_allocated)
   {
-    Vec3f* temp = new Vec3f[num_vertices_allocated * 2 + num_vertices_to_add - 1];
+    Vec3f* temp = new(std::nothrow) Vec3f[num_vertices_allocated * 2 + num_vertices_to_add - 1];
     if(!temp)
     {
       std::cerr << "BVH Error! Out of memory for vertices array on addSubModel() call!" << std::endl;
@@ -326,7 +327,7 @@ int BVHModel<BV>::addSubModel(const std::vector<Vec3f>& ps, const std::vector<Tr
     {
       num_tris_allocated = 1;
     }
-    Triangle* temp = new Triangle[num_tris_allocated * 2 + num_tris_to_add - 1];
+    Triangle* temp = new(std::nothrow) Triangle[num_tris_allocated * 2 + num_tris_to_add - 1];
     if(!temp)
     {
       std::cerr << "BVH Error! Out of memory for tri_indices array on addSubModel() call!" << std::endl;
@@ -366,7 +367,7 @@ int BVHModel<BV>::endModel()
 
   if(num_tris_allocated > num_tris)
   {
-    Triangle* new_tris = new Triangle[num_tris];
+    Triangle* new_tris = new(std::nothrow) Triangle[num_tris];
     if(!new_tris)
     {
       std::cerr << "BVH Error! Out of memory for tri_indices array in endModel() call!" << std::endl;
@@ -380,7 +381,7 @@ int BVHModel<BV>::endModel()
 
   if(num_vertices_allocated > num_vertices)
   {
-    Vec3f* new_vertices = new Vec3f[num_vertices];
+    Vec3f* new_vertices = new(std::nothrow) Vec3f[num_vertices];
     if(!new_vertices)
     {
       std::cerr << "BVH Error! Out of memory for vertices array in endModel() call!" << std::endl;
@@ -401,8 +402,8 @@ int BVHModel<BV>::endModel()
     num_bvs_to_be_allocated = 2 * num_tris - 1;
 
 
-  bvs = new BVNode<BV> [num_bvs_to_be_allocated];
-  primitive_indices = new unsigned int [num_bvs_to_be_allocated];
+  bvs = new(std::nothrow) BVNode<BV> [num_bvs_to_be_allocated];
+  primitive_indices = new(std::nothrow) unsigned int [num_bvs_to_be_allocated];
   if(!bvs || !primitive_indices)
   {
     std::cerr << "BVH Error! Out of memory for BV array in endModel()!" << std::endl;

--- a/test/test_fcl_bvh_models.cpp
+++ b/test/test_fcl_bvh_models.cpp
@@ -51,19 +51,8 @@ template<typename BV>
 void testBVHModelPointCloud()
 {
   boost::shared_ptr<BVHModel<BV> > model(new BVHModel<BV>);
-
-  if (model->getNodeType() != BV_AABB
-      && model->getNodeType() != BV_KDOP16
-      && model->getNodeType() != BV_KDOP18
-      && model->getNodeType() != BV_KDOP24)
-  {
-    std::cout << "Abort test since '" << getNodeTypeName(model->getNodeType())
-              << "' does not support point cloud model. "
-              << "Please see issue #67." << std::endl;
-    return;
-  }
-
   Box box;
+
   double a = box.side[0];
   double b = box.side[1];
   double c = box.side[2];

--- a/test/test_fcl_octomap.cpp
+++ b/test/test_fcl_octomap.cpp
@@ -215,7 +215,7 @@ void octomap_collision_test_BVH(std::size_t n, bool exhaustive)
   m1->addSubModel(p1, t1);
   m1->endModel();
 
-  OcTree* tree = new OcTree(boost::shared_ptr<const octomap::OcTree>(generateOcTree()));
+  OcTree* tree = new OcTree(boost::shared_ptr<octomap::OcTree>(generateOcTree()));
   boost::shared_ptr<CollisionGeometry> tree_ptr(tree);
 
   std::vector<Transform3f> transforms;
@@ -331,7 +331,7 @@ void octomap_cost_test(double env_scale, std::size_t env_size, std::size_t num_m
   else
     generateEnvironments(env, env_scale, env_size);
 
-  OcTree* tree = new OcTree(boost::shared_ptr<const octomap::OcTree>(generateOcTree()));
+  OcTree* tree = new OcTree(boost::shared_ptr<octomap::OcTree>(generateOcTree()));
   CollisionObject tree_obj((boost::shared_ptr<CollisionGeometry>(tree)));
 
   DynamicAABBTreeCollisionManager* manager = new DynamicAABBTreeCollisionManager();
@@ -451,7 +451,7 @@ void octomap_collision_test(double env_scale, std::size_t env_size, bool exhaust
   else
     generateEnvironments(env, env_scale, env_size);
 
-  OcTree* tree = new OcTree(boost::shared_ptr<const octomap::OcTree>(generateOcTree()));
+  OcTree* tree = new OcTree(boost::shared_ptr<octomap::OcTree>(generateOcTree()));
   CollisionObject tree_obj((boost::shared_ptr<CollisionGeometry>(tree)));
 
   DynamicAABBTreeCollisionManager* manager = new DynamicAABBTreeCollisionManager();
@@ -550,7 +550,7 @@ void octomap_distance_test(double env_scale, std::size_t env_size, bool use_mesh
   else
     generateEnvironments(env, env_scale, env_size);
 
-  OcTree* tree = new OcTree(boost::shared_ptr<const octomap::OcTree>(generateOcTree()));
+  OcTree* tree = new OcTree(boost::shared_ptr<octomap::OcTree>(generateOcTree()));
   CollisionObject tree_obj((boost::shared_ptr<CollisionGeometry>(tree)));
 
   DynamicAABBTreeCollisionManager* manager = new DynamicAABBTreeCollisionManager();


### PR DESCRIPTION
The functions beginModel, addTriangle and addSubModel now respect documentation, keeping tri_indices as NULL for point clouds. This fixes issue #67 .
