### PR TITLE
Fix incorrect use of FCL_BUILD_TYPE_DEBUG

### DIFF
--- a/test/test_fcl_broadphase.cpp
+++ b/test/test_fcl_broadphase.cpp
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(test_core_bf_broad_phase_collision_empty)
 /// check broad phase collision and self collision, only return collision or not
 BOOST_AUTO_TEST_CASE(test_core_bf_broad_phase_collision_binary)
 {
-#ifdef FCL_BUILD_TYPE_DEBUG
+#if FCL_BUILD_TYPE_DEBUG
   broad_phase_collision_test(2000, 10, 100, 1, false);
   broad_phase_collision_test(2000, 100, 100, 1, false);
   broad_phase_collision_test(2000, 10, 100, 1, true);
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE(test_core_mesh_bf_broad_phase_update_collision_mesh_binary)
 /// check broad phase update, in mesh, return 10 contacts
 BOOST_AUTO_TEST_CASE(test_core_mesh_bf_broad_phase_update_collision_mesh)
 {
-#ifdef FCL_BUILD_TYPE_DEBUG
+#if FCL_BUILD_TYPE_DEBUG
   broad_phase_update_collision_test(200, 10, 100, 10, false, true);
   broad_phase_update_collision_test(200, 100, 100, 10, false, true);
 #else
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(test_core_mesh_bf_broad_phase_update_collision_mesh)
 /// check broad phase update, in mesh, exhaustive
 BOOST_AUTO_TEST_CASE(test_core_mesh_bf_broad_phase_update_collision_mesh_exhaustive)
 {
-#ifdef FCL_BUILD_TYPE_DEBUG
+#if FCL_BUILD_TYPE_DEBUG
   broad_phase_update_collision_test(2000, 10, 100, 1, true, true);
   broad_phase_update_collision_test(2000, 100, 100, 1, true, true);
 #else
@@ -227,7 +227,7 @@ BOOST_AUTO_TEST_CASE(test_core_mesh_bf_broad_phase_update_collision_mesh_exhaust
 /// check broad phase distance
 BOOST_AUTO_TEST_CASE(test_core_mesh_bf_broad_phase_distance_mesh)
 {
-#ifdef FCL_BUILD_TYPE_DEBUG
+#if FCL_BUILD_TYPE_DEBUG
   broad_phase_distance_test(200, 10, 10, true);
   broad_phase_distance_test(200, 100, 10, true);
   broad_phase_distance_test(2000, 10, 10, true);
@@ -251,7 +251,7 @@ BOOST_AUTO_TEST_CASE(test_core_mesh_bf_broad_phase_self_distance_mesh)
 /// check broad phase collision and self collision, return only collision or not, in mesh
 BOOST_AUTO_TEST_CASE(test_core_mesh_bf_broad_phase_collision_mesh_binary)
 {
-#ifdef FCL_BUILD_TYPE_DEBUG
+#if FCL_BUILD_TYPE_DEBUG
   broad_phase_collision_test(2000, 10, 100, 1, false, true);
   broad_phase_collision_test(2000, 100, 100, 1, false, true);
 #else
@@ -263,7 +263,7 @@ BOOST_AUTO_TEST_CASE(test_core_mesh_bf_broad_phase_collision_mesh_binary)
 /// check broad phase collision and self collision, return 10 contacts, in mesh
 BOOST_AUTO_TEST_CASE(test_core_mesh_bf_broad_phase_collision_mesh)
 {
-#ifdef FCL_BUILD_TYPE_DEBUG
+#if FCL_BUILD_TYPE_DEBUG
   broad_phase_collision_test(2000, 10, 100, 10, false, true);
   broad_phase_collision_test(2000, 100, 100, 10, false, true);
 #else
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE(test_core_mesh_bf_broad_phase_collision_mesh)
 /// check broad phase collision and self collision, exhaustive, in mesh
 BOOST_AUTO_TEST_CASE(test_core_mesh_bf_broad_phase_collision_mesh_exhaustive)
 {
-#ifdef FCL_BUILD_TYPE_DEBUG
+#if FCL_BUILD_TYPE_DEBUG
   broad_phase_collision_test(2000, 10, 100, 1, true, true);
   broad_phase_collision_test(2000, 100, 100, 1, true, true);
 #else

--- a/test/test_fcl_octomap.cpp
+++ b/test/test_fcl_octomap.cpp
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(test_octomap_collision)
 
 BOOST_AUTO_TEST_CASE(test_octomap_collision_mesh)
 {
-#ifdef FCL_BUILD_TYPE_DEBUG
+#if FCL_BUILD_TYPE_DEBUG
   octomap_collision_test(200, 10, false, 10, true, true);
   octomap_collision_test(200, 100, false, 10, true, true);
   octomap_collision_test(200, 10, true, 1, true, true);
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(test_octomap_collision_mesh)
 
 BOOST_AUTO_TEST_CASE(test_octomap_collision_mesh_octomap_box)
 {
-#ifdef FCL_BUILD_TYPE_DEBUG
+#if FCL_BUILD_TYPE_DEBUG
   octomap_collision_test(200, 10, false, 10, true, false);
   octomap_collision_test(200, 100, false, 10, true, false);
   octomap_collision_test(200, 10, true, 1, true, false);
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE(test_octomap_distance)
 
 BOOST_AUTO_TEST_CASE(test_octomap_distance_mesh)
 {
-#ifdef FCL_BUILD_TYPE_DEBUG
+#if FCL_BUILD_TYPE_DEBUG
   octomap_distance_test(200, 5, true, true);
   octomap_distance_test(200, 50, true, true);
 #else
@@ -166,7 +166,7 @@ BOOST_AUTO_TEST_CASE(test_octomap_distance_mesh)
 
 BOOST_AUTO_TEST_CASE(test_octomap_distance_mesh_octomap_box)
 {
-#ifdef FCL_BUILD_TYPE_DEBUG
+#if FCL_BUILD_TYPE_DEBUG
   octomap_distance_test(200, 10, true, false);
   octomap_distance_test(200, 100, true, false);
 #else
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(test_octomap_bvh_obb_d_distance_obb)
 
 BOOST_AUTO_TEST_CASE(test_octomap_bvh_kios_d_distance_kios)
 {
-#ifdef FCL_BUILD_TYPE_DEBUG
+#if FCL_BUILD_TYPE_DEBUG
   octomap_distance_test_BVH<kIOS>(2);
 #else
   octomap_distance_test_BVH<kIOS>(5);


### PR DESCRIPTION
The build type check with `FCL_BUILD_TYPE_DEBUG` and `FCL_BUILD_TYPE_RELEASE` should be done using their values instead of whether they are defined or not since they are always defined.