### PR TITLE
Split SSE cmake option. Use more descriptive names.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,13 +50,18 @@ else()
 endif()
 
 # Whether to enable SSE
+set (SSE_FLAGS "" LIST)
 option(FCL_USE_X64_SSE "Whether FCL should x64 SSE instructions" ON)
 if (FCL_USE_X64_SSE)
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpmath=sse -msse -msse2 -msse3 -mssse3")
+    set(SSE_FLAGS -mfpmath=sse -msse -msse2 -msse3 -mssse3)
   elseif(MSVC)
-    add_definitions(/arch:SSE2)
+    # Win64 will add the flag automatically
+    if("$CMAKE_VS_PLATFORM_NAME}" STREQUAL "Win32")
+      set(SSE_FLAGS /arch:SSE2)
+    endif()
   endif()
+  add_compile_options(${SSE_FLAGS})
 endif()
 
 option(FCL_USE_HOST_CUSTOM_CFLAGS "Whether FCL should use cflags from the host used to compile" OFF)
@@ -78,7 +83,10 @@ if(FCL_USE_SSE)
                         "If you want to replicate the previous behaviour use FCL_USE_HOST_CUSTOM_CFLAGS")
     add_definitions(-march=native)
   elseif(MSVC)
-    add_definitions(/arch:SSE2)
+    # Win64 will add the flag automatically
+    if("$CMAKE_VS_PLATFORM_NAME}" STREQUAL "Win32")
+      add_definitions(/arch:SSE2)
+    endif()
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,12 +64,12 @@ if (FCL_USE_X64_SSE)
   add_compile_options(${SSE_FLAGS})
 endif()
 
-option(FCL_USE_HOST_CUSTOM_CFLAGS "Whether FCL should use cflags from the host used to compile" OFF)
-if (FCL_USE_HOST_CUSTOM_CFLAGS)
+option(FCL_USE_HOST_NATIVE_ARCH "Whether FCL should use cflags from the host used to compile" OFF)
+if (FCL_USE_HOST_NATIVE_ARCH)
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
   else()
-    message(WARNING "FCL_USE_HOST_CUSTOM_CFLAGS is only supported in Linux. No effect.")
+    message(WARNING "FCL_USE_HOST_NATIVE_ARCH is only supported in Linux. No effect.")
   endif()
 endif()
 
@@ -79,8 +79,8 @@ option(FCL_USE_SSE "(deprecated) Whether FCL should SSE instructions" OFF)
 if(FCL_USE_SSE)
   set(FCL_HAVE_SSE TRUE)
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    message(WARNING "FCL_USE_SSE is deprecated please use: FCL_USE_X64_SSE or FCL_USE_HOST_CUSTOM_CFLAGS. "
-                    "If you want to replicate the previous behaviour use FCL_USE_HOST_CUSTOM_CFLAGS")
+    message(WARNING "FCL_USE_SSE is deprecated please use: FCL_USE_X64_SSE or FCL_USE_HOST_NATIVE_ARCH. "
+                    "If you want to replicate the previous behaviour use FCL_USE_HOST_NATIVE_ARCH")
     add_definitions(-march=native)
   elseif(MSVC)
     # Win64 will add the flag automatically

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,8 +79,8 @@ option(FCL_USE_SSE "(deprecated) Whether FCL should SSE instructions" OFF)
 if(FCL_USE_SSE)
   set(FCL_HAVE_SSE TRUE)
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    message(DEPRECATION "FCL_USE_SSE is deprecated please use: FCL_USE_X64_SSE or FCL_USE_HOST_CUSTOM_CFLAGS. "
-                        "If you want to replicate the previous behaviour use FCL_USE_HOST_CUSTOM_CFLAGS")
+    message(WARNING "FCL_USE_SSE is deprecated please use: FCL_USE_X64_SSE or FCL_USE_HOST_CUSTOM_CFLAGS. "
+                    "If you want to replicate the previous behaviour use FCL_USE_HOST_CUSTOM_CFLAGS")
     add_definitions(-march=native)
   elseif(MSVC)
     # Win64 will add the flag automatically

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ else()
 endif()
 
 # Whether to enable SSE
-set (SSE_FLAGS "" LIST)
+set (SSE_FLAGS "")
 option(FCL_USE_X64_SSE "Whether FCL should x64 SSE instructions" ON)
 if (FCL_USE_X64_SSE)
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,10 +50,32 @@ else()
 endif()
 
 # Whether to enable SSE
-option(FCL_USE_SSE "Whether FCL should SSE instructions" ON)
+option(FCL_USE_X64_SSE "Whether FCL should x64 SSE instructions" ON)
+if (FCL_USE_X64_SSE)
+  if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpmath=sse -msse -msse2 -msse3 -mssse3")
+  elseif(MSVC)
+    add_definitions(/arch:SSE2)
+  endif()
+endif()
+
+option(FCL_USE_HOST_CUSTOM_CFLAGS "Whether FCL should use cflags from the host used to compile" OFF)
+if (FCL_USE_HOST_CUSTOM_CFLAGS)
+  if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+  else()
+    message(WARNING "FCL_USE_HOST_CUSTOM_CFLAGS is only supported in Linux. No effect.")
+  endif()
+endif()
+
+# DEPRECATED: old cmake option. Not strictly correct from the semantic point of view
+# it was activating march=native, not only SSE
+option(FCL_USE_SSE "(deprecated) Whether FCL should SSE instructions" OFF)
 if(FCL_USE_SSE)
   set(FCL_HAVE_SSE TRUE)
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    message(DEPRECATION "FCL_USE_SSE is deprecated please use: FCL_USE_X64_SSE or FCL_USE_HOST_CUSTOM_CFLAGS. "
+                        "If you want to replicate the previous behaviour use FCL_USE_HOST_CUSTOM_CFLAGS")
     add_definitions(-march=native)
   elseif(MSVC)
     add_definitions(/arch:SSE2)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,9 @@ else()
   add_library(${PROJECT_NAME} SHARED ${FCL_HEADERS} ${FCL_SOURCE_CODE})
 endif()
 
+# Be sure to pass to the consumer the set of SIMD used in the compilation
+target_compile_options(${PROJECT_NAME} PUBLIC ${SSE_FLAGS})
+
 set_target_properties(${PROJECT_NAME} PROPERTIES
   VERSION ${FCL_VERSION}
   SOVERSION ${FCL_ABI_VERSION})


### PR DESCRIPTION
Current `FCL_HAVE_SSE` is enabling `-march=native` when compiled with gcc/clang. This flag enables much more than just SSE and it is specially dangerous when building packages. 

Debian users [were the first detecting this problem](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=840165). Note that the error [appeared again the ROS community](https://github.com/flexible-collision-library/fcl/issues/187), which uses a custom version of the package. 

The current commit deprecate the option and change it by other two different ones:

* `FCL_USE_HOST_CUSTOM_CFLAGS` (default off): same effect than then previous  one, hopefully with a more decriptive name.

* `FCL_USE_X64_SSE` (default on):  enable the standard set of SEE flags supported in every x64 machine
.
I have included the set of cflags that we [use to build the gazebo amd64 debian package](https://anonscm.debian.org/cgit/debian-science/packages/gazebo.git/tree/debian/rules#n9). So far I did not get any bug report about them.