### PR TITLE
Fixing missing assignment in Convex class

### DIFF
--- a/include/fcl/shape/geometric_shapes.h
+++ b/include/fcl/shape/geometric_shapes.h
@@ -278,6 +278,7 @@ public:
     plane_dis = plane_dis_;
     num_planes = num_planes_;
     points = points_;
+    num_points = num_points_;
     polygons = polygons_;
     edges = NULL;
 


### PR DESCRIPTION
From what I understand the Convex class is not really supported, yet the missing assignment is an error as it is used uninitialized.