### PR TITLE
Fix fallback finding of ccd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,8 +117,7 @@ endif()
 if(NOT CCD_FOUND)
     # if pkfconfig is not installed, then fall back on more fragile detection
     # of ccd
-    find_path(CCD_INCLUDE_DIRS ccd.h
-        PATH_SUFFIXES ccd)
+    find_path(CCD_INCLUDE_DIRS ccd/ccd.h)
     find_library(CCD_LIBRARY
         ${CMAKE_SHARED_LIBRARY_PREFIX}ccd${CMAKE_SHARED_LIBRARY_SUFFIX})
     if(CCD_INCLUDE_DIRS AND CCD_LIBRARY)


### PR DESCRIPTION
Fix finding include directory for ccd when falling back from using pkg-config. The old mechanism would find the include directory as e.g. `prefix/include/ccd`, which fails when we try to include `ccd/ccd.h`. Drop the path suffix and instead search for the literal name `ccd/ccd.h`, which will produce the correct include path.