### PR TITLE
Fixed 'then' and 'else' statements

### DIFF
--- a/include/fcl/broadphase/detail/hierarchy_tree-inl.h
+++ b/include/fcl/broadphase/detail/hierarchy_tree-inl.h
@@ -1094,8 +1094,7 @@ struct SelectImpl<S, AABB<S>>
     else bv.min_[0] += vel[0];
     if(vel[1] > 0) bv.max_[1] += vel[1];
     else bv.min_[1] += vel[1];
-    if(vel[2] > 0) bv.max_[2] += vel[2];
-    else bv.max_[2] += vel[2];
+    bv.max_[2] += vel[2];
     tree.update(leaf, bv);
     return true;
   }
@@ -1112,8 +1111,7 @@ struct SelectImpl<S, AABB<S>>
     else bv.min_[0] += vel[0];
     if(vel[1] > 0) bv.max_[1] += vel[1];
     else bv.min_[1] += vel[1];
-    if(vel[2] > 0) bv.max_[2] += vel[2];
-    else bv.max_[2] += vel[2];
+    bv.max_[2] += vel[2];
     tree.update(leaf, bv);
     return true;
   }

--- a/include/fcl/broadphase/detail/hierarchy_tree-inl.h
+++ b/include/fcl/broadphase/detail/hierarchy_tree-inl.h
@@ -1095,7 +1095,7 @@ struct SelectImpl<S, AABB<S>>
     if(vel[1] > 0) bv.max_[1] += vel[1];
     else bv.min_[1] += vel[1];
     if(vel[2] > 0) bv.max_[2] += vel[2];
-      else bv.min_[2] += vel[2];
+    else bv.min_[2] += vel[2];
     tree.update(leaf, bv);
     return true;
   }
@@ -1113,7 +1113,7 @@ struct SelectImpl<S, AABB<S>>
     if(vel[1] > 0) bv.max_[1] += vel[1];
     else bv.min_[1] += vel[1];
     if(vel[2] > 0) bv.max_[2] += vel[2];
-      else bv.min_[2] += vel[2];
+    else bv.min_[2] += vel[2];
     tree.update(leaf, bv);
     return true;
   }

--- a/include/fcl/broadphase/detail/hierarchy_tree-inl.h
+++ b/include/fcl/broadphase/detail/hierarchy_tree-inl.h
@@ -1094,7 +1094,8 @@ struct SelectImpl<S, AABB<S>>
     else bv.min_[0] += vel[0];
     if(vel[1] > 0) bv.max_[1] += vel[1];
     else bv.min_[1] += vel[1];
-    bv.max_[2] += vel[2];
+    if(vel[2] > 0) bv.max_[2] += vel[2];
+      else bv.min_[2] += vel[2];
     tree.update(leaf, bv);
     return true;
   }
@@ -1111,7 +1112,8 @@ struct SelectImpl<S, AABB<S>>
     else bv.min_[0] += vel[0];
     if(vel[1] > 0) bv.max_[1] += vel[1];
     else bv.min_[1] += vel[1];
-    bv.max_[2] += vel[2];
+    if(vel[2] > 0) bv.max_[2] += vel[2];
+      else bv.min_[2] += vel[2];
     tree.update(leaf, bv);
     return true;
   }


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A warning, found using PVS-Studio:
fcl/include/fcl/broadphase/detail/hierarchy_tree-inl.h      1098    err     V523 The 'then' statement is equivalent to the 'else' statement.
fcl/include/fcl/broadphase/detail/hierarchy_tree-inl.h      1116    err     V523 The 'then' statement is equivalent to the 'else' statement.