### PR TITLE
Set CMP0042 to suppress a warning on OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,12 @@
 cmake_minimum_required(VERSION 2.8)
+
+# Use MACOSX_RPATH by default on OS X. This was added in CMake 2.8.12 and
+# became default in CMake 3.0. Explicitly setting this policy is necessary to
+# suppress a warning in CMake 3.0 and above.
+if(POLICY CMP0042)
+  cmake_policy(SET CMP0042 NEW)
+endif()
+
 project(fcl CXX C)
 
 # set the default build type


### PR DESCRIPTION
This pull request sets [CMP0042 policy](https://cmake.org/cmake/help/v3.0/policy/CMP0042.html) to NEW explicitly to suppress a warning on OS X like [what DART did before](https://github.com/dartsim/dart/pull/483).