### PR TITLE
unify interp_motion to match linear_axis/vel the other motions

### DIFF
--- a/include/fcl/math/motion/interp_motion.h
+++ b/include/fcl/math/motion/interp_motion.h
@@ -107,7 +107,10 @@ protected:
   mutable Transform3<S> tf;
 
   /// @brief Linear velocity
-  Vector3<S> linear_vel;
+  S linear_vel;
+
+  /// @brief Linear axis
+  Vector3<S> linear_axis;
 
   /// @brief Angular speed
   S angular_vel;
@@ -125,7 +128,9 @@ public:
 
   S getAngularVelocity() const;
 
-  const Vector3<S>& getLinearVelocity() const;
+  const S& getLinearVelocity() const;
+
+  const Vector3<S>& getLinearAxis() const;
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };

--- a/include/fcl/math/motion/tbv_motion_bound_visitor-inl.h
+++ b/include/fcl/math/motion/tbv_motion_bound_visitor-inl.h
@@ -235,9 +235,13 @@ struct TBVMotionBoundVisitorVisitImpl<S, RSS<S>, InterpMotion<S>>
     motion.getCurrentTransform(tf);
 
     const Vector3<S>& reference_p = motion.getReferencePoint();
+    const Vector3<S>& linear_axis = motion.getLinearAxis();
+    const S& linear_vel = motion.getLinearVelocity();
     const Vector3<S>& angular_axis = motion.getAngularAxis();
     S angular_vel = motion.getAngularVelocity();
-    const Vector3<S>& linear_vel = motion.getLinearVelocity();
+
+    // mu (motion bound) is zero if no movement on angular or linear axis
+    if ((angular_vel + linear_vel) == 0) return 0;
 
     S c_proj_max = ((tf.linear() * (visitor.bv.To - reference_p)).cross(angular_axis)).squaredNorm();
     S tmp;
@@ -250,7 +254,7 @@ struct TBVMotionBoundVisitorVisitImpl<S, RSS<S>, InterpMotion<S>>
 
     c_proj_max = std::sqrt(c_proj_max);
 
-    S v_dot_n = linear_vel.dot(visitor.n);
+    S v_dot_n = linear_axis.dot(visitor.n) * linear_vel;
     S w_cross_n = (angular_axis.cross(visitor.n)).norm() * angular_vel;
     S mu = v_dot_n + w_cross_n * (visitor.bv.r + c_proj_max);
 

--- a/include/fcl/math/motion/triangle_motion_bound_visitor-inl.h
+++ b/include/fcl/math/motion/triangle_motion_bound_visitor-inl.h
@@ -166,7 +166,8 @@ struct TriangleMotionBoundVisitorVisitImpl<S, InterpMotion<S>>
     const Vector3<S>& reference_p = motion.getReferencePoint();
     const Vector3<S>& angular_axis = motion.getAngularAxis();
     S angular_vel = motion.getAngularVelocity();
-    const Vector3<S>& linear_vel = motion.getLinearVelocity();
+    const Vector3<S>& linear_axis = motion.getLinearAxis();
+    const S& linear_vel = motion.getLinearVelocity();
 
     S proj_max = ((tf.linear() * (visitor.a - reference_p)).cross(angular_axis)).squaredNorm();
     S tmp;
@@ -177,7 +178,7 @@ struct TriangleMotionBoundVisitorVisitImpl<S, InterpMotion<S>>
 
     proj_max = std::sqrt(proj_max);
 
-    S v_dot_n = linear_vel.dot(visitor.n);
+    S v_dot_n = linear_axis.dot(visitor.n) * linear_vel;
     S w_cross_n = (angular_axis.cross(visitor.n)).norm() * angular_vel;
     S mu = v_dot_n + w_cross_n * proj_max;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,6 +58,7 @@ set(tests
     test_fcl_signed_distance.cpp
     test_fcl_simple.cpp
     test_fcl_sphere_capsule.cpp
+    test_fcl_interp_motion.cpp
 )
 
 if (FCL_HAVE_OCTOMAP)

