### PR TITLE
Make GJK struct variables static

### DIFF
--- a/include/fcl/narrowphase/narrowphase.h
+++ b/include/fcl/narrowphase/narrowphase.h
@@ -203,10 +203,6 @@ struct GJKSolver_libccd
   /// @brief default setting for GJK algorithm
   GJKSolver_libccd()
   {
-    max_collision_iterations = 500;
-    max_distance_iterations = 1000;
-    collision_tolerance = 1e-6;
-    distance_tolerance = 1e-6;
   }
 
 
@@ -227,16 +223,16 @@ struct GJKSolver_libccd
 
 
   /// @brief maximum number of iterations used in GJK algorithm for collision
-  unsigned int max_collision_iterations;
+  static unsigned int max_collision_iterations;
 
   /// @brief maximum number of iterations used in GJK algorithm for distance
-  unsigned int max_distance_iterations;
+  static unsigned int max_distance_iterations;
 
   /// @brief the threshold used in GJK algorithm to stop collision iteration
-  FCL_REAL collision_tolerance;
+  static FCL_REAL collision_tolerance;
 
   /// @brief the threshold used in GJK algorithm to stop distance iteration
-  FCL_REAL distance_tolerance;
+  static FCL_REAL distance_tolerance;
   
 
 };

--- a/src/narrowphase/narrowphase.cpp
+++ b/src/narrowphase/narrowphase.cpp
@@ -44,6 +44,11 @@
 namespace fcl
 {
 
+unsigned int GJKSolver_libccd::max_collision_iterations = 500;
+unsigned int GJKSolver_libccd::max_distance_iterations = 1000;
+FCL_REAL GJKSolver_libccd::collision_tolerance = 1e-6;
+FCL_REAL GJKSolver_libccd::distance_tolerance = 1e-6;
+
 namespace details
 {
 


### PR DESCRIPTION
Hi, The broadphase manager appears to use hardcoded GJK defaults for narowphase. I'm using broadphase, and have a need for a smaller collision tolerance in narowphase. In my main program, I can set the narowphase default with,
```
fcl::GJKSolver_libccd::collision_tolerance = 1e-15;
```
All the other defaults can be reset as well with this pull requested code.
-Doug Baldwin