### PR TITLE
Replace non-portable M_PI reference with fcl::constants invocation

### DIFF
--- a/test/test_fcl_cylinder_half_space.cpp
+++ b/test/test_fcl_cylinder_half_space.cpp
@@ -35,9 +35,9 @@
 
 #include <iostream>
 
-#include "fcl/fcl.h"
+#include <gtest/gtest.h>
 
-#include "gtest/gtest.h"
+#include "fcl/fcl.h"
 
 using namespace std;
 using namespace fcl;
@@ -77,7 +77,8 @@ void test_collision_cylinder_half_space(fcl::GJKSolverType solver_type)
   EXPECT_NEAR(contacts[0].penetration_depth, 0.051, kTolerance);
 
   // Now perform the same test but with the cylinder's z axis Cz pointing down.
-  X_WC.linear() = AngleAxis<S>(M_PI, Vector3d::UnitX()).matrix();
+  X_WC.linear() = AngleAxis<S>(fcl::constants<S>::pi(), 
+                               Vector3d::UnitX()).matrix();
   X_WC.translation() = Vector3<S>(0, 0, 0.049);
   cylinder_co.setTransform(X_WC);
 


### PR DESCRIPTION
There is a non-portable reference to M_PI in a test. This changes it to the fcl-standard constants reference to maintain portability.

(It also shuffles up the includes in the test to be more "standard".)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/264)
<!-- Reviewable:end -->
