### PR TITLE
SphereSphereIntersect point bugfix

### DIFF
--- a/src/narrowphase/narrowphase.cpp
+++ b/src/narrowphase/narrowphase.cpp
@@ -278,9 +278,9 @@ bool sphereSphereIntersect(const Sphere& s1, const Transform3f& tf1,
   {
     // If the centers of two sphere are at the same position, the normal is (0, 0, 0).
     // Otherwise, normal is pointing from center of object 1 to center of object 2
-    const Vec3f normal = len > 0 ? diff / len : diff;
-    const Vec3f point = tf1.transform(Vec3f()) + diff * s1.radius / (s1.radius + s2.radius);
+    const Vec3f normal = len > 0 ? diff / len : Vec3f();
     const FCL_REAL penetration_depth = s1.radius + s2.radius - len;
+    const Vec3f point = tf1.transform(Vec3f()) + normal * (s1.radius - 0.5 * penetration_depth);
     contacts->push_back(ContactPoint(normal, point, penetration_depth));
   }
 

--- a/test/test_fcl_geometric_shapes.cpp
+++ b/test/test_fcl_geometric_shapes.cpp
@@ -523,7 +523,7 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_spheresphere)
   tf2 = Transform3f(Vec3f(29.9, 0, 0));
   contacts.resize(1);
   contacts[0].normal.setValue(1, 0, 0);
-  contacts[0].pos.setValue(20.0 - 0.1 * 20.0/(20.0 + 10.0), 0, 0);
+  contacts[0].pos.setValue(20.0 - 0.5 * 0.1, 0, 0);
   contacts[0].penetration_depth = 0.1;
   testShapeIntersection(s1, tf1, s2, tf2, GST_LIBCCD, true, contacts);
 
@@ -531,7 +531,7 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_spheresphere)
   tf2 = transform * Transform3f(Vec3f(29.9, 0, 0));
   contacts.resize(1);
   contacts[0].normal = transform.getRotation() * Vec3f(1, 0, 0);
-  contacts[0].pos = transform.transform(Vec3f(20.0 - 0.1 * 20.0/(20.0 + 10.0), 0, 0));
+  contacts[0].pos = transform.transform(Vec3f(20.0 - 0.5 * 0.1, 0, 0));
   contacts[0].penetration_depth = 0.1;
   testShapeIntersection(s1, tf1, s2, tf2, GST_LIBCCD, true, contacts);
 
@@ -555,7 +555,7 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_spheresphere)
   tf2 = Transform3f(Vec3f(-29.9, 0, 0));
   contacts.resize(1);
   contacts[0].normal.setValue(-1, 0, 0);
-  contacts[0].pos.setValue(-20.0 + 0.1 * 20.0/(20.0 + 10.0), 0, 0);
+  contacts[0].pos.setValue(-20.0 + 0.5 * 0.1, 0, 0);
   contacts[0].penetration_depth = 0.1;
   testShapeIntersection(s1, tf1, s2, tf2, GST_LIBCCD, true, contacts);
 
@@ -563,7 +563,7 @@ BOOST_AUTO_TEST_CASE(shapeIntersection_spheresphere)
   tf2 = transform * Transform3f(Vec3f(-29.9, 0, 0));
   contacts.resize(1);
   contacts[0].normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  contacts[0].pos = transform.transform(Vec3f(-20.0 + 0.1 * 20.0/(20.0 + 10.0), 0, 0));
+  contacts[0].pos = transform.transform(Vec3f(-20.0 + 0.5 * 0.1, 0, 0));
   contacts[0].penetration_depth = 0.1;
   testShapeIntersection(s1, tf1, s2, tf2, GST_LIBCCD, true, contacts);
 
@@ -3773,7 +3773,7 @@ BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_spheresphere)
   tf2 = Transform3f(Vec3f(29.9, 0, 0));
   contacts.resize(1);
   contacts[0].normal.setValue(1, 0, 0);
-  contacts[0].pos.setValue(20.0 - 0.1 * 20.0/(20.0 + 10.0), 0, 0);
+  contacts[0].pos.setValue(20.0 - 0.5 * 0.1, 0, 0);
   contacts[0].penetration_depth = 0.1;
   testShapeIntersection(s1, tf1, s2, tf2, GST_INDEP, true, contacts);
 
@@ -3781,7 +3781,7 @@ BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_spheresphere)
   tf2 = transform * Transform3f(Vec3f(29.9, 0, 0));
   contacts.resize(1);
   contacts[0].normal = transform.getRotation() * Vec3f(1, 0, 0);
-  contacts[0].pos = transform.transform(Vec3f(20.0 - 0.1 * 20.0/(20.0 + 10.0), 0, 0));
+  contacts[0].pos = transform.transform(Vec3f(20.0 - 0.5 * 0.1, 0, 0));
   contacts[0].penetration_depth = 0.1;
   testShapeIntersection(s1, tf1, s2, tf2, GST_INDEP, true, contacts);
 
@@ -3805,7 +3805,7 @@ BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_spheresphere)
   tf2 = Transform3f(Vec3f(-29.9, 0, 0));
   contacts.resize(1);
   contacts[0].normal.setValue(-1, 0, 0);
-  contacts[0].pos.setValue(-20.0 + 0.1 * 20.0/(20.0 + 10.0), 0, 0);
+  contacts[0].pos.setValue(-20.0 + 0.5 * 0.1, 0, 0);
   contacts[0].penetration_depth = 0.1;
   testShapeIntersection(s1, tf1, s2, tf2, GST_INDEP, true, contacts);
 
@@ -3813,7 +3813,7 @@ BOOST_AUTO_TEST_CASE(shapeIntersectionGJK_spheresphere)
   tf2 = transform * Transform3f(Vec3f(-29.9, 0, 0));
   contacts.resize(1);
   contacts[0].normal = transform.getRotation() * Vec3f(-1, 0, 0);
-  contacts[0].pos = transform.transform(Vec3f(-20.0 + 0.1 * 20.0/(20.0 + 10.0), 0, 0));
+  contacts[0].pos = transform.transform(Vec3f(-20.0 + 0.5 * 0.1, 0, 0));
   contacts[0].penetration_depth = 0.1;
   testShapeIntersection(s1, tf1, s2, tf2, GST_INDEP, true, contacts);
 


### PR DESCRIPTION
The bug is that for sphere objects of differing radii, the collision point is dependent on the order of the objects, and is a non-linear function. With this proposed fix, the collision point is independent of the order of the sphere objects, and is a linear function. A comparison test of (o1, o2) with (o2, o1) would have identical pos.

This bug and fix is indicative of a pervasive set of fcl bugs when using a precise dynamic solver. Another example is sphere-plane, which again has a different pos depending on the order (o1, o2) or (o2, o1). In that case, pos would need to be the midpoint of the intersected radius, not the extreme.

In general, for consistent input to a precise dynamic solver, I will be making changes to fcl such that pos is always independent of object order. This means that for box-plane, pos will be at the centroid (I believe) of the intersection. In this way, pos will move incrementally over time instead of jumping from corner to corner of the box as can happen in the current implementation.

The solver I'm using is MBDyn, which fits perfectly with fcl, once a consistent interface is achieve as indicated by the above comments. I believe this kind of consistent interface has merit beyond my needs. Please let me know if you would like such changes pushed for consideration to merge.

