### PR TITLE
Cylinder half space bug fix

### DIFF
--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/halfspace-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/halfspace-inl.h
@@ -391,7 +391,7 @@ bool cylinderHalfspaceIntersect(const Cylinder<S>& s1, const Transform3<S>& tf1,
   else
   {
     Vector3<S> C = dir_z * cosa - new_s2.n;
-    if(std::abs(cosa + 1) < halfspaceIntersectTolerance<S>() || std::abs(cosa - 1) < halfspaceIntersectTolerance<S>())
+    if(std::abs(cosa) - 1 < halfspaceIntersectTolerance<S>())
       C = Vector3<S>(0, 0, 0);
     else
     {

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/halfspace-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/halfspace-inl.h
@@ -371,7 +371,7 @@ bool cylinderHalfspaceIntersect(const Cylinder<S>& s1, const Transform3<S>& tf1,
   Vector3<S> dir_z = R.col(2);
   S cosa = dir_z.dot(new_s2.n);
 
-  if(cosa < halfspaceIntersectTolerance<S>())
+  if(std::abs(cosa) < halfspaceIntersectTolerance<S>())
   {
     S signed_dist = new_s2.signedDistance(T);
     S depth = s1.radius - signed_dist;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,6 +45,7 @@ set(tests
     test_fcl_capsule_box_1.cpp
     test_fcl_capsule_box_2.cpp
     test_fcl_capsule_capsule.cpp
+    test_fcl_cylinder_half_space.cpp
     test_fcl_collision.cpp
     test_fcl_distance.cpp
     test_fcl_frontlist.cpp

--- a/test/test_fcl_cylinder_half_space.cpp
+++ b/test/test_fcl_cylinder_half_space.cpp
@@ -1,0 +1,110 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2013-2014, Willow Garage, Inc.
+ *  Copyright (c) 2014-2016, Open Source Robotics Foundation
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Open Source Robotics Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** \author Alejandro Castro */
+
+#include <iostream>
+
+#include "fcl/fcl.h"
+
+#include "gtest/gtest.h"
+
+using namespace std;
+using namespace fcl;
+
+template <typename S>
+void test_collision_cylinder_half_space(fcl::GJKSolverType solver_type)
+{
+  // Numerical precision expected in the results.
+  const double kTolerance = 5 * std::numeric_limits<double>::epsilon();
+
+  const S radius = 0.05;
+  const S length = 4 * radius;
+
+  auto half_space = std::make_shared<Halfspace<S>>(Vector3<S>::UnitZ(), 0.0);
+  auto cylinder = std::make_shared<Cylinder<S>>(radius, length);
+
+  // Pose of cylinder frame C in the world frame W.
+  Transform3<S> X_WC(Translation3<S>(Vector3<S>(0.0, 0.0, 0.049)));
+
+  // Pose of half space frame H in the world frame W.
+  Transform3<S> X_WH = Transform3<S>::Identity();
+
+  CollisionObject<S> half_sapce_co(half_space, X_WH);
+  CollisionObject<S> cylinder_co(cylinder, X_WC);
+
+  fcl::CollisionResult<S> result;
+  static const int num_max_contacts = std::numeric_limits<int>::max();
+  static const bool enable_contact = true;
+  fcl::CollisionRequest<S> request(num_max_contacts, enable_contact);
+  request.gjk_solver_type = solver_type;
+
+  fcl::collide(&half_sapce_co, &cylinder_co, request, result);
+  vector<Contact<S>> contacts;
+  result.getContacts(contacts);
+
+  EXPECT_EQ(static_cast<int>(contacts.size()), 1);
+  EXPECT_NEAR(contacts[0].penetration_depth, 0.051, kTolerance);
+
+  // Now perform the same test but with the cylinder's z axis Cz pointing down.
+  X_WC.linear() = AngleAxisd(M_PI, Vector3d::UnitX()).matrix();
+  X_WC.translation() = Vector3d(0, 0, 0.049);
+  cylinder_co.setTransform(X_WC);
+
+  result.clear();
+  contacts.clear();
+
+  fcl::collide(&half_sapce_co, &cylinder_co, request, result);
+  result.getContacts(contacts);
+
+  EXPECT_EQ(static_cast<int>(contacts.size()), 1);
+  EXPECT_NEAR(contacts[0].penetration_depth, 0.051, kTolerance);
+}
+
+GTEST_TEST(FCL_GEOMETRIC_SHAPES, collision_cylinder_half_space_libccd)
+{
+  test_collision_cylinder_half_space<double>(fcl::GJKSolverType::GST_LIBCCD);
+}
+
+GTEST_TEST(FCL_GEOMETRIC_SHAPES, collision_cylinder_half_space_indep)
+{
+  test_collision_cylinder_half_space<double>(fcl::GJKSolverType::GST_INDEP);
+}
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/test_fcl_cylinder_half_space.cpp
+++ b/test/test_fcl_cylinder_half_space.cpp
@@ -1,9 +1,7 @@
 /*
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2013-2014, Willow Garage, Inc.
- *  Copyright (c) 2014-2016, Open Source Robotics Foundation
- *  All rights reserved.
+ *  Copyright (c) 2018, Toyota Research Institute
  *
  *  Redistribution and use in source and binary forms, with or without
  *  modification, are permitted provided that the following conditions
@@ -62,7 +60,7 @@ void test_collision_cylinder_half_space(fcl::GJKSolverType solver_type)
   // Pose of half space frame H in the world frame W.
   Transform3<S> X_WH = Transform3<S>::Identity();
 
-  CollisionObject<S> half_sapce_co(half_space, X_WH);
+  CollisionObject<S> half_space_co(half_space, X_WH);
   CollisionObject<S> cylinder_co(cylinder, X_WC);
 
   fcl::CollisionResult<S> result;
@@ -71,7 +69,7 @@ void test_collision_cylinder_half_space(fcl::GJKSolverType solver_type)
   fcl::CollisionRequest<S> request(num_max_contacts, enable_contact);
   request.gjk_solver_type = solver_type;
 
-  fcl::collide(&half_sapce_co, &cylinder_co, request, result);
+  fcl::collide(&half_space_co, &cylinder_co, request, result);
   vector<Contact<S>> contacts;
   result.getContacts(contacts);
 
@@ -79,14 +77,14 @@ void test_collision_cylinder_half_space(fcl::GJKSolverType solver_type)
   EXPECT_NEAR(contacts[0].penetration_depth, 0.051, kTolerance);
 
   // Now perform the same test but with the cylinder's z axis Cz pointing down.
-  X_WC.linear() = AngleAxisd(M_PI, Vector3d::UnitX()).matrix();
-  X_WC.translation() = Vector3d(0, 0, 0.049);
+  X_WC.linear() = AngleAxis<S>(M_PI, Vector3d::UnitX()).matrix();
+  X_WC.translation() = Vector3<S>(0, 0, 0.049);
   cylinder_co.setTransform(X_WC);
 
   result.clear();
   contacts.clear();
 
-  fcl::collide(&half_sapce_co, &cylinder_co, request, result);
+  fcl::collide(&half_space_co, &cylinder_co, request, result);
   result.getContacts(contacts);
 
   EXPECT_EQ(static_cast<int>(contacts.size()), 1);

--- a/test/test_fcl_cylinder_half_space.cpp
+++ b/test/test_fcl_cylinder_half_space.cpp
@@ -48,7 +48,7 @@ template <typename S>
 void test_collision_cylinder_half_space(fcl::GJKSolverType solver_type)
 {
   // Numerical precision expected in the results.
-  const double kTolerance = 5 * std::numeric_limits<double>::epsilon();
+  const double kTolerance = 20 * std::numeric_limits<double>::epsilon();
 
   const S radius = 0.05;
   const S length = 4 * radius;


### PR DESCRIPTION
There is a bug with the penetration query for cylinder vs half space. This is reported in RobotLocomotion/drake#8049.

This PR fixes this bug and implements a new unit test that without the fix would not pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/255)
<!-- Reviewable:end -->
