### PR TITLE
Build libccd with double precision on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,7 +31,9 @@ before_build:
             curl -L -o libccd-2.0.tar.gz https://github.com/danfis/libccd/archive/v2.0.tar.gz &&
             cmake -E tar zxf libccd-2.0.tar.gz &&
             cd libccd-2.0 &&
-            cmake -G "%CMAKE_GENERATOR_NAME%" -DCMAKE_BUILD_TYPE=%Configuration% . &&
+            mkdir build &&
+            cd build &&
+            cmake -G "%CMAKE_GENERATOR_NAME%" -DCMAKE_BUILD_TYPE=%Configuration% -DCCD_DOUBLE=True .. &&
             cmake --build . --target install --config %Configuration% &&
             cd ..
          ) else (echo Using cached libccd)

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,7 +35,7 @@ before_build:
             cd build &&
             cmake -G "%CMAKE_GENERATOR_NAME%" -DCMAKE_BUILD_TYPE=%Configuration% -DCCD_DOUBLE=True .. &&
             cmake --build . --target install --config %Configuration% &&
-            cd ..
+            cd ..\..
          ) else (echo Using cached libccd)
   - cmd: if not exist C:\"Program Files"\Eigen\include\eigen3\Eigen\Core (
             curl -L -o eigen-eigen-dc6cfdf9bcec.tar.gz https://bitbucket.org/eigen/eigen/get/3.2.9.tar.gz &&


### PR DESCRIPTION
FCL fails to pass `test_fcl_capsule_box_1` test with `libccd` built with single precision, which was discovered in #215. To partially address the issue, this PR changes the CI build scripts for Windows to always use `libccd` built with double precision.

We might want to do similar work for macOS as well.

Unrelated change: `libccd` is now built in `build` directory.