### PR TITLE
Correct distance queries to report nearest point in world frame

### DIFF
--- a/include/fcl/narrowphase/detail/gjk_solver_indep-inl.h
+++ b/include/fcl/narrowphase/detail/gjk_solver_indep-inl.h
@@ -625,8 +625,10 @@ struct ShapeDistanceIndepImpl
 
       if(distance) *distance = (w0 - w1).norm();
 
-      if(p1) *p1 = w0;
-      if(p2) (*p2).noalias() = shape.toshape0.inverse() * w1;
+      // Answer is solved in Shape1's local frame; answers are given in the
+      // world frame.
+      if(p1) p1->noalias() = tf1 * w0;
+      if(p2) p2->noalias() = tf1 * w1;
 
       return true;
     }
@@ -880,8 +882,9 @@ struct ShapeTriangleDistanceIndepImpl
       }
 
       if(distance) *distance = (w0 - w1).norm();
+      // The answers are produced in world coordinates. Keep them there.
       if(p1) *p1 = w0;
-      if(p2) (*p2).noalias() = shape.toshape0 * w1;
+      if(p2) *p2 = w1;
       return true;
     }
     else
@@ -970,8 +973,8 @@ struct ShapeTransformedTriangleDistanceIndepImpl
       }
 
       if(distance) *distance = (w0 - w1).norm();
-      if(p1) *p1 = w0;
-      if(p2) (*p2).noalias() = shape.toshape0 * w1;
+      if(p1) p1->noalias() = tf1 * w0;
+      if(p2) p2->noalias() = tf1 * w1;
       return true;
     }
     else

--- a/include/fcl/narrowphase/detail/gjk_solver_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/gjk_solver_libccd-inl.h
@@ -567,12 +567,6 @@ struct ShapeSignedDistanceLibccdImpl
           p1,
           p2);
 
-    if (p1)
-      (*p1).noalias() = tf1.inverse(Eigen::Isometry) * *p1;
-
-    if (p2)
-      (*p2).noalias() = tf2.inverse(Eigen::Isometry) * *p2;
-
     detail::GJKInitializer<S, Shape1>::deleteGJKObject(o1);
     detail::GJKInitializer<S, Shape2>::deleteGJKObject(o2);
 
@@ -623,12 +617,6 @@ struct ShapeDistanceLibccdImpl
           dist,
           p1,
           p2);
-
-    if (p1)
-      (*p1).noalias() = tf1.inverse(Eigen::Isometry) * *p1;
-
-    if (p2)
-      (*p2).noalias() = tf2.inverse(Eigen::Isometry) * *p2;
 
     detail::GJKInitializer<S, Shape1>::deleteGJKObject(o1);
     detail::GJKInitializer<S, Shape2>::deleteGJKObject(o2);
@@ -848,8 +836,6 @@ struct ShapeTriangleDistanceLibccdImpl
           dist,
           p1,
           p2);
-    if(p1)
-      (*p1).noalias() = tf.inverse(Eigen::Isometry) * *p1;
 
     detail::GJKInitializer<S, Shape>::deleteGJKObject(o1);
     detail::triDeleteGJKObject(o2);
@@ -923,10 +909,6 @@ struct ShapeTransformedTriangleDistanceLibccdImpl
           dist,
           p1,
           p2);
