### PR TITLE
Return the correct nearest points from `distance(...)`

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ environment:
   CTEST_OUTPUT_ON_FAILURE: 1
 
 cache:
-  - C:\Program Files\libccd
+  - C:\Program Files\libccd -> .appveyor.yml
 
 configuration:
   - Debug

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ environment:
   CTEST_OUTPUT_ON_FAILURE: 1
 
 cache:
-  - C:\Program Files\libccd
+  #- C:\Program Files\libccd
 
 configuration:
   - Debug

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ environment:
   CTEST_OUTPUT_ON_FAILURE: 1
 
 cache:
-  #- C:\Program Files\libccd
+  - C:\Program Files\libccd
 
 configuration:
   - Debug

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -1005,44 +1005,56 @@ static int __ccdEPA(const void *obj1, const void *obj2,
     return 0;
 }
 
+/** Returns the points p1 and p2 on the original shapes that correspond to point
+ * p in the given simplex.*/
 static void extractClosestPoints(ccd_simplex_t* simplex,
-                                 ccd_vec3_t* p1, ccd_vec3_t* p2, ccd_vec3_t* v)
+                                 ccd_vec3_t* p1, ccd_vec3_t* p2, ccd_vec3_t* p)
 {
   int simplex_size = ccdSimplexSize(simplex);
   assert(simplex_size <= 3);
   if (simplex_size == 1)
   {
-      // closest points are the ones stored in the simplex
+      // Closest points are the ones stored in the simplex
       if(p1) *p1 = simplex->ps[simplex->last].v1;
       if(p2) *p2 = simplex->ps[simplex->last].v2;
   }
   else if (simplex_size ==2)
   {
-      // closest points lie between the two points in the simplex
-      // v = (1-s)*vA + s*vB, 0 <= s <= 1
-      // v - vA = s*(vB - vA)
-      // s = (v_x - vA_x)/(vB_x - vA_x)
-      double vA_x{ccdVec3X(&(simplex->ps[0].v))};
-      double vB_x{ccdVec3X(&(simplex->ps[1].v))};
-      double  v_x{ccdVec3X(v)};
-      double    s{(v_x - vA_x) / (vB_x - vA_x)};
+      // Closest points lie on the segment defined by the points in the simplex
+      // Let the segment be defined by points A and B. We can write p as
+      //
+      // p = A + s*AB, 0 <= s <= 1
+      // p - A = s*AB
+      //
+      // This defines three equations, but we only need one. Take the x
+      // component
+      //
+      // p_x - A_x = s*AB_x
+      //
+      // Thus, s is given by
+      //
+      // s = (p_x - A_x)/(B_x - vA_x)
+      double A_x{ccdVec3X(&(simplex->ps[0].v))};
+      double B_x{ccdVec3X(&(simplex->ps[1].v))};
+      double p_x{ccdVec3X(p)};
+      double    s{(p_x - A_x) / (B_x - A_x)};
       if (p1)
       {
-        ccd_vec3_t tmp;
+        // p1 = A1 + s*A1B1
+        ccd_vec3_t sAB;
+        ccdVec3Sub2(&sAB, &(simplex->ps[1].v1), &(simplex->ps[0].v1));
+        ccdVec3Scale(&sAB, s);
         ccdVec3Copy(p1, &(simplex->ps[0].v1));
-        ccdVec3Copy(&tmp, &(simplex->ps[1].v1));
-        ccdVec3Scale(p1, 1 - s);
-        ccdVec3Scale(&tmp, s);
-        ccdVec3Add(p1, &tmp);
+        ccdVec3Add(p1, &sAB);
       }
       if (p2)
       {
-        ccd_vec3_t tmp;
+        // p2 = A2 + s*A2B2
+        ccd_vec3_t sAB;
+        ccdVec3Sub2(&sAB, &(simplex->ps[1].v2), &(simplex->ps[0].v2));
+        ccdVec3Scale(&sAB, s);
         ccdVec3Copy(p2, &(simplex->ps[0].v2));
-        ccdVec3Copy(&tmp, &(simplex->ps[1].v2));
-        ccdVec3Scale(p2, 1 - s);
-        ccdVec3Scale(&tmp, s);
-        ccdVec3Add(p2, &tmp);
+        ccdVec3Add(p2, &sAB);
       }
   }
   else // simplex_size == 3
@@ -1058,20 +1070,20 @@ static void extractClosestPoints(ccd_simplex_t* simplex,
     ccdVec3Cross(&n, &AB, &AC);
     ccdVec3Normalize(&n);
 
-    // Since v lies in ABC, it can be expressed as
+    // Since p lies in ABC, it can be expressed as
     //
-    // v = A + v'
-    // v' = s*AB + t*AC
+    // p = A + p'
+    // p' = s*AB + t*AC
     //
     // where 0 <= s, t, s+t <= 1.
-    ccdVec3Sub2(&v_prime, v, &(simplex->ps[0].v));
+    ccdVec3Sub2(&v_prime, p, &(simplex->ps[0].v));
 
     // To find the corresponding v1 and v2, we need
     // values for s and t. Taking cross products with AB and AC gives the
     // following system:
     //
-    // AB x v' =  t*(AB x AC)
-    // AC x v' = -s*(AB x AC)
+    // AB x p' =  t*(AB x AC)
+    // AC x p' = -s*(AB x AC)
     ccdVec3Cross(&AB_cross_v_prime, &AB, &v_prime);
     ccdVec3Cross(&AC_cross_v_prime, &AC, &v_prime);
     ccdVec3Cross(&AB_cross_AC, &AB, &AC);
@@ -1079,19 +1091,20 @@ static void extractClosestPoints(ccd_simplex_t* simplex,
     // To convert this to a system of scalar equations, we take the dot product
     // with n:
     //
-    // n . (AB x v') =  t * n . (AB x AC)
-    // n . (AC x v') = -s * n . (AB x AC)
+    // n . (AB x p') =  t * n . (AB x AC)
+    // n . (AC x p') = -s * n . (AB x AC)
     double n_dot_AB_cross_AC{ccdVec3Dot(&n, &AB_cross_AC)};
 
     // Therefore, s and t are given by
     //
-    // s = -n . (AC x v') / n . (AB x AC)
-    // t =  n . (AB x v') / n . (AB x AC)
+    // s = -n . (AC x p') / n . (AB x AC)
+    // t =  n . (AB x p') / n . (AB x AC)
     double s{-ccdVec3Dot(&n, &AC_cross_v_prime) / n_dot_AB_cross_AC};
     double t{ccdVec3Dot(&n, &AB_cross_v_prime) / n_dot_AB_cross_AC};
 
     if (p1)
     {
+      // p1 = A1 + s*A1B1 + t*A1C1
       ccd_vec3_t sAB, tAC;
       ccdVec3Sub2(&sAB, &(simplex->ps[1].v1), &(simplex->ps[0].v1));
       ccdVec3Scale(&sAB, s);
@@ -1103,6 +1116,7 @@ static void extractClosestPoints(ccd_simplex_t* simplex,
     }
     if (p2)
     {
+      // p2 = A2 + s*A2B2 + t*A2C2
       ccd_vec3_t sAB, tAC;
       ccdVec3Sub2(&sAB, &(simplex->ps[1].v2), &(simplex->ps[0].v2));
       ccdVec3Scale(&sAB, s);

--- a/include/fcl/narrowphase/detail/gjk_solver_indep-inl.h
+++ b/include/fcl/narrowphase/detail/gjk_solver_indep-inl.h
@@ -620,7 +620,7 @@ struct ShapeDistanceIndepImpl
       if(distance) *distance = (w0 - w1).norm();
 
       if(p1) *p1 = w0;
-      if(p2) (*p2).noalias() = shape.toshape0 * w1;
+      if(p2) (*p2).noalias() = shape.toshape0.inverse() * w1;
 
       return true;
     }

--- a/include/fcl/narrowphase/distance-inl.h
+++ b/include/fcl/narrowphase/distance-inl.h
@@ -205,11 +205,13 @@ S distance(
   case GST_LIBCCD:
     {
       detail::GJKSolver_libccd<S> solver;
+      solver.distance_tolerance = request.distance_tolerance;
       return distance(o1, o2, &solver, request, result);
     }
   case GST_INDEP:
     {
       detail::GJKSolver_indep<S> solver;
+      solver.gjk_tolerance = request.distance_tolerance;
       return distance(o1, o2, &solver, request, result);
     }
   default:
@@ -229,11 +231,13 @@ S distance(
   case GST_LIBCCD:
     {
       detail::GJKSolver_libccd<S> solver;
+      solver.distance_tolerance = request.distance_tolerance;
       return distance(o1, tf1, o2, tf2, &solver, request, result);
     }
   case GST_INDEP:
     {
       detail::GJKSolver_indep<S> solver;
+      solver.gjk_tolerance = request.distance_tolerance;
       return distance(o1, tf1, o2, tf2, &solver, request, result);
     }
   default:

--- a/include/fcl/narrowphase/distance_request-inl.h
+++ b/include/fcl/narrowphase/distance_request-inl.h
@@ -56,11 +56,13 @@ DistanceRequest<S>::DistanceRequest(
     bool enable_signed_distance_,
     S rel_err_,
     S abs_err_,
+    S distance_tolerance_,
     GJKSolverType gjk_solver_type_)
   : enable_nearest_points(enable_nearest_points_),
     enable_signed_distance(enable_signed_distance_),
     rel_err(rel_err_),
     abs_err(abs_err_),
+    distance_tolerance(distance_tolerance_),
     gjk_solver_type(gjk_solver_type_)
 {
   // Do nothing

--- a/include/fcl/narrowphase/distance_request.h
+++ b/include/fcl/narrowphase/distance_request.h
@@ -95,6 +95,9 @@ struct DistanceRequest
   S rel_err; // relative error, between 0 and 1
   S abs_err; // absoluate error
 
+  /// @brief the threshold used in GJK algorithm to stop distance iteration
+  S distance_tolerance;
+
   /// @brief narrow phase solver type
   GJKSolverType gjk_solver_type;
 
@@ -103,6 +106,7 @@ struct DistanceRequest
       bool enable_signed_distance = false,
       S rel_err_ = 0.0,
       S abs_err_ = 0.0,
+      S distance_tolerance = 1e-6,
       GJKSolverType gjk_solver_type_ = GST_LIBCCD);
 
   bool isSatisfied(const DistanceResult<S>& result) const;

--- a/test/test_fcl_capsule_box_1.cpp
+++ b/test/test_fcl_capsule_box_1.cpp
@@ -54,6 +54,8 @@ void test_distance_capsule_box()
   // Enable computation of nearest points
   fcl::DistanceRequest<S> distanceRequest (true);
   fcl::DistanceResult<S> distanceResult;
+  fcl::detail::GJKSolver_libccd<S> gjk_solver;
+  gjk_solver.distance_tolerance = 1e-7;
 
   fcl::Transform3<S> tf1(fcl::Translation3<S>(fcl::Vector3<S> (3., 0, 0)));
   fcl::Transform3<S> tf2 = fcl::Transform3<S>::Identity();
@@ -61,7 +63,7 @@ void test_distance_capsule_box()
   fcl::CollisionObject<S> box (boxGeometry, tf2);
 
   // test distance
-  fcl::distance (&capsule, &box, distanceRequest, distanceResult);
+  fcl::distance (&capsule, &box, &gjk_solver, distanceRequest, distanceResult);
   // Nearest point on capsule
   fcl::Vector3<S> o1 (distanceResult.nearest_points [0]);
   // Nearest point on box
@@ -70,7 +72,7 @@ void test_distance_capsule_box()
   EXPECT_NEAR (o1 [0], -2.0, 1e-4);
   EXPECT_NEAR (o1 [1],  0.0, 1e-4);
   EXPECT_NEAR (o2 [0],  0.5, 1e-4);
-  EXPECT_NEAR (o1 [1],  0.0, 1e-4); // TODO(JS): maybe o2 rather than o1?
+  EXPECT_NEAR (o2 [1],  0.0, 1e-4);
 
   // Move capsule above box
   tf1 = fcl::Translation3<S>(fcl::Vector3<S> (0., 0., 8.));
@@ -78,7 +80,7 @@ void test_distance_capsule_box()
 
   // test distance
   distanceResult.clear ();
-  fcl::distance (&capsule, &box, distanceRequest, distanceResult);
+  fcl::distance (&capsule, &box, &gjk_solver, distanceRequest, distanceResult);
   o1 = distanceResult.nearest_points [0];
   o2 = distanceResult.nearest_points [1];
 
@@ -88,7 +90,7 @@ void test_distance_capsule_box()
   EXPECT_NEAR (o1 [2], -4.0, 1e-4);
 
   // Disabled broken test lines. Please see #25.
-  // CHECK_CLOSE_TO_0 (o2 [0], 1e-4);
+  EXPECT_NEAR (o2 [0],  0.0, 1e-4);
   EXPECT_NEAR (o2 [1],  0.0, 1e-4);
   EXPECT_NEAR (o2 [2],  2.0, 1e-4);
 
@@ -99,7 +101,7 @@ void test_distance_capsule_box()
 
   // test distance
   distanceResult.clear ();
-  fcl::distance (&capsule, &box, distanceRequest, distanceResult);
+  fcl::distance (&capsule, &box, &gjk_solver, distanceRequest, distanceResult);
   o1 = distanceResult.nearest_points [0];
   o2 = distanceResult.nearest_points [1];
 

--- a/test/test_fcl_capsule_box_1.cpp
+++ b/test/test_fcl_capsule_box_1.cpp
@@ -37,12 +37,13 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <limits>
 #include "fcl/narrowphase/distance.h"
 #include "fcl/narrowphase/collision.h"
 #include "fcl/narrowphase/collision_object.h"
 
 template <typename S>
-void test_distance_capsule_box()
+void test_distance_capsule_box(fcl::GJKSolverType solver_type, S solver_tolerance, S test_tolerance)
 {
   using CollisionGeometryPtr_t = std::shared_ptr<fcl::CollisionGeometry<S>>;
 
@@ -54,8 +55,9 @@ void test_distance_capsule_box()
   // Enable computation of nearest points
   fcl::DistanceRequest<S> distanceRequest (true);
   fcl::DistanceResult<S> distanceResult;
-  fcl::detail::GJKSolver_libccd<S> gjk_solver;
-  gjk_solver.distance_tolerance = 1e-7;
+
+  distanceRequest.gjk_solver_type = solver_type;
+  distanceRequest.distance_tolerance = solver_tolerance;
 
   fcl::Transform3<S> tf1(fcl::Translation3<S>(fcl::Vector3<S> (3., 0, 0)));
   fcl::Transform3<S> tf2 = fcl::Transform3<S>::Identity();
@@ -63,16 +65,16 @@ void test_distance_capsule_box()
   fcl::CollisionObject<S> box (boxGeometry, tf2);
 
   // test distance
-  fcl::distance (&capsule, &box, &gjk_solver, distanceRequest, distanceResult);
+  fcl::distance (&capsule, &box, distanceRequest, distanceResult);
   // Nearest point on capsule
   fcl::Vector3<S> o1 (distanceResult.nearest_points [0]);
   // Nearest point on box
   fcl::Vector3<S> o2 (distanceResult.nearest_points [1]);
-  EXPECT_NEAR (distanceResult.min_distance, 0.5, 1e-4);
-  EXPECT_NEAR (o1 [0], -2.0, 1e-4);
-  EXPECT_NEAR (o1 [1],  0.0, 1e-4);
-  EXPECT_NEAR (o2 [0],  0.5, 1e-4);
-  EXPECT_NEAR (o2 [1],  0.0, 1e-4);
+  EXPECT_NEAR (distanceResult.min_distance, 0.5, test_tolerance);
+  EXPECT_NEAR (o1 [0], -2.0, test_tolerance);
+  EXPECT_NEAR (o1 [1],  0.0, test_tolerance);
+  EXPECT_NEAR (o2 [0],  0.5, test_tolerance);
+  EXPECT_NEAR (o2 [1],  0.0, test_tolerance);
 
   // Move capsule above box
   tf1 = fcl::Translation3<S>(fcl::Vector3<S> (0., 0., 8.));
@@ -80,19 +82,18 @@ void test_distance_capsule_box()
 
   // test distance
   distanceResult.clear ();
-  fcl::distance (&capsule, &box, &gjk_solver, distanceRequest, distanceResult);
+  fcl::distance (&capsule, &box, distanceRequest, distanceResult);
   o1 = distanceResult.nearest_points [0];
   o2 = distanceResult.nearest_points [1];
 
-  EXPECT_NEAR (distanceResult.min_distance, 2.0, 1e-4);
-  EXPECT_NEAR (o1 [0],  0.0, 1e-4);
-  EXPECT_NEAR (o1 [1],  0.0, 1e-4);
-  EXPECT_NEAR (o1 [2], -4.0, 1e-4);
+  EXPECT_NEAR (distanceResult.min_distance, 2.0, test_tolerance);
+  EXPECT_NEAR (o1 [0],  0.0, test_tolerance);
+  EXPECT_NEAR (o1 [1],  0.0, test_tolerance);
+  EXPECT_NEAR (o1 [2], -4.0, test_tolerance);
 
-  // Disabled broken test lines. Please see #25.
-  EXPECT_NEAR (o2 [0],  0.0, 1e-4);
-  EXPECT_NEAR (o2 [1],  0.0, 1e-4);
-  EXPECT_NEAR (o2 [2],  2.0, 1e-4);
+  EXPECT_NEAR (o2 [0],  0.0, test_tolerance);
+  EXPECT_NEAR (o2 [1],  0.0, test_tolerance);
+  EXPECT_NEAR (o2 [2],  2.0, test_tolerance);
 
   // Rotate capsule around y axis by pi/2 and move it behind box
   tf1.translation() = fcl::Vector3<S>(-10., 0., 0.);
@@ -101,23 +102,27 @@ void test_distance_capsule_box()
 
   // test distance
   distanceResult.clear ();
-  fcl::distance (&capsule, &box, &gjk_solver, distanceRequest, distanceResult);
+  fcl::distance (&capsule, &box, distanceRequest, distanceResult);
   o1 = distanceResult.nearest_points [0];
   o2 = distanceResult.nearest_points [1];
 
-  EXPECT_NEAR (distanceResult.min_distance, 5.5, 1e-4);
-  EXPECT_NEAR (o1 [0],  0.0, 1e-4);
-  EXPECT_NEAR (o1 [1],  0.0, 1e-4);
-  EXPECT_NEAR (o1 [2],  4.0, 1e-4);
-  EXPECT_NEAR (o2 [0], -0.5, 1e-4);
-  EXPECT_NEAR (o2 [1],  0.0, 1e-4);
-  EXPECT_NEAR (o2 [2],  0.0, 1e-4);
+  EXPECT_NEAR (distanceResult.min_distance, 5.5, test_tolerance);
+  EXPECT_NEAR (o1 [0],  0.0, test_tolerance);
+  EXPECT_NEAR (o1 [1],  0.0, test_tolerance);
+  EXPECT_NEAR (o1 [2],  4.0, test_tolerance);
+  EXPECT_NEAR (o2 [0], -0.5, test_tolerance);
+  EXPECT_NEAR (o2 [1],  0.0, test_tolerance);
+  EXPECT_NEAR (o2 [2],  0.0, test_tolerance);
 }
 
-GTEST_TEST(FCL_GEOMETRIC_SHAPES, distance_capsule_box)
+GTEST_TEST(FCL_GEOMETRIC_SHAPES, distance_capsule_box_ccd)
 {
-//  test_distance_capsule_box<float>();
-  test_distance_capsule_box<double>();
+  test_distance_capsule_box<double>(fcl::GJKSolverType::GST_LIBCCD, 1e-6, 1e-4);
+}
+
+GTEST_TEST(FCL_GEOMETRIC_SHAPES, distance_capsule_box_indep)
+{
+  test_distance_capsule_box<double>(fcl::GJKSolverType::GST_INDEP, 1e-8, 1e-4);
 }
 
 //==============================================================================

--- a/test/test_fcl_capsule_box_2.cpp
+++ b/test/test_fcl_capsule_box_2.cpp
@@ -56,6 +56,8 @@ void test_distance_capsule_box()
   // Enable computation of nearest points
   fcl::DistanceRequest<S> distanceRequest (true);
   fcl::DistanceResult<S> distanceResult;
+  fcl::detail::GJKSolver_libccd<S> gjk_solver;
+  gjk_solver.distance_tolerance = 1e-7;
 
   // Rotate capsule around y axis by pi/2 and move it behind box
   fcl::Transform3<S> tf1 = fcl::Translation3<S>(fcl::Vector3<S>(-10., 0.8, 1.5))
@@ -66,19 +68,17 @@ void test_distance_capsule_box()
 
   // test distance
   distanceResult.clear ();
-  fcl::distance (&capsule, &box, distanceRequest, distanceResult);
+  fcl::distance (&capsule, &box, &gjk_solver, distanceRequest, distanceResult);
   fcl::Vector3<S> o1 = distanceResult.nearest_points [0];
   fcl::Vector3<S> o2 = distanceResult.nearest_points [1];
 
   EXPECT_NEAR (distanceResult.min_distance, 5.5, 1e-4);
-  // Disabled broken test lines. Please see #25.
-  // EXPECT_NEAR (o1 [0],  0.0, 1e-4);
-  // EXPECT_NEAR (o1 [1],  0.0, 1e-4);
+  EXPECT_NEAR (o1 [0],  0.0, 1e-4);
+  EXPECT_NEAR (o1 [1],  0.0, 1e-4);
   EXPECT_NEAR (o1 [2],  4.0, 1e-4);
   EXPECT_NEAR (o2 [0], -0.5, 1e-4);
-  // Disabled broken test lines. Please see #25.
-  // EXPECT_NEAR (o2 [1], 0.8, 1e-4);
-  // EXPECT_NEAR (o2 [2], 1.5, 1e-4);
+  EXPECT_NEAR (o2 [1],  0.8, 1e-4);
+  EXPECT_NEAR (o2 [2],  1.5, 1e-4);
 }
 
 GTEST_TEST(FCL_GEOMETRIC_SHAPES, distance_capsule_box)

--- a/test/test_fcl_capsule_box_2.cpp
+++ b/test/test_fcl_capsule_box_2.cpp
@@ -44,7 +44,7 @@
 #include "fcl/narrowphase/collision_object.h"
 
 template <typename S>
-void test_distance_capsule_box()
+void test_distance_capsule_box(fcl::GJKSolverType solver_type, S solver_tolerance, S test_tolerance)
 {
   using CollisionGeometryPtr_t = std::shared_ptr<fcl::CollisionGeometry<S>>;
 
@@ -56,8 +56,9 @@ void test_distance_capsule_box()
   // Enable computation of nearest points
   fcl::DistanceRequest<S> distanceRequest (true);
   fcl::DistanceResult<S> distanceResult;
-  fcl::detail::GJKSolver_libccd<S> gjk_solver;
-  gjk_solver.distance_tolerance = 1e-7;
+
+  distanceRequest.gjk_solver_type = solver_type;
+  distanceRequest.distance_tolerance = solver_tolerance;
 
   // Rotate capsule around y axis by pi/2 and move it behind box
   fcl::Transform3<S> tf1 = fcl::Translation3<S>(fcl::Vector3<S>(-10., 0.8, 1.5))
@@ -68,23 +69,27 @@ void test_distance_capsule_box()
 
   // test distance
   distanceResult.clear ();
-  fcl::distance (&capsule, &box, &gjk_solver, distanceRequest, distanceResult);
+  fcl::distance (&capsule, &box, distanceRequest, distanceResult);
   fcl::Vector3<S> o1 = distanceResult.nearest_points [0];
   fcl::Vector3<S> o2 = distanceResult.nearest_points [1];
 
-  EXPECT_NEAR (distanceResult.min_distance, 5.5, 1e-4);
-  EXPECT_NEAR (o1 [0],  0.0, 1e-4);
-  EXPECT_NEAR (o1 [1],  0.0, 1e-4);
-  EXPECT_NEAR (o1 [2],  4.0, 1e-4);
-  EXPECT_NEAR (o2 [0], -0.5, 1e-4);
-  EXPECT_NEAR (o2 [1],  0.8, 1e-4);
-  EXPECT_NEAR (o2 [2],  1.5, 1e-4);
+  EXPECT_NEAR (distanceResult.min_distance, 5.5, test_tolerance);
+  EXPECT_NEAR (o1 [0],  0.0, test_tolerance);
+  EXPECT_NEAR (o1 [1],  0.0, test_tolerance);
+  EXPECT_NEAR (o1 [2],  4.0, test_tolerance);
+  EXPECT_NEAR (o2 [0], -0.5, test_tolerance);
+  EXPECT_NEAR (o2 [1],  0.8, test_tolerance);
+  EXPECT_NEAR (o2 [2],  1.5, test_tolerance);
 }
 
-GTEST_TEST(FCL_GEOMETRIC_SHAPES, distance_capsule_box)
+GTEST_TEST(FCL_GEOMETRIC_SHAPES, distance_capsule_box_ccd)
 {
-//  test_distance_capsule_box<float>();
-  test_distance_capsule_box<double>();
+  test_distance_capsule_box<double>(fcl::GJKSolverType::GST_LIBCCD, 1e-7, 1e-4);
+}
+
+GTEST_TEST(FCL_GEOMETRIC_SHAPES, distance_capsule_box_indep)
+{
+  test_distance_capsule_box<double>(fcl::GJKSolverType::GST_INDEP, 1e-9, 1e-4);
 }
 
 //==============================================================================


### PR DESCRIPTION
This PR fixes issues in both the CCD-based and the independent GJK solvers, which caused `distance` to return erroneous values for the nearest points.

- CCD-base solver: Currently the most recently computed support points are returned as the nearest points, which is incorrect. The nearest points lie in the convex-hull of the points contained in the `simplex` variable. The points on the original shapes can be computed from the `simplex` and the nearest point to the origin on the Minkowski difference, `dir`.
- Independent solver: Currently, `p2` is not properly transformed to its shape's (`shape1`) frame. `toshape0` converts points from `shape1` frame to `shape0` frame. The points extracted from the GJK simplex are in `shape0` frame, so the inverse of `toshape0` needs to be applied.

The `test_fcl_capsule_box_*` tests contained lines that failed due to the issues described above. This PR uncomments those lines and modifies the tests to exercise both solvers.

This PR also adds a `distance_tolerance` member to `fcl::DistanceRequest`, which corresponds to the `distance_tolerance` and `gjk_tolerance` members in `GJKSolver_libccd` and `GJKSolver_indep` respectively. @jslee02, is this an appropriate way to expose this knob to the user? I didn't use `abs_err` because the default for that was 0.0, whereas the defaults for `distance_tolerance` and `gjk_tolerance` are 1e-6.