### PR TITLE
Small fixes to allow compilation in Visual Studio 2015, and get rid of some warnings

### DIFF
--- a/src/BVH/BV_fitter.cpp
+++ b/src/BVH/BV_fitter.cpp
@@ -46,7 +46,7 @@ namespace fcl
 static const double kIOS_RATIO = 1.5;
 static const double invSinA = 2;
 static const double invCosA = 2.0 / sqrt(3.0);
-static const double sinA = 0.5;
+// static const double sinA = 0.5;
 static const double cosA = sqrt(3.0) / 2.0;
 
 static inline void axisFromEigen(Vec3f eigenV[3], Matrix3f::U eigenS[3], Vec3f axis[3])

--- a/src/broadphase/interval_tree.cpp
+++ b/src/broadphase/interval_tree.cpp
@@ -38,6 +38,7 @@
 #include "fcl/broadphase/interval_tree.h"
 #include <iostream>
 #include <cstdlib>
+#include <algorithm>
 
 
 namespace fcl

--- a/test/test_fcl_capsule_capsule.cpp
+++ b/test/test_fcl_capsule_capsule.cpp
@@ -37,6 +37,7 @@
 
 #define BOOST_TEST_MODULE "FCL_CAPSULE_CAPSULE"
 #include <boost/test/unit_test.hpp>
+#include <boost/math/constants/constants.hpp>
 
 #include "fcl/collision.h"
 #include "fcl/shape/geometric_shapes.h"
@@ -125,7 +126,7 @@ BOOST_AUTO_TEST_CASE(distance_capsulecapsule_transformZ)
 
 BOOST_AUTO_TEST_CASE(distance_capsulecapsule_transformZ2)
 {
-  const FCL_REAL Pi = std::acos(FCL_REAL(-1.0));
+  const FCL_REAL Pi = boost::math::constants::pi<FCL_REAL>();
 
   GJKSolver_indep solver;
   Capsule s1(5, 10);

--- a/test/test_fcl_capsule_capsule.cpp
+++ b/test/test_fcl_capsule_capsule.cpp
@@ -42,8 +42,7 @@
 #include "fcl/shape/geometric_shapes.h"
 #include "fcl/narrowphase/narrowphase.h"
 
-#include "math.h"
-
+#include <cmath>
 using namespace fcl;
 
 BOOST_AUTO_TEST_CASE(distance_capsulecapsule_origin)
@@ -66,7 +65,7 @@ BOOST_AUTO_TEST_CASE(distance_capsulecapsule_origin)
   std::cerr << "applied transformation of two caps: " << transform.getTranslation() << " & " << transform2.getTranslation() << std::endl;
   std::cerr << "computed points in caps to caps" << closest_p1 << " & " << closest_p2 << "with dist: " << dist << std::endl;
 
-  BOOST_CHECK(fabs(dist - 10.1) < 0.001);
+  BOOST_CHECK(std::abs(dist - 10.1) < 0.001);
   BOOST_CHECK(res);
 
 }
@@ -92,8 +91,8 @@ BOOST_AUTO_TEST_CASE(distance_capsulecapsule_transformXY)
   std::cerr << "applied transformation of two caps: " << transform.getTranslation() << " & " << transform2.getTranslation() << std::endl;
   std::cerr << "computed points in caps to caps" << closest_p1 << " & " << closest_p2 << "with dist: " << dist << std::endl;
 
-  float expected = sqrt(800) - 10;
-  BOOST_CHECK(fabs(expected-dist) < 0.01);
+  FCL_REAL expected = std::sqrt(FCL_REAL(800)) - 10;
+  BOOST_CHECK(std::abs(expected-dist) < 0.01);
   BOOST_CHECK(res);
 
 }
@@ -118,7 +117,7 @@ BOOST_AUTO_TEST_CASE(distance_capsulecapsule_transformZ)
   std::cerr << "applied transformation of two caps: " << transform.getTranslation() << " & " << transform2.getTranslation() << std::endl;
   std::cerr << "computed points in caps to caps" << closest_p1 << " & " << closest_p2 << "with dist: " << dist << std::endl;
 
-  BOOST_CHECK(fabs(dist - 0.1) < 0.001);
+  BOOST_CHECK(std::abs(dist - 0.1) < 0.001);
   BOOST_CHECK(res);
 
 }
@@ -126,6 +125,7 @@ BOOST_AUTO_TEST_CASE(distance_capsulecapsule_transformZ)
 
 BOOST_AUTO_TEST_CASE(distance_capsulecapsule_transformZ2)
 {
+  const FCL_REAL Pi = std::acos(FCL_REAL(-1.0));
 
   GJKSolver_indep solver;
   Capsule s1(5, 10);
@@ -137,7 +137,8 @@ BOOST_AUTO_TEST_CASE(distance_capsulecapsule_transformZ2)
   Transform3f transform2;
   transform2 = Transform3f(Vec3f(0,0,25.1));
   Matrix3f rot2;
-  rot2.setEulerZYX(0,M_PI_2,0);
+
+  rot2.setEulerZYX(0,Pi/2,0);
   transform2.setRotation(rot2);
 
   bool res;
@@ -148,7 +149,7 @@ BOOST_AUTO_TEST_CASE(distance_capsulecapsule_transformZ2)
   std::cerr << "applied transformation of two caps: " << transform.getRotation() << " & " << transform2.getRotation() << std::endl;
   std::cerr << "computed points in caps to caps" << closest_p1 << " & " << closest_p2 << "with dist: " << dist << std::endl;
 
-  BOOST_CHECK(fabs(dist - 5.1) < 0.001);
+  BOOST_CHECK(std::abs(dist - 5.1) < 0.001);
   BOOST_CHECK(res);
 
 }

--- a/test/test_fcl_collision.cpp
+++ b/test/test_fcl_collision.cpp
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(OBB_shape_test)
       computeBV(ellipsoid, transforms[i], obb2);
 
       bool overlap_obb = obb1.overlap(obb2);
-      bool overlap_ellipsoid = solver.shapeIntersect(box1, box1_tf, ellipsoid, transforms[i], NULL, NULL, NULL);
+      bool overlap_ellipsoid = solver.shapeIntersect(box1, box1_tf, ellipsoid, transforms[i], NULL);
       BOOST_CHECK(overlap_obb >= overlap_ellipsoid);
     }
 


### PR DESCRIPTION
I tried building FCL on Windows 10 with Visual Studio 2015 Win64 and got a couple of compilation failures (there was a missing include and use of non-standard constant `M_PI_2`). This PR fixes those and allows FCL to build. However 4 or 13 tests failed -- those need to be addressed but I'm not attempting that in this PR.

There were also a few warnings when I built in Ubuntu 14.04; those are fixed here too. All tests passed there.