### PR TITLE
Hierarchy tree bottom-up building: initialize iterators

### DIFF
--- a/include/fcl/broadphase/hierarchy_tree.hxx
+++ b/include/fcl/broadphase/hierarchy_tree.hxx
@@ -280,11 +280,21 @@ void HierarchyTree<BV>::bottomup(const NodeVecIterator lbeg, const NodeVecIterat
   while(lbeg < lcur_end - 1)
   {
     NodeVecIterator min_it1, min_it2;
+    // initialize iterators to first two elements, they will be chosen
+    // in case no mimimum bounding volume can be found
+    min_it1 = lbeg;
+    min_it2 = lbeg +1;
     FCL_REAL min_size = std::numeric_limits<FCL_REAL>::max();
     for(NodeVecIterator it1 = lbeg; it1 < lcur_end; ++it1)
     {
       for(NodeVecIterator it2 = it1 + 1; it2 < lcur_end; ++it2)
       {
+        if (std::isnan((*it1)->bv.size()) ||
+            std::isnan((*it2)->bv.size()))
+        {
+          continue;
+        }
+
         FCL_REAL cur_size = ((*it1)->bv + (*it2)->bv).size();
         if(cur_size < min_size)
         {


### PR DESCRIPTION
A segmentation fault is caused if the iterators in the hierarchy tree bottomup() method aren't initialized. It can happen that the minimum spanning BV cannot be found, for example if one of the BV's has a nan value size (or same for inf value).

While this would be an error arising earlier on, e.g. when updating the AABBs, it would be good to at least have the iterators here initialized to do anything at all.

We need this fix for FCL 0.5 or lower (compatible with DART 6.1). Of course the same fix could / should be applied to the master branch. Please let me know what you think about this, and then I can also post a PR to master and/or FCL 0.3 and 0.4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/213)
<!-- Reviewable:end -->
