### PR TITLE
ensure the locally generated config.h is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ endif()
 
 # FCL's own include dir should be at the front of the include path
 include_directories(BEFORE "include")
-include_directories("${CMAKE_CURRENT_BINARY_DIR}/include")
+include_directories(BEFORE "${CMAKE_CURRENT_BINARY_DIR}/include")
 
 if(PKG_CONFIG_FOUND)
   pkg_check_modules(CCD ccd)


### PR DESCRIPTION
Should fix https://github.com/flexible-collision-library/fcl/issues/132

This is necessary, because if one of the dependencies is installed to a place where another version of `fcl` is also installed, it can happen that the include directories favor the installed `fcl/config.h` over the one generated for the local build. This is why people never saw it in CI (since CI didn't install `fcl` before trying to build `fcl`).

This should be backported to the `fcl-0.3` branch too :smile:.