### PR TITLE
Remove more boost usage and replace with C++11 equivalents.

### DIFF
--- a/include/fcl/BVH/BVH_model.h
+++ b/include/fcl/BVH/BVH_model.h
@@ -45,15 +45,13 @@
 #include "fcl/BVH/BV_fitter.h"
 #include <vector>
 #include <memory>
-#include <boost/noncopyable.hpp>
 
 namespace fcl
 {
 
 /// @brief A class describing the bounding hierarchy of a mesh model or a point cloud model (which is viewed as a degraded version of mesh)
 template<typename BV>
-class BVHModel : public CollisionGeometry,
-                 private boost::noncopyable
+class BVHModel : public CollisionGeometry
 {
 
 public:

--- a/include/fcl/broadphase/interval_tree.h
+++ b/include/fcl/broadphase/interval_tree.h
@@ -47,7 +47,6 @@ namespace fcl
 
 /// @brief Interval trees implemented using red-black-trees as described in
 /// the book Introduction_To_Algorithms_ by Cormen, Leisserson, and Rivest.
-/// Can be replaced in part by boost::icl::interval_set, which is only supported after boost 1.46 and does not support delete node routine.
 struct SimpleInterval
 {
 public:

--- a/include/fcl/ccd/interpolation/interpolation_factory.h
+++ b/include/fcl/ccd/interpolation/interpolation_factory.h
@@ -44,7 +44,7 @@
 #include <map>
 
 #include <memory>
-#include <boost/function.hpp>
+#include <functional>
 
 namespace fcl 
 {
@@ -52,7 +52,7 @@ namespace fcl
 class InterpolationFactory
 {	
 public:
-  typedef boost::function<std::shared_ptr<Interpolation>(FCL_REAL, FCL_REAL)> CreateFunction;
+  typedef std::function<std::shared_ptr<Interpolation>(FCL_REAL, FCL_REAL)> CreateFunction;
 
 public:
   void registerClass(const InterpolationType type, const CreateFunction create_function);

--- a/include/fcl/data_types.h
+++ b/include/fcl/data_types.h
@@ -39,16 +39,16 @@
 #define FCL_DATA_TYPES_H
 
 #include <cstddef>
-#include <boost/cstdint.hpp>
+#include <cstdint>
 
 namespace fcl
 {
 
 typedef double FCL_REAL;
-typedef boost::uint64_t FCL_INT64;
-typedef boost::int64_t FCL_UINT64;
-typedef boost::uint32_t FCL_UINT32;
-typedef boost::int32_t FCL_INT32;
+typedef std::uint_fast64_t FCL_INT64;
+typedef std::int_fast64_t FCL_UINT64;
+typedef std::uint_fast32_t FCL_UINT32;
+typedef std::int_fast32_t FCL_INT32;
 
 /// @brief Triangle with 3 indices for points
 class Triangle

--- a/include/fcl/intersect.h
+++ b/include/fcl/intersect.h
@@ -39,7 +39,6 @@
 #define FCL_INTERSECT_H
 
 #include "fcl/math/transform.h"
-#include <boost/math/special_functions/erf.hpp>
 
 namespace fcl
 {

--- a/include/fcl/knn/greedy_kcenters.h
+++ b/include/fcl/knn/greedy_kcenters.h
@@ -50,7 +50,7 @@ class GreedyKCenters
 {
 public:
   /// @brief The definition of a distance function
-  typedef boost::function<double(const _T&, const _T&)> DistanceFunction;
+  typedef std::function<double(const _T&, const _T&)> DistanceFunction;
 
   GreedyKCenters(void)
   {

--- a/include/fcl/knn/nearest_neighbors.h
+++ b/include/fcl/knn/nearest_neighbors.h
@@ -40,7 +40,6 @@
 
 #include <vector>
 #include <functional>
-#include <boost/function.hpp>
 
 namespace fcl
 {
@@ -51,7 +50,7 @@ class NearestNeighbors
 public:
 
   /// @brief The definition of a distance function
-  typedef boost::function<double(const _T&, const _T&)> DistanceFunction;
+  typedef std::function<double(const _T&, const _T&)> DistanceFunction;
 
   NearestNeighbors(void)
   {

--- a/include/fcl/knn/nearest_neighbors_GNAT.h
+++ b/include/fcl/knn/nearest_neighbors_GNAT.h
@@ -40,7 +40,7 @@
 #include "fcl/knn/nearest_neighbors.h"
 #include "fcl/knn/greedy_kcenters.h"
 #include "fcl/exception.h"
-#include <boost/unordered_set.hpp>
+#include <unordered_set>
 #include <queue>
 #include <algorithm>
 
@@ -239,7 +239,7 @@ public:
       if (!gnat.removed_.empty())
       {
         out << "Elements marked for removal:\n";
-        for (typename boost::unordered_set<const _T*>::const_iterator it = gnat.removed_.begin();
+        for (typename std::unordered_set<const _T*>::const_iterator it = gnat.removed_.begin();
              it != gnat.removed_.end(); it++)
           out << **it << '\t';
         out << std::endl;
@@ -252,12 +252,12 @@ public:
   void integrityCheck()
   {
     std::vector<_T> lst;
-    boost::unordered_set<const _T*> tmp;
+    std::unordered_set<const _T*> tmp;
     // get all elements, including those marked for removal
     removed_.swap(tmp);
     list(lst);
     // check if every element marked for removal is also in the tree
-    for (typename boost::unordered_set<const _T*>::iterator it=tmp.begin(); it!=tmp.end(); it++)
+    for (typename std::unordered_set<const _T*>::iterator it=tmp.begin(); it!=tmp.end(); it++)
     {
       unsigned int i;
       for (i=0; i<lst.size(); ++i)
@@ -689,7 +689,7 @@ protected:
   /// \brief The data structure used to split data into subtrees.
   GreedyKCenters<_T>              pivotSelector_;
   /// \brief Cache of removed elements.
-  boost::unordered_set<const _T*> removed_;
+  std::unordered_set<const _T*> removed_;
 };
 }
 

--- a/include/fcl/math/transform.h
+++ b/include/fcl/math/transform.h
@@ -40,7 +40,7 @@
 #define FCL_TRANSFORM_H
 
 #include "fcl/math/matrix_3f.h"
-#include <boost/thread/mutex.hpp>
+#include <mutex>
 
 namespace fcl
 {
@@ -182,7 +182,7 @@ static inline std::ostream& operator << (std::ostream& o, const Quaternion3f& q)
 /// @brief Simple transform class used locally by InterpMotion
 class Transform3f
 {
-  boost::mutex lock_;
+  std::mutex lock_;
 
   /// @brief Whether matrix cache is set
   mutable bool matrix_set;

--- a/include/fcl/math/vec_nf.h
+++ b/include/fcl/math/vec_nf.h
@@ -5,7 +5,6 @@
 #include <iostream>
 #include <limits>
 #include <vector>
-#include <boost/array.hpp>
 #include <cstdarg>
 #include "fcl/data_types.h"
 

--- a/include/fcl/octree.h
+++ b/include/fcl/octree.h
@@ -41,7 +41,7 @@
 
 
 #include <memory>
-#include <boost/array.hpp>
+#include <array>
 
 #include <octomap/octomap.h>
 #include "fcl/BV/AABB.h"
@@ -134,9 +134,9 @@ public:
 
   /// @brief transform the octree into a bunch of boxes; uncertainty information is kept in the boxes. However, we
   /// only keep the occupied boxes (i.e., the boxes whose occupied probability is higher enough).
-  inline std::vector<boost::array<FCL_REAL, 6> > toBoxes() const
+  inline std::vector<std::array<FCL_REAL, 6> > toBoxes() const
   {
-    std::vector<boost::array<FCL_REAL, 6> > boxes;
+    std::vector<std::array<FCL_REAL, 6> > boxes;
     boxes.reserve(tree->size() / 2);
     for(octomap::OcTree::iterator it = tree->begin(tree->getTreeDepth()), end = tree->end();
         it != end;
@@ -152,7 +152,7 @@ public:
         FCL_REAL c = (*it).getOccupancy();
         FCL_REAL t = tree->getOccupancyThres();
 
-        boost::array<FCL_REAL, 6> box = {{x, y, z, size, c, t}};
+        std::array<FCL_REAL, 6> box = {{x, y, z, size, c, t}};
         boxes.push_back(box);
       }
     }

--- a/include/fcl/shape/geometric_shape_to_BVH_model.h
+++ b/include/fcl/shape/geometric_shape_to_BVH_model.h
@@ -41,7 +41,6 @@
 
 #include "fcl/shape/geometric_shapes.h"
 #include "fcl/BVH/BVH_model.h"
-#include <boost/math/constants/constants.hpp>
 
 namespace fcl
 {

--- a/include/fcl/traversal/traversal_node_bvhs.h
+++ b/include/fcl/traversal/traversal_node_bvhs.h
@@ -47,7 +47,6 @@
 #include "fcl/intersect.h"
 #include "fcl/ccd/motion.h"
 
-#include <boost/shared_array.hpp>
 #include <memory>
 #include <limits>
 #include <vector>

--- a/src/BVH/BVH_model.cpp
+++ b/src/BVH/BVH_model.cpp
@@ -45,7 +45,6 @@ namespace fcl
 
 template<typename BV>
 BVHModel<BV>::BVHModel(const BVHModel<BV>& other) : CollisionGeometry(other),
-                                                    boost::noncopyable(),
                                                     num_tris(other.num_tris),
                                                     num_vertices(other.num_vertices),
                                                     build_state(other.build_state),

--- a/src/articulated_model/model.cpp
+++ b/src/articulated_model/model.cpp
@@ -37,7 +37,6 @@
 
 #include "fcl/articulated_model/model.h"
 #include "fcl/articulated_model/model_config.h"
-#include <boost/assert.hpp>
 
 namespace fcl
 {

--- a/src/articulated_model/model_config.cpp
+++ b/src/articulated_model/model_config.cpp
@@ -38,11 +38,7 @@
 #include "fcl/articulated_model/model_config.h"
 #include "fcl/articulated_model/joint.h"
 #include <algorithm>
-
-// Define for boost version < 1.47
-#ifndef BOOST_ASSERT_MSG
-#define BOOST_ASSERT_MSG(expr, msg) ((void)0)
-#endif
+#include <cassert>
 
 namespace fcl
 {
@@ -63,7 +59,7 @@ ModelConfig::ModelConfig(std::map<std::string, std::shared_ptr<Joint> > joints_m
 JointConfig ModelConfig::getJointConfigByJointName(const std::string& joint_name) const
 {
   std::map<std::string, JointConfig>::const_iterator it = joint_cfgs_map_.find(joint_name);
-  BOOST_ASSERT_MSG((it != joint_cfgs_map_.end()), "Joint name not valid");
+  assert(it != joint_cfgs_map_.end());
 
   return it->second;
 }
@@ -71,7 +67,7 @@ JointConfig ModelConfig::getJointConfigByJointName(const std::string& joint_name
 JointConfig& ModelConfig::getJointConfigByJointName(const std::string& joint_name)
 {
   std::map<std::string, JointConfig>::iterator it = joint_cfgs_map_.find(joint_name);
-  BOOST_ASSERT_MSG((it != joint_cfgs_map_.end()), "Joint name not valid");
+  assert(it != joint_cfgs_map_.end());
 
   return it->second;
 }

--- a/src/ccd/interpolation/interpolation_factory.cpp
+++ b/src/ccd/interpolation/interpolation_factory.cpp
@@ -37,13 +37,7 @@
 
 #include "fcl/ccd/interpolation/interpolation_factory.h"
 #include "fcl/ccd/interpolation/interpolation_linear.h"
-
-#include <boost/assert.hpp>
-
-// Define for boost version < 1.47
-#ifndef BOOST_ASSERT_MSG
-#define BOOST_ASSERT_MSG(expr, msg) ((void)0)
-#endif
+#include <cassert>
 
 namespace fcl 
 {
@@ -70,7 +64,7 @@ InterpolationFactory::create(const InterpolationType type, const FCL_REAL start_
 {
   std::map<InterpolationType, CreateFunction>::const_iterator it = creation_map_.find(type);
 
-  BOOST_ASSERT_MSG((it != creation_map_.end()), "CreateFunction wasn't found.");
+  assert(it != creation_map_.end());
 
   return (it->second)(start_value, end_value);  
 }

--- a/src/math/sampling.cpp
+++ b/src/math/sampling.cpp
@@ -1,33 +1,32 @@
 #include "fcl/math/sampling.h"
-#include <boost/random/lagged_fibonacci.hpp>
-#include <boost/random/uniform_int.hpp>
-#include <boost/thread/mutex.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
+#include <mutex>
+#include <chrono>
 
 namespace fcl
 {
 
 /// The seed the user asked for (cannot be 0)
-static boost::uint32_t userSetSeed = 0;
+static std::uint_fast32_t userSetSeed = 0;
 	
 /// Flag indicating whether the first seed has already been generated or not
 static bool firstSeedGenerated = false;
 	
 /// The value of the first seed
-static boost::uint32_t firstSeedValue = 0;
+static std::uint_fast32_t firstSeedValue = 0;
 	
 /// Compute the first seed to be used; this function should be called only once
-static boost::uint32_t firstSeed()
+static std::uint_fast32_t firstSeed()
 {
-  static boost::mutex fsLock;
-  boost::mutex::scoped_lock slock(fsLock);
+  static std::mutex fsLock;
+  std::unique_lock<std::mutex> slock(fsLock);
 		
   if(firstSeedGenerated)
     return firstSeedValue;
 			
   if(userSetSeed != 0)
     firstSeedValue = userSetSeed;
-  else firstSeedValue = (boost::uint32_t)(boost::posix_time::microsec_clock::universal_time() - boost::posix_time::ptime(boost::date_time::min_date_time)).total_microseconds();
+  else firstSeedValue = (std::uint_fast32_t)std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::system_clock::now() - std::chrono::system_clock::time_point()).count();
   firstSeedGenerated = true;
 		
   return firstSeedValue;
@@ -36,22 +35,21 @@ static boost::uint32_t firstSeed()
 /// We use a different random number generator for the seeds of the
 /// Other random generators. The root seed is from the number of
 /// nano-seconds in the current time.
-static boost::uint32_t nextSeed()
+static std::uint_fast32_t nextSeed()
 {
-  static boost::mutex rngMutex;
-  boost::mutex::scoped_lock slock(rngMutex);
-  static boost::lagged_fibonacci607 sGen(firstSeed());
-  static boost::uniform_int<> sDist(1, 1000000000);
-  static boost::variate_generator<boost::lagged_fibonacci607&, boost::uniform_int<> > s(sGen, sDist);
-  return s();
+  static std::mutex rngMutex;
+  std::unique_lock<std::mutex> slock(rngMutex);
+  static std::ranlux24_base sGen;
+  static std::uniform_int_distribution<> sDist(1, 1000000000);
+  return sDist(sGen);
 }
 	
-boost::uint32_t RNG::getSeed()
+std::uint_fast32_t RNG::getSeed()
 {
   return firstSeed();
 }
 	
-void RNG::setSeed(boost::uint32_t seed)
+void RNG::setSeed(std::uint_fast32_t seed)
 {
   if(firstSeedGenerated)
   {
@@ -68,9 +66,7 @@ void RNG::setSeed(boost::uint32_t seed)
 	
 RNG::RNG() : generator_(nextSeed()),
                  uniDist_(0, 1),
-                 normalDist_(0, 1),
-                 uni_(generator_, uniDist_),
-                 normal_(generator_, normalDist_)
+                 normalDist_(0, 1)
 {
 }
 	
@@ -96,9 +92,9 @@ int RNG::halfNormalInt(int r_min, int r_max, double focus)
 //       pg. 124-132
 void RNG::quaternion(double value[4])
 {
-  double x0 = uni_();
+  double x0 = uniDist_(generator_);
   double r1 = sqrt(1.0 - x0), r2 = sqrt(x0);
-  double t1 = 2.0 * constants::pi * uni_(), t2 = 2.0 * constants::pi * uni_();
+  double t1 = 2.0 * constants::pi * uniDist_(generator_), t2 = 2.0 * constants::pi * uniDist_(generator_);
   double c1 = cos(t1), s1 = sin(t1);
   double c2 = cos(t2), s2 = sin(t2);
   value[0] = s1 * r1;
@@ -110,9 +106,9 @@ void RNG::quaternion(double value[4])
 // From Effective Sampling and Distance Metrics for 3D Rigid Body Path Planning, by James Kuffner, ICRA 2004
 void RNG::eulerRPY(double value[3])
 {
-  value[0] = constants::pi * (2.0 * uni_() - 1.0);
-  value[1] = acos(1.0 - 2.0 * uni_()) - constants::pi / 2.0;
-  value[2] = constants::pi * (2.0 * uni_() - 1.0);
+  value[0] = constants::pi * (2.0 * uniDist_(generator_) - 1.0);
+  value[1] = acos(1.0 - 2.0 * uniDist_(generator_)) - constants::pi / 2.0;
+  value[2] = constants::pi * (2.0 * uniDist_(generator_) - 1.0);
 }
 	
 void RNG::disk(double r_min, double r_max, double& x, double& y)

--- a/src/math/transform.cpp
+++ b/src/math/transform.cpp
@@ -37,6 +37,7 @@
 
 #include "fcl/math/constants.h"
 #include "fcl/math/transform.h"
+#include <cassert>
 
 namespace fcl
 {
@@ -410,7 +411,7 @@ Vec3f Quaternion3f::getRow(std::size_t i) const
 
 const Matrix3f& Transform3f::getRotationInternal() const
 {
-  boost::mutex::scoped_lock slock(const_cast<boost::mutex&>(lock_));
+  std::unique_lock<std::mutex> slock(const_cast<std::mutex&>(lock_));
   if(!matrix_set)
   {
     q.toRotation(R);

--- a/src/profile.cpp
+++ b/src/profile.cpp
@@ -222,7 +222,7 @@ void fcl::tools::Profiler::printThreadInfo(std::ostream &out, const PerThread &d
   {
     const AvgInfo &a = data.avg.find(avg[i].name)->second;
     out << avg[i].name << ": " << avg[i].value << " (stddev = " <<
-      sqrt(std::fabs(a.totalSqr - (double)a.parts * avg[i].value * avg[i].value) / ((double)a.parts - 1.)) << ")" << std::endl;
+      std::sqrt(std::abs(a.totalSqr - (double)a.parts * avg[i].value * avg[i].value) / ((double)a.parts - 1.)) << ")" << std::endl;
   }
 
   std::vector<dataDoubleVal> time;

--- a/src/profile.cpp
+++ b/src/profile.cpp
@@ -37,7 +37,7 @@
 /** \author Ioan Sucan */
 
 #include "fcl/profile.h"
-
+#include <cmath>
 
 fcl::tools::Profiler& fcl::tools::Profiler::Instance(void)
 {
@@ -222,7 +222,7 @@ void fcl::tools::Profiler::printThreadInfo(std::ostream &out, const PerThread &d
   {
     const AvgInfo &a = data.avg.find(avg[i].name)->second;
     out << avg[i].name << ": " << avg[i].value << " (stddev = " <<
-      sqrt(fabs(a.totalSqr - (double)a.parts * avg[i].value * avg[i].value) / ((double)a.parts - 1.)) << ")" << std::endl;
+      sqrt(std::fabs(a.totalSqr - (double)a.parts * avg[i].value * avg[i].value) / ((double)a.parts - 1.)) << ")" << std::endl;
   }
 
   std::vector<dataDoubleVal> time;

--- a/test/general_test.cpp
+++ b/test/general_test.cpp
@@ -3,7 +3,6 @@
 #include <fcl/narrowphase/narrowphase.h>
 #include <iostream>
 #include <fcl/collision.h>
-#include <boost/foreach.hpp>
 
 using namespace std;
 using namespace fcl;
@@ -48,7 +47,7 @@ int main(int argc, char** argv)
   result.getContacts(contacts);
 
   cout << contacts.size() << " contacts found" << endl;
-  BOOST_FOREACH(Contact& contact, contacts) {
+  for(const Contact &contact : contacts) {
     cout << "position: " << contact.pos << endl;
   }
 }

--- a/test/test_fcl_octomap.cpp
+++ b/test/test_fcl_octomap.cpp
@@ -631,7 +631,7 @@ void octomap_distance_test(double env_scale, std::size_t env_size, bool use_mesh
 
 void generateBoxesFromOctomap(std::vector<CollisionObject*>& boxes, OcTree& tree)
 {
-  std::vector<boost::array<FCL_REAL, 6> > boxes_ = tree.toBoxes();
+  std::vector<std::array<FCL_REAL, 6> > boxes_ = tree.toBoxes();
 
   for(std::size_t i = 0; i < boxes_.size(); ++i)
   {
@@ -684,7 +684,7 @@ void generateEnvironments(std::vector<CollisionObject*>& env, double env_scale, 
 
 void generateBoxesFromOctomapMesh(std::vector<CollisionObject*>& boxes, OcTree& tree)
 {
-  std::vector<boost::array<FCL_REAL, 6> > boxes_ = tree.toBoxes();
+  std::vector<std::array<FCL_REAL, 6> > boxes_ = tree.toBoxes();
 
   for(std::size_t i = 0; i < boxes_.size(); ++i)
   {

--- a/test/test_fcl_simple.cpp
+++ b/test/test_fcl_simple.cpp
@@ -11,8 +11,6 @@
 #include "fcl/math/sampling.h"
 #include "fcl/knn/nearest_neighbors_GNAT.h"
 
-#include <boost/assign/list_of.hpp>
-
 using namespace fcl;
 
 static FCL_REAL epsilon = 1e-6;
@@ -86,7 +84,7 @@ BOOST_AUTO_TEST_CASE(Vec_nf_test)
   for(int i = 0; i < 4; ++i)
     upper[i] = 1;
 
-  Vecnf<4> aa(boost::assign::list_of<FCL_REAL>(1)(2).convert_to_container<std::vector<FCL_REAL> >());
+  Vecnf<4> aa(std::vector<FCL_REAL>({1,2}));
   std::cout << aa << std::endl;
 
   SamplerR<4> sampler(lower, upper);


### PR DESCRIPTION
Note: BVH_Model has a copy constructor, so having it derive from boost::noncopyable makes no sense. We can delete the copy assignment operator, if desired.
Only remaining boost usage in include/ and src/ is boost::dynamic_bitset. Use std::vector\<bool\> instead?