### PR TITLE
add safe-guards to allow octree headers only if octomap enabled

### DIFF
--- a/include/fcl/octree.h
+++ b/include/fcl/octree.h
@@ -39,6 +39,10 @@
 #ifndef FCL_OCTREE_H
 #define FCL_OCTREE_H
 
+#include "fcl/config.h"
+#if not(FCL_HAVE_OCTOMAP)
+#error "This header requires fcl to be compiled with octomap support"
+#endif
 
 #include <memory>
 #include <array>

--- a/include/fcl/traversal/traversal_node_octree.h
+++ b/include/fcl/traversal/traversal_node_octree.h
@@ -38,6 +38,11 @@
 #ifndef FCL_TRAVERSAL_NODE_OCTREE_H
 #define FCL_TRAVERSAL_NODE_OCTREE_H
 
+#include "fcl/config.h"
+#if not(FCL_HAVE_OCTOMAP)
+#error "This header requires fcl to be compiled with octomap support"
+#endif
+
 #include "fcl/collision_data.h"
 #include "fcl/traversal/traversal_node_base.h"
 #include "fcl/narrowphase/narrowphase.h"


### PR DESCRIPTION
octomap is no header-only dependency and there is a hard-coded value in the
internal config.h header that specifies whether it is available or not. This
value influences the behavior of fcl headers
(include/fcl/traversal/traversal_node_setup.h) and it influences which methods
are available in the library
(src/broadphase/broadphase_dynamic_AABB_tree.cpp) Using these interfaces even
though fcl was configured without octomap invites trouble and should be
prevented.

Problems arise if fcl is not compiled with octomap but some version of octomap
is available at compile time of a dependent project. Basically this is the
case with libfcl in ubuntu xenial
(it was compiled without octomap support) and ros kinetic's octomap 1.8. I
expected to find errors on fcl not being configured with octomap but instead
only got compile issues because of interface changes.