### PR TITLE
Fix extractClosestPoint method, reset dir variable

### DIFF
--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -1211,6 +1211,9 @@ static inline ccd_real_t _ccdDist(const void *obj1, const void *obj2,
     // find out support point
     __ccdSupport(obj1, obj2, &dir, ccd, &last);
 
+    // Reset dir back
+    ccdVec3Scale(&dir, -dist);
+
     // record last distance
     last_dist = dist;
 
@@ -1382,6 +1385,9 @@ static inline ccd_real_t ccdGJKDist2(const void *obj1, const void *obj2, const c
 
     // find out support point
     __ccdSupport(obj1, obj2, &dir, ccd, &last);
+
+    // Reset dir back
+    ccdVec3Scale(&dir, -dist);
 
     // record last distance
     last_dist = dist;


### PR DESCRIPTION
It was difficult to track down but occasionally I would get invalid nearest points being meters off. It turns out `dir` variable gets normalized [here](https://github.com/flexible-collision-library/fcl/blob/master/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h#L1208-L1209). Which becomes an issue at two places. The first, if it makes it into this if statement [here](https://github.com/flexible-collision-library/fcl/blob/master/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h#L1222-L1226) it passes an incorrect point to be extracted. The second place, is on the next interation if enters this [function](https://github.com/flexible-collision-library/fcl/blob/master/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h#L1197) and there is not improvement the `dir` is not recalculated shown [here](https://github.com/flexible-collision-library/fcl/blob/master/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h#L203-L206). Which then if it enters this if statment [here](https://github.com/flexible-collision-library/fcl/blob/master/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h#L1222-L1226) it would pass an incorrect point to be extracted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/251)
<!-- Reviewable:end -->
