### PR TITLE
Hide coveralls repository token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,10 @@ compiler:
   - clang
 
 env:
-  - BUILD_TYPE=Debug   COVERALLS=OFF
+  - BUILD_TYPE=Debug   COVERALLS=ON
   - BUILD_TYPE=Release COVERALLS=OFF
 
 matrix:
-  include:
-    - os: linux
-      compiler: gcc
-      env: BUILD_TYPE=Debug COVERALLS=ON COVERALLS_REPO_TOKEN=PheK7dcpQFPXAUG0wTMVTnSVF349jEJGc
   exclude:
     - os: osx
       compiler: gcc
@@ -46,7 +42,7 @@ script:
 
   # Build
   - make -j4
-  - if [ $COVERALLS = ON ]; then make coveralls; fi
+  - if [ $COVERALLS = ON ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then make coveralls; fi
 
   # Run unit tests
   - make test


### PR DESCRIPTION
The coveralls repository token is supposed to be private because it grants write access. To hide it while it keeps working:

1. removed `COVERALLS_REPO_TOKEN` from `.travis.yml`
1. generated a new repository token
1. set `COVERALLS_REPO_TOKEN` to the new token on Travis as a hidden environment variable

as [we did in DART](https://github.com/dartsim/dart/pull/688) thanks to @mkoval.

Also, I changed the coverage test to be done in linux/debug builds instead of adding a separate build to reduce the whole Travis test. It could be better the coverage test is done only for gcc, but Travis doesn't provide environment variable to detect the compiler. I'm open to hearing a better way to do this.