### PR TITLE
Convex hull

### DIFF
--- a/include/fcl/geometry/shape/convex-inl.h
+++ b/include/fcl/geometry/shape/convex-inl.h
@@ -50,14 +50,14 @@ class FCL_EXPORT Convex<double>;
 //==============================================================================
 template <typename S>
 Convex<S>::Convex(
-    Vector3<S>* plane_normals, S* plane_dis, int num_planes_,
-    Vector3<S>* points, int num_points_, int* polygons_)
+    Vector3<S>* plane_normals_, S* plane_dis_, int num_planes_,
+    Vector3<S>* points_, int num_points_, int* polygons_)
   : ShapeBase<S>()
 {
-  plane_normals = plane_normals;
-  plane_dis = plane_dis;
+  plane_normals = plane_normals_;
+  plane_dis = plane_dis_;
   num_planes = num_planes_;
-  points = points;
+  points = points_;
   num_points = num_points_;
   polygons = polygons_;
   edges = nullptr;
@@ -98,8 +98,8 @@ Convex<S>::~Convex()
 template <typename S>
 void Convex<S>::computeLocalAABB()
 {
-  this->aabb_local.min_.setConstant(-std::numeric_limits<S>::max());
-  this->aabb_local.max_.setConstant(std::numeric_limits<S>::max());
+  this->aabb_local.min_.setConstant(std::numeric_limits<S>::max());
+  this->aabb_local.max_.setConstant(-std::numeric_limits<S>::max());
   for(int i = 0; i < num_points; ++i)
     this->aabb_local += points[i];
 

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -1208,7 +1208,6 @@ static inline ccd_real_t _ccdDist(const void *obj1, const void *obj2,
     // check whether we improved for at least a minimum tolerance
     if ((last_dist - dist) < ccd->dist_tolerance)
     {
-      ccdVec3Normalize(&dir);
       extractClosestPoints(simplex, p1, p2, &dir);
       return dist;
     }
@@ -1233,7 +1232,6 @@ static inline ccd_real_t _ccdDist(const void *obj1, const void *obj2,
     dist = CCD_SQRT(dist);
     if (CCD_FABS(last_dist - dist) < ccd->dist_tolerance)
     {
-      ccdVec3Normalize(&dir);
       extractClosestPoints(simplex, p1, p2, &dir);
       return last_dist;
     }
@@ -1385,7 +1383,6 @@ static inline ccd_real_t ccdGJKDist2(const void *obj1, const void *obj2, const c
     // check whether we improved for at least a minimum tolerance
     if ((last_dist - dist) < ccd->dist_tolerance)
     {
-      ccdVec3Normalize(&dir);
       extractClosestPoints(&simplex, p1, p2, &dir);
       return dist;
     }
@@ -1410,7 +1407,6 @@ static inline ccd_real_t ccdGJKDist2(const void *obj1, const void *obj2, const c
     dist = CCD_SQRT(dist);
     if (CCD_FABS(last_dist - dist) < ccd->dist_tolerance)
     {
-      ccdVec3Normalize(&dir);
       extractClosestPoints(&simplex, p1, p2, &dir);
       return last_dist;
     }

--- a/include/fcl/narrowphase/detail/gjk_solver_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/gjk_solver_libccd-inl.h
@@ -561,12 +561,6 @@ struct ShapeSignedDistanceLibccdImpl
           p1,
           p2);
 
-    if (p1)
-      (*p1).noalias() = tf1.inverse(Eigen::Isometry) * *p1;
-
-    if (p2)
-      (*p2).noalias() = tf2.inverse(Eigen::Isometry) * *p2;
-
     detail::GJKInitializer<S, Shape1>::deleteGJKObject(o1);
     detail::GJKInitializer<S, Shape2>::deleteGJKObject(o2);
 
@@ -617,12 +611,6 @@ struct ShapeDistanceLibccdImpl
           dist,
           p1,
           p2);
-
-    if (p1)
-      (*p1).noalias() = tf1.inverse(Eigen::Isometry) * *p1;
-
-    if (p2)
-      (*p2).noalias() = tf2.inverse(Eigen::Isometry) * *p2;
 
     detail::GJKInitializer<S, Shape1>::deleteGJKObject(o1);
     detail::GJKInitializer<S, Shape2>::deleteGJKObject(o2);
@@ -770,8 +758,6 @@ struct ShapeTriangleDistanceLibccdImpl
           dist,
           p1,
           p2);
-    if(p1)
-      (*p1).noalias() = tf.inverse(Eigen::Isometry) * *p1;
 
     detail::GJKInitializer<S, Shape>::deleteGJKObject(o1);
     detail::triDeleteGJKObject(o2);
@@ -845,10 +831,6 @@ struct ShapeTransformedTriangleDistanceLibccdImpl
           dist,
           p1,
           p2);
-    if(p1)
-      (*p1).noalias() = tf1.inverse(Eigen::Isometry) * *p1;
-    if(p2)
-      (*p2).noalias() = tf2.inverse(Eigen::Isometry) * *p2;
 
     detail::GJKInitializer<S, Shape>::deleteGJKObject(o1);
     detail::triDeleteGJKObject(o2);

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/sphere_capsule-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/sphere_capsule-inl.h
@@ -146,10 +146,14 @@ bool sphereCapsuleDistance(const Sphere<S>& s1, const Transform3<S>& tf1,
   if(p1)
   {
     *p1 = s_c - diff * s1.radius;
-    *p1 = tf1.inverse(Eigen::Isometry) * tf2 * (*p1);
+    *p1 = tf2 * (*p1);
   }
 
-  if(p2) *p2 = segment_point + diff * s1.radius;
+  if(p2)
+  {
+    *p2 = segment_point + diff * s2.radius;
+    *p2 = tf2 * (*p2);
+  }
 
   return true;
 }

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/sphere_sphere-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/sphere_sphere-inl.h
@@ -99,8 +99,8 @@ bool sphereSphereDistance(const Sphere<S>& s1, const Transform3<S>& tf1,
   if(len > s1.radius + s2.radius)
   {
     if(dist) *dist = len - (s1.radius + s2.radius);
-    if(p1) *p1 = tf1.inverse(Eigen::Isometry) * (o1 - diff * (s1.radius / len));
-    if(p2) *p2 = tf2.inverse(Eigen::Isometry) * (o2 + diff * (s2.radius / len));
+    if(p1) *p1 = (o1 - diff * (s1.radius / len));
+    if(p2) *p2 = (o2 + diff * (s2.radius / len));
     return true;
   }
 

--- a/test/test_fcl_signed_distance.cpp
+++ b/test/test_fcl_signed_distance.cpp
@@ -58,6 +58,7 @@ void test_distance_spheresphere(GJKSolverType solver_type)
   request.enable_signed_distance = true;
   request.enable_nearest_points = true;
   request.gjk_solver_type = solver_type;
+  request.distance_tolerance = 1e-14;
 
   DistanceResult<S> result;
 
@@ -68,9 +69,13 @@ void test_distance_spheresphere(GJKSolverType solver_type)
   tf2.translation() = Vector3<S>(40, 0, 0);
   res = distance(&s1, tf1, &s2, tf2, request, result);
   EXPECT_TRUE(res);
-  EXPECT_TRUE(std::abs(result.min_distance - 10) < 1e-6);
-  EXPECT_TRUE(result.nearest_points[0].isApprox(Vector3<S>(20, 0, 0)));
-  EXPECT_TRUE(result.nearest_points[1].isApprox(Vector3<S>(30, 0, 0)));
+  EXPECT_NEAR(result.min_distance, 10, 1e-6);
+  EXPECT_NEAR(result.nearest_points[0](0), 20, 1e-6);
+  EXPECT_NEAR(result.nearest_points[0](1),  0, 1e-6);
+  EXPECT_NEAR(result.nearest_points[0](2),  0, 1e-6);
+  EXPECT_NEAR(result.nearest_points[1](0), 30, 1e-6);
+  EXPECT_NEAR(result.nearest_points[1](1),  0, 1e-6);
+  EXPECT_NEAR(result.nearest_points[1](2),  0, 1e-6);
 
   // Expecting distance to be -5
   result.clear();
@@ -78,7 +83,7 @@ void test_distance_spheresphere(GJKSolverType solver_type)
   res = distance(&s1, tf1, &s2, tf2, request, result);
 
   EXPECT_TRUE(res);
-  EXPECT_TRUE(std::abs(result.min_distance - (-5)) < 1e-2);
+  EXPECT_NEAR(result.min_distance, -5, 1e-2);
   // TODO(JS): The negative distance computation using libccd requires
   // unnecessarily high error tolerance.
 
@@ -86,8 +91,12 @@ void test_distance_spheresphere(GJKSolverType solver_type)
   // surface of the spheres.
   if (solver_type == GST_LIBCCD)
   {
-    EXPECT_TRUE(result.nearest_points[0].isApprox(Vector3<S>(20, 0, 0)));
-    EXPECT_TRUE(result.nearest_points[1].isApprox(Vector3<S>(15, 0, 0)));
+    EXPECT_NEAR(result.nearest_points[0](0), 20, 1e-6);
+    EXPECT_NEAR(result.nearest_points[0](1),  0, 1e-6);
+    EXPECT_NEAR(result.nearest_points[0](2),  0, 1e-6);
+    EXPECT_NEAR(result.nearest_points[1](0), 15, 1e-6);
+    EXPECT_NEAR(result.nearest_points[1](1),  0, 1e-6);
+    EXPECT_NEAR(result.nearest_points[1](2),  0, 1e-6);
   }
 
   // Expecting distance to be -1.715728753
@@ -96,7 +105,8 @@ void test_distance_spheresphere(GJKSolverType solver_type)
   res = distance(&s1, tf1, &s2, tf2, request, result);
 
   EXPECT_TRUE(res);
-  EXPECT_TRUE(std::abs(result.min_distance - (-1.715728753)) < 1e-2);
+  const S expected_distance = tf2.translation().norm() - 30;
+  EXPECT_NEAR(result.min_distance, expected_distance, 1e-6);
   // TODO(JS): The negative distance computation using libccd requires
   // unnecessarily high error tolerance.
 
@@ -104,8 +114,14 @@ void test_distance_spheresphere(GJKSolverType solver_type)
   // surface of the spheres.
   if (solver_type == GST_LIBCCD)
   {
-    EXPECT_TRUE(result.nearest_points[0].isApprox(Vector3<S>(20, 0, 0)));
-    EXPECT_TRUE(result.nearest_points[1].isApprox(Vector3<S>(15, 0, 0)));
+    const S xz0 = std::sqrt((20 * 20) / 2);
+    const S xz1 = 20 - std::sqrt((10 * 10) / 2);
+    EXPECT_NEAR(result.nearest_points[0](0), xz0, 1e-3);
+    EXPECT_NEAR(result.nearest_points[0](1),   0, 1e-3);
+    EXPECT_NEAR(result.nearest_points[0](2), xz0, 1e-3);
+    EXPECT_NEAR(result.nearest_points[1](0), xz1, 1e-3);
+    EXPECT_NEAR(result.nearest_points[1](1),   0, 1e-3);
+    EXPECT_NEAR(result.nearest_points[1](2), xz1, 1e-3);
   }
 }
 
@@ -132,9 +148,13 @@ void test_distance_spherecapsule(GJKSolverType solver_type)
   tf2.translation() = Vector3<S>(40, 0, 0);
   res = distance(&s1, tf1, &s2, tf2, request, result);
   EXPECT_TRUE(res);
-  EXPECT_TRUE(std::abs(result.min_distance - 10) < 1e-6);
-  EXPECT_TRUE(result.nearest_points[0].isApprox(Vector3<S>(20, 0, 0), 1e-3));
-  EXPECT_TRUE(result.nearest_points[1].isApprox(Vector3<S>(30, 0, 0), 1e-3));
+  EXPECT_NEAR(result.min_distance, 10, 1e-6);
+  EXPECT_NEAR(result.nearest_points[0](0), 20, 1e-3);
+  EXPECT_NEAR(result.nearest_points[0](1),  0, 1e-3);
+  EXPECT_NEAR(result.nearest_points[0](2),  0, 1e-3);
+  EXPECT_NEAR(result.nearest_points[1](0), 30, 1e-3);
+  EXPECT_NEAR(result.nearest_points[1](1),  0, 1e-3);
+  EXPECT_NEAR(result.nearest_points[1](2),  0, 1e-3);
 
   // Expecting distance to be -5
   result.clear();
@@ -142,7 +162,7 @@ void test_distance_spherecapsule(GJKSolverType solver_type)
   res = distance(&s1, tf1, &s2, tf2, request, result);
 
   EXPECT_TRUE(res);
-  EXPECT_TRUE(std::abs(result.min_distance - (-5)) < 1e-2);
+  EXPECT_NEAR(result.min_distance, -5, 1e-2);
   // TODO(JS): The negative distance computation using libccd requires
   // unnecessarily high error tolerance.
 
@@ -150,8 +170,12 @@ void test_distance_spherecapsule(GJKSolverType solver_type)
   // surface of the spheres.
   if (solver_type == GST_LIBCCD)
   {
-    EXPECT_TRUE(result.nearest_points[0].isApprox(Vector3<S>(20, 0, 0)));
-    EXPECT_TRUE(result.nearest_points[1].isApprox(Vector3<S>(15, 0, 0)));
+    EXPECT_NEAR(result.nearest_points[0](0), 20, 1e-6);
+    EXPECT_NEAR(result.nearest_points[0](1),  0, 1e-6);
+    EXPECT_NEAR(result.nearest_points[0](2),  0, 1e-6);
+    EXPECT_NEAR(result.nearest_points[1](0), 15, 1e-6);
+    EXPECT_NEAR(result.nearest_points[1](1),  0, 1e-6);
+    EXPECT_NEAR(result.nearest_points[1](2),  0, 1e-6);
   }
 }
 


### PR DESCRIPTION
This PR address two items.

- The first was the convex shape's aabb was being initialized incorrectly causing it to always be infinite size.
- The second, is I noticed that when getting distance information for convex shapes the nearest points were appeared to be in the shape frame to the global. After making the changes below they are now in the global frame.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/250)
<!-- Reviewable:end -->