-    if(p1)
-      (*p1).noalias() = tf1.inverse(Eigen::Isometry) * *p1;
-    if(p2)
-      (*p2).noalias() = tf2.inverse(Eigen::Isometry) * *p2;
 
     detail::GJKInitializer<S, Shape>::deleteGJKObject(o1);
     detail::triDeleteGJKObject(o2);

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/sphere_sphere-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/sphere_sphere-inl.h
@@ -99,8 +99,8 @@ bool sphereSphereDistance(const Sphere<S>& s1, const Transform3<S>& tf1,
   if(len > s1.radius + s2.radius)
   {
     if(dist) *dist = len - (s1.radius + s2.radius);
-    if(p1) *p1 = tf1.inverse(Eigen::Isometry) * (o1 - diff * (s1.radius / len));
-    if(p2) *p2 = tf2.inverse(Eigen::Isometry) * (o2 + diff * (s2.radius / len));
+    if(p1) *p1 = (o1 - diff * (s1.radius / len));
+    if(p2) *p2 = (o2 + diff * (s2.radius / len));
     return true;
   }
 

--- a/include/fcl/narrowphase/distance_result.h
+++ b/include/fcl/narrowphase/distance_result.h
@@ -63,9 +63,9 @@ public:
   /// @sa DistanceRequest::enable_signed_distance
   S min_distance;
 
-  /// @brief Nearest points in the world coordinates
+  /// @brief Nearest points in the world coordinates.
   ///
-  /// @sa DeistanceRequest::enable_nearest_points
+  /// @sa DistanceRequest::enable_nearest_points
   Vector3<S> nearest_points[2];
 
   /// @brief collision object 1

--- a/test/test_fcl_capsule_box_1.cpp
+++ b/test/test_fcl_capsule_box_1.cpp
@@ -71,7 +71,7 @@ void test_distance_capsule_box(fcl::GJKSolverType solver_type, S solver_toleranc
   // Nearest point on box
   fcl::Vector3<S> o2 (distanceResult.nearest_points [1]);
   EXPECT_NEAR (distanceResult.min_distance, 0.5, test_tolerance);
-  EXPECT_NEAR (o1 [0], -2.0, test_tolerance);
+  EXPECT_NEAR (o1 [0],  1.0, test_tolerance);
   EXPECT_NEAR (o1 [1],  0.0, test_tolerance);
   EXPECT_NEAR (o2 [0],  0.5, test_tolerance);
   EXPECT_NEAR (o2 [1],  0.0, test_tolerance);
@@ -89,7 +89,7 @@ void test_distance_capsule_box(fcl::GJKSolverType solver_type, S solver_toleranc
   EXPECT_NEAR (distanceResult.min_distance, 2.0, test_tolerance);
   EXPECT_NEAR (o1 [0],  0.0, test_tolerance);
   EXPECT_NEAR (o1 [1],  0.0, test_tolerance);
-  EXPECT_NEAR (o1 [2], -4.0, test_tolerance);
+  EXPECT_NEAR (o1 [2],  4.0, test_tolerance);
 
   EXPECT_NEAR (o2 [0],  0.0, test_tolerance);
   EXPECT_NEAR (o2 [1],  0.0, test_tolerance);
@@ -107,9 +107,9 @@ void test_distance_capsule_box(fcl::GJKSolverType solver_type, S solver_toleranc
   o2 = distanceResult.nearest_points [1];
 
   EXPECT_NEAR (distanceResult.min_distance, 5.5, test_tolerance);
-  EXPECT_NEAR (o1 [0],  0.0, test_tolerance);
+  EXPECT_NEAR (o1 [0], -6.0, test_tolerance);
   EXPECT_NEAR (o1 [1],  0.0, test_tolerance);
-  EXPECT_NEAR (o1 [2],  4.0, test_tolerance);
+  EXPECT_NEAR (o1 [2],  0.0, test_tolerance);
   EXPECT_NEAR (o2 [0], -0.5, test_tolerance);
   EXPECT_NEAR (o2 [1],  0.0, test_tolerance);
   EXPECT_NEAR (o2 [2],  0.0, test_tolerance);

--- a/test/test_fcl_capsule_box_2.cpp
+++ b/test/test_fcl_capsule_box_2.cpp
@@ -74,9 +74,9 @@ void test_distance_capsule_box(fcl::GJKSolverType solver_type, S solver_toleranc
   fcl::Vector3<S> o2 = distanceResult.nearest_points [1];
 
   EXPECT_NEAR (distanceResult.min_distance, 5.5, test_tolerance);
-  EXPECT_NEAR (o1 [0],  0.0, test_tolerance);
-  EXPECT_NEAR (o1 [1],  0.0, test_tolerance);
-  EXPECT_NEAR (o1 [2],  4.0, test_tolerance);
+  EXPECT_NEAR (o1 [0], -6.0, test_tolerance);
+  EXPECT_NEAR (o1 [1],  0.8, test_tolerance);
+  EXPECT_NEAR (o1 [2],  1.5, test_tolerance);
   EXPECT_NEAR (o2 [0], -0.5, test_tolerance);
   EXPECT_NEAR (o2 [1],  0.8, test_tolerance);
   EXPECT_NEAR (o2 [2],  1.5, test_tolerance);

--- a/test/test_fcl_distance.cpp
+++ b/test/test_fcl_distance.cpp
@@ -39,6 +39,7 @@
 
 #include "fcl/narrowphase/detail/traversal/collision_node.h"
 #include "test_fcl_utility.h"
+#include "eigen_matrix_compare.h"
 #include "fcl_resources/config.h"
 
 // TODO(SeanCurtis-TRI): A file called `test_fcl_distance.cpp` should *not* have
@@ -315,6 +316,10 @@ void NearestPointFromDegenerateSimplex() {
   // line segment. As a result, nearest points were populated with NaN values.
   // See https://github.com/flexible-collision-library/fcl/issues/293 for
   // more discussion.
+  // This test is only relevant if box-box distance is computed via GJK. If
+  // a custom test is created, this may no longer be relevant.
+  // TODO(SeanCurtis-TRI): Provide some mechanism where we can assert what the
+  // solving algorithm is (i.e., default convex vs. custom).
   DistanceResult<S> result;
   DistanceRequest<S> request;
   request.enable_nearest_points = true;
@@ -335,15 +340,25 @@ void NearestPointFromDegenerateSimplex() {
 
   EXPECT_NO_THROW(fcl::distance(&box_object_1, &box_object_2, request, result));
 
-  // The values here have been visually confirmed from the computation.
+  // These hard-coded values have been previously computed and visually
+  // inspected and considered to be the ground truth for this very specific
+  // test configuration.
   S expected_dist{0.053516322172152138};
-  Vector3<S> expected_p0{-1.375, -0.098881502700918666, -0.025000000000000022};
-  Vector3<S> expected_p1{0.21199965773384655, 0.074999692703297122,
-                         0.084299993303443954};
-  EXPECT_TRUE(nearlyEqual(result.nearest_points[0], expected_p0));
-  EXPECT_TRUE(nearlyEqual(result.nearest_points[1], expected_p1));
-  // TODO(SeanCurtis-TRI): Change this tolerance to constants<S>::eps_34() when
-  // the mac single/double libccd problem is resolved.
+  // The "nearest" points (N1 and N2) measured and expressed in box 1's and
+  // box 2's frames (B1 and B2, respectively).
+  const Vector3<S> expected_p_B1N1{-1.375, -0.098881502700918666,
+                                   -0.025000000000000022};
+  const Vector3<S> expected_p_B2N2{0.21199965773384655, 0.074999692703297122,
+                                   0.084299993303443954};
+  // The nearest points in the world frame.
+  const Vector3<S> expected_p_WN1 =
+      box_object_1.getTransform() * expected_p_B1N1;
+  const Vector3<S> expected_p_WN2 =
+      box_object_2.getTransform() * expected_p_B2N2;
+  EXPECT_TRUE(CompareMatrices(result.nearest_points[0], expected_p_WN1,
+                              DELTA<S>(), MatrixCompareType::absolute));
+  EXPECT_TRUE(CompareMatrices(result.nearest_points[1], expected_p_WN2,
+                              DELTA<S>(), MatrixCompareType::absolute));
   EXPECT_NEAR(expected_dist, result.min_distance,
               constants<ccd_real_t>::eps_34());
 }

--- a/test/test_fcl_signed_distance.cpp
+++ b/test/test_fcl_signed_distance.cpp
@@ -34,6 +34,7 @@
 
 #include <gtest/gtest.h>
 
+#include "eigen_matrix_compare.h"
 #include "fcl/narrowphase/distance.h"
 #include "fcl/narrowphase/detail/traversal/collision_node.h"
 #include "fcl/narrowphase/detail/gjk_solver_libccd.h"
@@ -48,8 +49,10 @@ bool verbose = false;
 template <typename S>
 void test_distance_spheresphere(GJKSolverType solver_type)
 {
-  Sphere<S> s1{20};
-  Sphere<S> s2{10};
+  const S radius_1 = 20;
+  const S radius_2 = 10;
+  Sphere<S> s1{radius_1};
+  Sphere<S> s2{radius_2};
 
   Transform3<S> tf1{Transform3<S>::Identity()};
   Transform3<S> tf2{Transform3<S>::Identity()};
@@ -61,46 +64,126 @@ void test_distance_spheresphere(GJKSolverType solver_type)
 
   DistanceResult<S> result;
 
-  bool res{false};
-
   // Expecting distance to be 10
   result.clear();
   tf2.translation() = Vector3<S>(40, 0, 0);
-  res = distance(&s1, tf1, &s2, tf2, request, result);
-  EXPECT_TRUE(res);
-  EXPECT_TRUE(std::abs(result.min_distance - 10) < 1e-6);
-  EXPECT_TRUE(result.nearest_points[0].isApprox(Vector3<S>(20, 0, 0)));
-  EXPECT_TRUE(result.nearest_points[1].isApprox(Vector3<S>(-10, 0, 0)));
+  distance(&s1, tf1, &s2, tf2, request, result);
+  EXPECT_NEAR(result.min_distance, 10, 1e-6);
+  EXPECT_TRUE(CompareMatrices(result.nearest_points[0], Vector3<S>(20, 0, 0),
+                              request.distance_tolerance));
+  EXPECT_TRUE(CompareMatrices(result.nearest_points[1], Vector3<S>(30, 0, 0),
+                              request.distance_tolerance));
 
-  // Expecting distance to be -5
-  result.clear();
-  tf2.translation() = Vector3<S>(25, 0, 0);
-  res = distance(&s1, tf1, &s2, tf2, request, result);
-
-  EXPECT_TRUE(res);
   // request.distance_tolerance is actually the square of the distance
   // tolerance, namely the difference between distance returned from FCL's EPA
   // implementation and the actual distance, is less than
   // sqrt(request.distance_tolerance).
   const S distance_tolerance = std::sqrt(request.distance_tolerance);
-  EXPECT_NEAR(result.min_distance, -5, distance_tolerance);
 
+  // Expecting distance to be -5
+  result.clear();
+  tf2.translation() = Vector3<S>(25, 0, 0);
+  distance(&s1, tf1, &s2, tf2, request, result);
+  EXPECT_NEAR(result.min_distance, -5, request.distance_tolerance);
+
+  // TODO(JS): Only GST_LIBCCD can compute the pair of nearest points on the
+  // surface of the penetrating spheres.
+  if (solver_type == GST_LIBCCD)
+  {
+    EXPECT_TRUE(CompareMatrices(result.nearest_points[0], Vector3<S>(20, 0, 0),
+                                distance_tolerance));
+    EXPECT_TRUE(CompareMatrices(result.nearest_points[1], Vector3<S>(15, 0, 0),
+                                distance_tolerance));
+  }
+
+  result.clear();
+  tf2.translation() = Vector3<S>(20, 0, 20);
+  distance(&s1, tf1, &s2, tf2, request, result);
+
+  S expected_dist =
+      (tf1.translation() - tf2.translation()).norm() - radius_1 - radius_2;
+  EXPECT_NEAR(result.min_distance, expected_dist, distance_tolerance);
   // TODO(JS): Only GST_LIBCCD can compute the pair of nearest points on the
   // surface of the spheres.
   if (solver_type == GST_LIBCCD)
   {
-    EXPECT_TRUE(result.nearest_points[0].isApprox(Vector3<S>(20, 0, 0),
-                                                  distance_tolerance));
-    EXPECT_TRUE(result.nearest_points[1].isApprox(Vector3<S>(-10, 0, 0),
-                                                  distance_tolerance));
+    Vector3<S> dir = (tf2.translation() - tf1.translation()).normalized();
+    Vector3<S> p0_expected = dir * radius_1;
+    EXPECT_TRUE(CompareMatrices(result.nearest_points[0], p0_expected,
+                                distance_tolerance));
+    Vector3<S> p1_expected = tf2.translation() - dir * radius_2;
+    EXPECT_TRUE(CompareMatrices(result.nearest_points[1], p1_expected,
+                                distance_tolerance));
+  }
+}
+
+template <typename S>
+void test_distance_spherecapsule(GJKSolverType solver_type)
+{
+  Sphere<S> s1{20};
+  Capsule<S> s2{10, 20};
+
+  Transform3<S> tf1{Transform3<S>::Identity()};
+  Transform3<S> tf2{Transform3<S>::Identity()};
+
+  DistanceRequest<S> request;
+  request.enable_signed_distance = true;
+  request.enable_nearest_points = true;
+  request.gjk_solver_type = solver_type;
+
+  DistanceResult<S> result;
+
+  // Expecting distance to be 10
+  result.clear();
+  tf2.translation() = Vector3<S>(40, 0, 0);
+  distance(&s1, tf1, &s2, tf2, request, result);
+  EXPECT_NEAR(result.min_distance, 10, request.distance_tolerance);
+  EXPECT_TRUE(CompareMatrices(result.nearest_points[0], Vector3<S>(20, 0, 0),
+                              request.distance_tolerance));
+  EXPECT_TRUE(CompareMatrices(result.nearest_points[1], Vector3<S>(30, 0, 0),
+                              request.distance_tolerance));
+
+  // Expecting distance to be -5
+  result.clear();
+  tf2.translation() = Vector3<S>(25, 0, 0);
+  distance(&s1, tf1, &s2, tf2, request, result);
+
+  // request.distance_tolerance is actually the square of the distance
+  // tolerance, namely the difference between distance returned from FCL's EPA
+  // implementation and the actual distance, is less than
+  // sqrt(request.distance_tolerance).
+  const S distance_tolerance = std::sqrt(request.distance_tolerance);
+  ASSERT_NEAR(result.min_distance, -5, distance_tolerance);
+  if (solver_type == GST_LIBCCD)
+  {
+    // NOTE: Currently, only GST_LIBCCD computes the pair of nearest points.
+    EXPECT_TRUE(CompareMatrices(result.nearest_points[0], Vector3<S>(20, 0, 0),
+                                distance_tolerance * 100));
+    EXPECT_TRUE(CompareMatrices(result.nearest_points[1], Vector3<S>(15, 0, 0),
+                                distance_tolerance * 100));
   }
 }
 
 //==============================================================================
-GTEST_TEST(FCL_NEGATIVE_DISTANCE, sphere_sphere)
+
+GTEST_TEST(FCL_NEGATIVE_DISTANCE, sphere_sphere_ccd)
 {
   test_distance_spheresphere<double>(GST_LIBCCD);
+}
+
+GTEST_TEST(FCL_NEGATIVE_DISTANCE, sphere_sphere_indep)
+{
   test_distance_spheresphere<double>(GST_INDEP);
+}
+
+GTEST_TEST(FCL_NEGATIVE_DISTANCE, sphere_capsule_ccd)
+{
+  test_distance_spherecapsule<double>(GST_LIBCCD);
+}
+
+GTEST_TEST(FCL_NEGATIVE_DISTANCE, sphere_capsule_indep)
+{
+  test_distance_spherecapsule<double>(GST_INDEP);
 }
 
 //==============================================================================


### PR DESCRIPTION
Changed *slightly* from the original PR submission.

Now this focuses on correcting the return values in the distance queries. `DistanceResult` reports that the near points are reported in the *world* frame. However, this was not supported by the code. This PR changes the various distance queries to report world-frame values and updates the tests to reflect this.

~~This PR is an alternate variation of #250 -- trying to get through CI.~~

- ~~The first was the convex shape's aabb was being initialized incorrectly causing it to always be infinite size.~~
- ~~The second, is I noticed that when getting distance information for convex shapes the nearest points were appeared to be in the shape frame to the global. After making the changes below they are now in the global frame.~~

~~NOTE: Part of this PR introduces a signed-distance test between a sphere and capsule. The test revealed an error in the calculation. The test documents this error.~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/288)
<!-- Reviewable:end -->
