### PR TITLE
Remove tapping deprecated homebrew-science

### DIFF
--- a/ci/install_osx.sh
+++ b/ci/install_osx.sh
@@ -1,5 +1,3 @@
-brew tap homebrew/science
-
 brew update > /dev/null
 
 brew install git


### PR DESCRIPTION
homebrew-science is deprecated, and `libccd` is migrated to homebrew-core.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/262)
<!-- Reviewable:end -->
