### PR TITLE
[BUG FIX]octree vs mesh CollisionResult now returns triangle id.

### DIFF
--- a/include/fcl/traversal/traversal_node_octree.h
+++ b/include/fcl/traversal/traversal_node_octree.h
@@ -597,7 +597,7 @@ private:
             {
               is_intersect = true;
               if(cresult->numContacts() < crequest->num_max_contacts)
-                cresult->addContact(Contact(tree1, tree2, root1 - tree1->getRoot(), root2));
+                cresult->addContact(Contact(tree1, tree2, root1 - tree1->getRoot(), primitive_id));
             }
           }
           else
@@ -610,7 +610,7 @@ private:
             {
               is_intersect = true;
               if(cresult->numContacts() < crequest->num_max_contacts)
-                cresult->addContact(Contact(tree1, tree2, root1 - tree1->getRoot(), root2, contact, normal, depth));
+                cresult->addContact(Contact(tree1, tree2, root1 - tree1->getRoot(), primitive_id, contact, normal, depth));
             }
           }
 


### PR DESCRIPTION
In previous version of fcl, the Contact objects contained in CollisionResult object, pointed
to invalid triangle id in a specific case.
This case is the collision request between an octree and a mesh.
This has been fixed and a simple test has been added.
It simply verifies that the returned triangle id actually exists in the object.