### PR TITLE
Nuke unused include of boost/zip_iterator

### DIFF
--- a/include/fcl/broadphase/hierarchy_tree.h
+++ b/include/fcl/broadphase/hierarchy_tree.h
@@ -43,7 +43,6 @@
 #include "fcl/BV/AABB.h"
 #include "fcl/broadphase/morton.h"
 #include <boost/bind.hpp>
-#include <boost/iterator/zip_iterator.hpp>
 
 namespace fcl
 {


### PR DESCRIPTION
Thanks to extensive research by @jslee02 (see #100), we know boost zip_iterator isn't needed. This PR deletes the include.

Please check off the zip_iterator box in issue #102 if you merge this.