### PR TITLE
Move make_aligned_shared() to under fcl namespace

### DIFF
--- a/test/test_fcl_collision.cpp
+++ b/test/test_fcl_collision.cpp
@@ -91,7 +91,7 @@ template <typename S>
 void test_OBB_Box_test()
 {
   S r_extents[] = {-1000, -1000, -1000, 1000, 1000, 1000};
-  Eigen::aligned_vector<Transform3<S>> rotate_transform;
+  aligned_vector<Transform3<S>> rotate_transform;
   test::generateRandomTransforms(r_extents, rotate_transform, 1);
 
   AABB<S> aabb1;
@@ -107,7 +107,7 @@ void test_OBB_Box_test()
   S extents[] = {-1000, -1000, -1000, 1000, 1000, 1000};
   std::size_t n = 1000;
 
-  Eigen::aligned_vector<Transform3<S>> transforms;
+  aligned_vector<Transform3<S>> transforms;
   test::generateRandomTransforms(extents, transforms, n);
 
   for(std::size_t i = 0; i < transforms.size(); ++i)
@@ -136,7 +136,7 @@ template <typename S>
 void test_OBB_shape_test()
 {
   S r_extents[] = {-1000, -1000, -1000, 1000, 1000, 1000};
-  Eigen::aligned_vector<Transform3<S>> rotate_transform;
+  aligned_vector<Transform3<S>> rotate_transform;
   test::generateRandomTransforms(r_extents, rotate_transform, 1);
 
   AABB<S> aabb1;
@@ -152,7 +152,7 @@ void test_OBB_shape_test()
   S extents[] = {-1000, -1000, -1000, 1000, 1000, 1000};
   std::size_t n = 1000;
 
-  Eigen::aligned_vector<Transform3<S>> transforms;
+  aligned_vector<Transform3<S>> transforms;
   test::generateRandomTransforms(extents, transforms, n);
 
   for(std::size_t i = 0; i < transforms.size(); ++i)
@@ -214,7 +214,7 @@ void test_OBB_AABB_test()
   S extents[] = {-1000, -1000, -1000, 1000, 1000, 1000};
   std::size_t n = 1000;
 
-  Eigen::aligned_vector<Transform3<S>> transforms;
+  aligned_vector<Transform3<S>> transforms;
   test::generateRandomTransforms(extents, transforms, n);
 
   AABB<S> aabb1;
@@ -259,7 +259,7 @@ void test_mesh_mesh()
   test::loadOBJFile(TEST_RESOURCES_DIR"/env.obj", p1, t1);
   test::loadOBJFile(TEST_RESOURCES_DIR"/rob.obj", p2, t2);
 
-  Eigen::aligned_vector<Transform3<S>> transforms;
+  aligned_vector<Transform3<S>> transforms;
   S extents[] = {-3000, -3000, 0, 3000, 3000, 3000};
 #ifdef NDEBUG
   std::size_t n = 10;

--- a/test/test_fcl_distance.cpp
+++ b/test/test_fcl_distance.cpp
@@ -87,7 +87,7 @@ void test_mesh_distance()
   test::loadOBJFile(TEST_RESOURCES_DIR"/env.obj", p1, t1);
   test::loadOBJFile(TEST_RESOURCES_DIR"/rob.obj", p2, t2);
 
-  Eigen::aligned_vector<Transform3<S>> transforms; // t0
+  aligned_vector<Transform3<S>> transforms; // t0
   S extents[] = {-3000, -3000, 0, 3000, 3000, 3000};
 #ifdef NDEBUG
   std::size_t n = 10;

--- a/test/test_fcl_frontlist.cpp
+++ b/test/test_fcl_frontlist.cpp
@@ -73,8 +73,8 @@ void test_front_list()
   test::loadOBJFile(TEST_RESOURCES_DIR"/env.obj", p1, t1);
   test::loadOBJFile(TEST_RESOURCES_DIR"/rob.obj", p2, t2);
 
-  Eigen::aligned_vector<Transform3<S>> transforms; // t0
-  Eigen::aligned_vector<Transform3<S>> transforms2; // t1
+  aligned_vector<Transform3<S>> transforms; // t0
+  aligned_vector<Transform3<S>> transforms2; // t1
   S extents[] = {-3000, -3000, 0, 3000, 3000, 3000};
   S delta_trans[] = {1, 1, 1};
 #ifdef NDEBUG

--- a/test/test_fcl_octomap_collision.cpp
+++ b/test/test_fcl_octomap_collision.cpp
@@ -181,7 +181,7 @@ void octomap_collision_test_BVH(std::size_t n, bool exhaustive, double resolutio
   OcTree<S>* tree = new OcTree<S>(std::shared_ptr<const octomap::OcTree>(test::generateOcTree(resolution)));
   std::shared_ptr<CollisionGeometry<S>> tree_ptr(tree);
 
-  Eigen::aligned_vector<Transform3<S>> transforms;
+  aligned_vector<Transform3<S>> transforms;
   S extents[] = {-10, -10, 10, 10, 10, 10};
 
   test::generateRandomTransforms(extents, transforms, n);

--- a/test/test_fcl_octomap_distance.cpp
+++ b/test/test_fcl_octomap_distance.cpp
@@ -184,7 +184,7 @@ void octomap_distance_test_BVH(std::size_t n, double resolution)
   OcTree<S>* tree = new OcTree<S>(std::shared_ptr<octomap::OcTree>(test::generateOcTree(resolution)));
   std::shared_ptr<CollisionGeometry<S>> tree_ptr(tree);
 
-  Eigen::aligned_vector<Transform3<S>> transforms;
+  aligned_vector<Transform3<S>> transforms;
   S extents[] = {-10, -10, 10, 10, 10, 10};
 
   test::generateRandomTransforms(extents, transforms, n);

--- a/test/test_fcl_utility.h
+++ b/test/test_fcl_utility.h
@@ -135,15 +135,15 @@ void generateRandomTransform(S extents[6], Transform3<S>& transform);
 
 /// @brief Generate n random transforms whose translations are constrained by extents.
 template <typename S>
-void generateRandomTransforms(S extents[6], Eigen::aligned_vector<Transform3<S>>& transforms, std::size_t n);
+void generateRandomTransforms(S extents[6], aligned_vector<Transform3<S>>& transforms, std::size_t n);
 
 /// @brief Generate n random transforms whose translations are constrained by extents. Also generate another transforms2 which have additional random translation & rotation to the transforms generated.
 template <typename S>
-void generateRandomTransforms(S extents[6], S delta_trans[3], S delta_rot, Eigen::aligned_vector<Transform3<S>>& transforms, Eigen::aligned_vector<Transform3<S>>& transforms2, std::size_t n);
+void generateRandomTransforms(S extents[6], S delta_trans[3], S delta_rot, aligned_vector<Transform3<S>>& transforms, aligned_vector<Transform3<S>>& transforms2, std::size_t n);
 
 /// @brief Generate n random tranforms and transform2 with addtional random translation/rotation. The transforms and transform2 are used as initial and goal configurations for the first mesh. The second mesh is in I. This is used for continuous collision detection checking.
 template <typename S>
-void generateRandomTransforms_ccd(S extents[6], Eigen::aligned_vector<Transform3<S>>& transforms, Eigen::aligned_vector<Transform3<S>>& transforms2, S delta_trans[3], S delta_rot, std::size_t n,
+void generateRandomTransforms_ccd(S extents[6], aligned_vector<Transform3<S>>& transforms, aligned_vector<Transform3<S>>& transforms2, S delta_trans[3], S delta_rot, std::size_t n,
                                  const std::vector<Vector3<S>>& vertices1, const std::vector<Triangle>& triangles1,
                                  const std::vector<Vector3<S>>& vertices2, const std::vector<Triangle>& triangles2);
 
@@ -419,7 +419,7 @@ void generateRandomTransform(const std::array<S, 6>& extents, Transform3<S>& tra
 
 //==============================================================================
 template <typename S>
-void generateRandomTransforms(S extents[6], Eigen::aligned_vector<Transform3<S>>& transforms, std::size_t n)
+void generateRandomTransforms(S extents[6], aligned_vector<Transform3<S>>& transforms, std::size_t n)
 {
   transforms.resize(n);
   for(std::size_t i = 0; i < n; ++i)
@@ -446,7 +446,7 @@ void generateRandomTransforms(S extents[6], Eigen::aligned_vector<Transform3<S>>
 
 //==============================================================================
 template <typename S>
-void generateRandomTransforms(S extents[6], S delta_trans[3], S delta_rot, Eigen::aligned_vector<Transform3<S>>& transforms, Eigen::aligned_vector<Transform3<S>>& transforms2, std::size_t n)
+void generateRandomTransforms(S extents[6], S delta_trans[3], S delta_rot, aligned_vector<Transform3<S>>& transforms, aligned_vector<Transform3<S>>& transforms2, std::size_t n)
 {
   transforms.resize(n);
   transforms2.resize(n);
@@ -491,7 +491,7 @@ void generateRandomTransforms(S extents[6], S delta_trans[3], S delta_rot, Eigen
 
 //==============================================================================
 template <typename S>
-void generateRandomTransforms_ccd(S extents[6], Eigen::aligned_vector<Transform3<S>>& transforms, Eigen::aligned_vector<Transform3<S>>& transforms2, S delta_trans[3], S delta_rot, std::size_t n,
+void generateRandomTransforms_ccd(S extents[6], aligned_vector<Transform3<S>>& transforms, aligned_vector<Transform3<S>>& transforms2, S delta_trans[3], S delta_rot, std::size_t n,
                                  const std::vector<Vector3<S>>& vertices1, const std::vector<Triangle>& triangles1,
                                  const std::vector<Vector3<S>>& vertices2, const std::vector<Triangle>& triangles2)
 {
@@ -549,7 +549,7 @@ template <typename S>
 void generateEnvironments(std::vector<CollisionObject<S>*>& env, S env_scale, std::size_t n)
 {
   S extents[] = {-env_scale, env_scale, -env_scale, env_scale, -env_scale, env_scale};
-  Eigen::aligned_vector<Transform3<S>> transforms;
+  aligned_vector<Transform3<S>> transforms;
 
   generateRandomTransforms(extents, transforms, n);
   for(std::size_t i = 0; i < n; ++i)
@@ -578,7 +578,7 @@ template <typename S>
 void generateEnvironmentsMesh(std::vector<CollisionObject<S>*>& env, S env_scale, std::size_t n)
 {
   S extents[] = {-env_scale, env_scale, -env_scale, env_scale, -env_scale, env_scale};
-  Eigen::aligned_vector<Transform3<S>> transforms;
+  aligned_vector<Transform3<S>> transforms;
 
   generateRandomTransforms(extents, transforms, n);
   Box<S> box(5, 10, 20);


### PR DESCRIPTION
Adding definitions under `Eigen` namespace possibly cause confliction with `Eigen` or other libraries. This PR moves `make_aligned_shared()`, which was defined under `Eigen` namespace, to under `fcl` namespace.