### PR TITLE
Fix build when libccd package config not found.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,10 +129,10 @@ if(NOT CCD_FOUND)
     # of ccd
     find_path(CCD_INCLUDE_DIRS ccd.h
         PATH_SUFFIXES ccd)
-    find_library(CCD_LIBRARY_DIRS
+    find_library(CCD_LIBRARY
         ${CMAKE_SHARED_LIBRARY_PREFIX}ccd${CMAKE_SHARED_LIBRARY_SUFFIX})
-    if(CCD_INCLUDE_DIRS AND CCD_LIBRARY_DIRS)
-        set(CCD_LIBRARIES "ccd")
+    if(CCD_INCLUDE_DIRS AND CCD_LIBRARY)
+        set(CCD_LIBRARIES "${CCD_LIBRARY}")
     else()
         message(FATAL_ERROR "Libccd is required by FCL")
     endif()


### PR DESCRIPTION
Link to ccd library by full path per preferred cmake convention.  This fixed the build when libccd is not found by pkgconfig.