### PR TITLE
Move travis CI to use xcode 9 instead of 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ matrix:
       compiler: clang
       env: BUILD_TYPE=Release COVERALLS=OFF
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode9
       compiler: clang
       env: BUILD_TYPE=Debug COVERALLS=OFF
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode9
       compiler: clang
       env: BUILD_TYPE=Release COVERALLS=OFF
 


### PR DESCRIPTION
Various mac errors seem to go away by advancing from xcode 7.3 to later versions. This tests it under travis.ci.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/266)
<!-- Reviewable:end -->