--- a/test/test_fcl_interp_motion.cpp
+++ b/test/test_fcl_interp_motion.cpp
@@ -1,0 +1,304 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2011-2014, Willow Garage, Inc.
+ *  Copyright (c) 2014-2016, Open Source Robotics Foundation
+ *  Copyright (c) 2016, Toyota Research Institute
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Open Source Robotics Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+
+#include "fcl/config.h"
+#include "fcl/math/bv/AABB.h"
+#include "fcl/math/motion/interp_motion.h"
+
+using namespace fcl;
+
+template <typename S>
+void test_interp_motion_empty()
+{
+  Transform3<S> from;
+  from.setIdentity();
+  Transform3<S> to;
+  to.setIdentity();
+
+  InterpMotion<S> interp_motion;
+
+  Vector3<S> linear_axis = interp_motion.getLinearAxis();
+  EXPECT_TRUE(linear_axis == Vector3<S>(0.0, 0.0, 0.0));
+  S linear_vel = interp_motion.getLinearVelocity();
+  EXPECT_TRUE(linear_vel == 0);
+
+  Vector3<S> angular_axis = interp_motion.getAngularAxis();
+  EXPECT_TRUE(angular_axis == Vector3<S>(0.0, 0.0, 0.0));
+  S angular_vel = interp_motion.getAngularVelocity();
+  EXPECT_TRUE(angular_vel == 0);
+
+  Vector3<S> ref_p = interp_motion.getReferencePoint();
+  EXPECT_TRUE(ref_p == Vector3<S>(0.0, 0.0, 0.0));
+
+  Transform3<S> itf; itf.setIdentity();
+  Transform3<S> ctf;
+
+  interp_motion.integrate(0);
+  interp_motion.getCurrentTransform(ctf);
+  EXPECT_TRUE(itf.translation() == ctf.translation());
+  EXPECT_TRUE(itf.rotation() == ctf.rotation());
+
+  interp_motion.integrate(0.4);
+  interp_motion.getCurrentTransform(ctf);
+  EXPECT_TRUE(itf.translation() == ctf.translation());
+  EXPECT_TRUE(itf.rotation() == ctf.rotation());
+
+  interp_motion.integrate(1);
+  interp_motion.getCurrentTransform(ctf);
+  EXPECT_TRUE(itf.translation() == ctf.translation());
+  EXPECT_TRUE(itf.rotation() == ctf.rotation());
+
+  // NOTE: There is a limit for dt > 1, but not for dt < 0
+  // interp_motion.integrate(-.5);
+  // interp_motion.getCurrentTransform(ctf);
+  // EXPECT_TRUE(itf.translation() == ctf.translation());
+  // EXPECT_TRUE(itf.rotation() == ctf.rotation());
+
+  interp_motion.integrate(2.25);
+  interp_motion.getCurrentTransform(ctf);
+  EXPECT_TRUE(itf.translation() == ctf.translation());
+  EXPECT_TRUE(itf.rotation() == ctf.rotation());
+
+  // TODO computeMotionBound
+  // TODO getTaylorModel
+}
+
+
+template <typename S>
+void test_interp_motion_only_translation()
+{
+  Transform3<S> from;
+  from.setIdentity();
+  Transform3<S> to;
+  to.setIdentity();
+  to.translation()[0] = 3;
+  to.translation()[1] = 4;
+  to.translation()[2] = 0;
+
+  InterpMotion<S> interp_motion(from, to);
+
+  Vector3<S> linear_axis = interp_motion.getLinearAxis();
+  S linear_vel = interp_motion.getLinearVelocity();
+  EXPECT_TRUE(linear_axis == Vector3<S>(0.6, 0.8, 0.0));
+  EXPECT_TRUE(linear_vel == 5);
+
+  Vector3<S> angular_axis = interp_motion.getAngularAxis();
+  S angular_vel = interp_motion.getAngularVelocity();
+  EXPECT_TRUE(angular_axis == Vector3<S>(1.0, 0.0, 0.0));
+  EXPECT_TRUE(angular_vel == 0);
+
+  Vector3<S> ref_p = interp_motion.getReferencePoint();
+  EXPECT_TRUE(ref_p == Vector3<S>(0.0, 0.0, 0.0));
+
+  Transform3<S> ctf;
+
+  interp_motion.integrate(0);
+  interp_motion.getCurrentTransform(ctf);
+  EXPECT_TRUE(ctf.translation() == from.translation());
+  EXPECT_TRUE(ctf.rotation() == from.rotation());
+
+  interp_motion.integrate(0.25);
+  interp_motion.getCurrentTransform(ctf);
+  EXPECT_TRUE(ctf.translation() == Vector3<S>(0.75,1,0.0));
+  EXPECT_TRUE(ctf.rotation() == from.rotation());
+
+  interp_motion.integrate(1);
+  interp_motion.getCurrentTransform(ctf);
+  EXPECT_TRUE(ctf.translation() == to.translation());
+  EXPECT_TRUE(ctf.rotation() == from.rotation());
+
+  // NOTE: There is a limit for dt > 1, but not for dt < 0
+  // interp_motion.integrate(-.5);
+  // interp_motion.getCurrentTransform(ctf);
+  // EXPECT_TRUE(ctf.translation() == from.translation());
+  // EXPECT_TRUE(ctf.rotation() == from.rotation());
+
+  interp_motion.integrate(2.25);
+  interp_motion.getCurrentTransform(ctf);
+  EXPECT_TRUE(ctf.translation() == to.translation());
+  EXPECT_TRUE(ctf.rotation() == to.rotation());
+
+  // TODO computeMotionBound
+  // TODO getTaylorModel
+}
+
+template <typename S>
+void test_interp_motion_only_rotation()
+{
+  Transform3<S> from;
+  from.setIdentity();
+  Vector3<S> up(0.0, 0.0, 1.0);
+  AngleAxis<S> aapi(M_PI, up);
+  AngleAxis<S> aapih(M_PI/2, up);
+  Transform3<S> to(aapi);
+
+  InterpMotion<S> interp_motion(from, to);
+
+  Vector3<S> linear_axis = interp_motion.getLinearAxis();
+  S linear_vel = interp_motion.getLinearVelocity();
+  EXPECT_TRUE(linear_axis == Vector3<S>(0.0, 0.0, 0.0));
+  EXPECT_TRUE(linear_vel == 0);
+
+  Vector3<S> angular_axis = interp_motion.getAngularAxis();
+  S angular_vel = interp_motion.getAngularVelocity();
+  EXPECT_TRUE(angular_axis == up);
+  EXPECT_TRUE(angular_vel == M_PI);
+
+  Vector3<S> ref_p = interp_motion.getReferencePoint();
+  EXPECT_TRUE(ref_p == Vector3<S>(0.0, 0.0, 0.0));
+
+  Transform3<S> ctf;
+
+  interp_motion.integrate(0);
+  interp_motion.getCurrentTransform(ctf);
+  EXPECT_TRUE(ctf.translation() == from.translation());
+  EXPECT_TRUE(ctf.rotation() == from.rotation());
+
+  interp_motion.integrate(0.5);
+  interp_motion.getCurrentTransform(ctf);
+  EXPECT_TRUE(ctf.translation() == from.translation());
+  Quaternion<S> ctfq; ctfq = ctf.rotation(); ctfq.normalize();
+  Quaternion<S> mpihq; mpihq = aapih; mpihq.normalize();
+  EXPECT_TRUE(ctfq.isApprox(mpihq));
+
+  interp_motion.integrate(1);
+  interp_motion.getCurrentTransform(ctf);
+  EXPECT_TRUE(ctf.translation() == to.translation());
+  EXPECT_TRUE(ctf.rotation() == to.rotation());
+
+  // NOTE: There is a limit for dt > 1, but not for dt < 0
+  // interp_motion.integrate(-.5);
+  // interp_motion.getCurrentTransform(ctf);
+  // EXPECT_TRUE(ctf.translation() == from.translation());
+  // EXPECT_TRUE(ctf.rotation() == from.rotation());
+
+  interp_motion.integrate(2.25);
+  interp_motion.getCurrentTransform(ctf);
+  EXPECT_TRUE(ctf.translation() == to.translation());
+  EXPECT_TRUE(ctf.rotation() == to.rotation());
+
+  // TODO computeMotionBound
+  // TODO getTaylorModel
+}
+
+template <typename S>
+void test_interp_motion_both()
+{
+  Transform3<S> from;
+  from.setIdentity();
+  Vector3<S> up(0.0, 0.0, 1.0);
+  AngleAxis<S> aapi(M_PI, up);
+  AngleAxis<S> aapih(M_PI/2, up);
+  Transform3<S> to(aapi);
+  to.translation()[0] = 3;
+  to.translation()[1] = 4;
+  to.translation()[2] = 0;
+
+  InterpMotion<S> interp_motion(from, to);
+
+  Vector3<S> linear_axis = interp_motion.getLinearAxis();
+  S linear_vel = interp_motion.getLinearVelocity();
+  EXPECT_TRUE(linear_axis == Vector3<S>(0.6, 0.8, 0.0));
+  EXPECT_TRUE(linear_vel == 5);
+
+  Vector3<S> angular_axis = interp_motion.getAngularAxis();
+  S angular_vel = interp_motion.getAngularVelocity();
+  EXPECT_TRUE(angular_axis == up);
+  EXPECT_TRUE(angular_vel == M_PI);
+
+  Vector3<S> ref_p = interp_motion.getReferencePoint();
+  EXPECT_TRUE(ref_p == Vector3<S>(0.0, 0.0, 0.0));
+
+  Transform3<S> ctf;
+
+  interp_motion.integrate(0);
+  interp_motion.getCurrentTransform(ctf);
+  EXPECT_TRUE(ctf.translation() == from.translation());
+  EXPECT_TRUE(ctf.rotation() == from.rotation());
+
+  interp_motion.integrate(0.5);
+  interp_motion.getCurrentTransform(ctf);
+  EXPECT_TRUE(ctf.translation() == Vector3<S>(1.5,2.0,0.0));
+  Quaternion<S> ctfq; ctfq = ctf.rotation(); ctfq.normalize();
+  Quaternion<S> mpihq; mpihq = aapih; mpihq.normalize();
+  EXPECT_TRUE(ctfq.isApprox(mpihq));
+
+  interp_motion.integrate(1);
+  interp_motion.getCurrentTransform(ctf);
+  EXPECT_TRUE(ctf.translation() == to.translation());
+  EXPECT_TRUE(ctf.rotation() == to.rotation());
+
+  // NOTE: There is a limit for dt > 1, but not for dt < 0
+  // interp_motion.integrate(-.5);
+  // interp_motion.getCurrentTransform(ctf);
+  // EXPECT_TRUE(ctf.translation() == from.translation());
+  // EXPECT_TRUE(ctf.rotation() == from.rotation());
+
+  interp_motion.integrate(2.25);
+  interp_motion.getCurrentTransform(ctf);
+  EXPECT_TRUE(ctf.translation() == to.translation());
+  EXPECT_TRUE(ctf.rotation() == to.rotation());
+
+  // TODO computeMotionBound
+  // TODO getTaylorModel
+}
+
+
+// TODO: The other constructors
+
+GTEST_TEST(FCL_MATH, interp_motion_test_motion)
+{
+  // test_interp_motion_empty<float>();
+  test_interp_motion_empty<double>();
+
+  // test_interp_motion_only_translation<float>();
+  test_interp_motion_only_translation<double>();
+
+  // test_interp_motion_only_rotation<float>();
+  test_interp_motion_only_rotation<double>();
+
+  // test_interp_motion_both<float>();
+  test_interp_motion_both<double>();
+}
+
+//==============================================================================
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
The Interpolation motion returns a `linearVelocity()` with is a vector, in contrast to other motions that split the value into `linearVelocity()` (a scalar) and `linearAxis()` which is a normalized vector. In this PR we're adapting the Interpolation motion to match the other motions.

Also added a first set of unit tests.

Question: Most motions have a test whether `dt > 1` and if so  they set `dt = 1`. Why is this test **one-sided**? That is, why not testing for `dt < 0` and setting `dt = 0` then? 