### PR TITLE
Removes dependence on boost::dynamic_bitset and fixes test failure on Windows

### DIFF
--- a/include/fcl/broadphase/morton.h
+++ b/include/fcl/broadphase/morton.h
@@ -156,7 +156,7 @@ struct morton_functor<FCL_UINT64>
 
 /// @brief Functor to compute N bit morton code for a given AABB
 /// N must be a multiple of 3.
-template<int N>
+template<size_t N>
 struct morton_functor<std::bitset<N>> 
 {
   static_assert(N%3==0, "Number of bits must be a multiple of 3");

--- a/include/fcl/data_types.h
+++ b/include/fcl/data_types.h
@@ -45,10 +45,10 @@ namespace fcl
 {
 
 typedef double FCL_REAL;
-typedef std::uint_fast64_t FCL_INT64;
-typedef std::int_fast64_t FCL_UINT64;
-typedef std::uint_fast32_t FCL_UINT32;
-typedef std::int_fast32_t FCL_INT32;
+typedef std::int64_t  FCL_INT64;
+typedef std::uint64_t FCL_UINT64;
+typedef std::int32_t  FCL_INT32;
+typedef std::uint32_t FCL_UINT32;
 
 /// @brief Triangle with 3 indices for points
 class Triangle

--- a/src/broadphase/broadphase_bruteforce.cpp
+++ b/src/broadphase/broadphase_bruteforce.cpp
@@ -37,6 +37,7 @@
 
 #include "fcl/broadphase/broadphase_bruteforce.h"
 #include <limits>
+#include <iterator>
 
 namespace fcl
 {

--- a/test/test_fcl_math.cpp
+++ b/test/test_fcl_math.cpp
@@ -3,6 +3,7 @@
  *
  *  Copyright (c) 2011-2014, Willow Garage, Inc.
  *  Copyright (c) 2014-2015, Open Source Robotics Foundation
+ *  Copyright (c) 2016, Toyota Research Institute
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -629,15 +630,13 @@ BOOST_AUTO_TEST_CASE(vec_test_sse_vec64_consistent)
 BOOST_AUTO_TEST_CASE(morton)
 {
   AABB bbox(Vec3f(0, 0, 0), Vec3f(1000, 1000, 1000));
-  morton_functor<boost::dynamic_bitset<> > F1(bbox, 10);
-  morton_functor<boost::dynamic_bitset<> > F2(bbox, 20);
-  morton_functor<FCL_UINT64> F3(bbox);
-  morton_functor<FCL_UINT32> F4(bbox);
+  morton_functor<std::bitset<30>> F1(bbox);
+  morton_functor<std::bitset<60>> F2(bbox);
+  morton_functor<FCL_UINT64> F3(bbox); // 60 bits
+  morton_functor<FCL_UINT32> F4(bbox); // 30 bits
 
   Vec3f p(254, 873, 674);
-  std::cout << std::hex << F1(p).to_ulong() << std::endl;
-  std::cout << std::hex << F2(p).to_ulong() << std::endl;
-  std::cout << std::hex << F3(p) << std::endl;
-  std::cout << std::hex << F4(p) << std::endl;
-  
+
+  BOOST_CHECK(F1(p).to_ulong() == F4(p));
+  BOOST_CHECK(F2(p).to_ullong() == F3(p));
 }


### PR DESCRIPTION
This PR changes the bitset specialization of `morton_functor` to use `std::bitset` instead of `boost::dynamic_bitset`. The number of bits must now be set at compile time but there doesn't seem to be any reason for run time sizing, and it wasn't being used anywhere or tested.

When this is merged there will no longer be any boost dependency in the fcl code. However, the tests are still using the boost test framework.

This PR also fixes a Windows test failure reported in #107. That reduces the number of Windows failures from 4 to 3.