### PR TITLE
Revert bug introduced in cylinder/half-space intersection.

### DIFF
--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/halfspace-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/halfspace-inl.h
@@ -391,7 +391,7 @@ bool cylinderHalfspaceIntersect(const Cylinder<S>& s1, const Transform3<S>& tf1,
   else
   {
     Vector3<S> C = dir_z * cosa - new_s2.n;
-    if(std::abs(cosa) - 1 < halfspaceIntersectTolerance<S>())
+    if(std::abs(cosa + 1) < halfspaceIntersectTolerance<S>() || std::abs(cosa - 1) < halfspaceIntersectTolerance<S>())
       C = Vector3<S>(0, 0, 0);
     else
     {


### PR DESCRIPTION
We introduced a new bug in #255 when "simplifying" an `if` statement. A separate unit test should've been introduced in that PR for that change but we didn't and therefore we introduced a bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/267)
<!-- Reviewable:end -->
