### PR TITLE
Fix the bug in penEPAPosClosest

### DIFF
--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -1249,52 +1249,78 @@ static inline ccd_real_t _ccdDist(const void *obj1, const void *obj2,
   return -CCD_REAL(1.);
 }
 
-static int penEPAPosCmp(const void *a, const void *b)
-{
-    ccd_pt_vertex_t *v1, *v2;
-    v1 = *(ccd_pt_vertex_t **)a;
-    v2 = *(ccd_pt_vertex_t **)b;
-
-    if (ccdEq(v1->dist, v2->dist)){
-        return 0;
-    }else if (v1->dist < v2->dist){
-        return -1;
-    }else{
-        return 1;
-    }
-}
-
 static int penEPAPosClosest(const ccd_pt_t *pt, const ccd_pt_el_t *nearest,
                             ccd_vec3_t *p1, ccd_vec3_t* p2)
 {
-    FCL_UNUSED(nearest);
-
-    ccd_pt_vertex_t *v;
-    ccd_pt_vertex_t **vs;
-    size_t i, len;
-    // compute median
-    len = 0;
-    ccdListForEachEntry(&pt->vertices, v, ccd_pt_vertex_t, list){
-        len++;
+  // We reconstruct the simplex on which the nearest point lives, and then
+  // compute the deepest penetration point on each geometric objects.
+  if (nearest->type == CCD_PT_VERTEX) {
+    ccd_pt_vertex_t* v = ccdListEntry(&nearest->list, ccd_pt_vertex_t, list);
+    if(v == NULL) {
+      return -1;
     }
-
-    vs = CCD_ALLOC_ARR(ccd_pt_vertex_t*, len);
-    if (vs == NULL)
-        return -1;
-
-    i = 0;
-    ccdListForEachEntry(&pt->vertices, v, ccd_pt_vertex_t, list){
-        vs[i++] = v;
-    }
-
-    qsort(vs, len, sizeof(ccd_pt_vertex_t*), penEPAPosCmp);
-
-    ccdVec3Copy(p1, &vs[0]->v.v1);
-    ccdVec3Copy(p2, &vs[0]->v.v2);
-
-    free(vs);
-
+    ccdVec3Copy(p1, &v->v.v1);
+    ccdVec3Copy(p2, &v->v.v2);
     return 0;
+  } else {
+    ccd_simplex_t s;
+    ccdSimplexInit(&s);
+    if (nearest->type == CCD_PT_EDGE) {
+      ccd_pt_edge_t* e = ccdListEntry(&nearest->list, ccd_pt_edge_t, list);
+      if (e == NULL) {
+        return -1;
+      }
+      //std::cout << "edge vertex1:\n" << supportToString(e->vertex[0]->v) << "\n";
+      //std::cout << "edge vertex2:\n" << supportToString(e->vertex[1]->v) << "\n";
+      ccdSimplexAdd(&s, &(e->vertex[0]->v));
+      ccdSimplexAdd(&s, &(e->vertex[1]->v));
+    } else if (nearest->type == CCD_PT_FACE) {
+      ccd_pt_face_t* f = ccdListEntry(&nearest->list, ccd_pt_face_t, list);
+      if (f == NULL) {
+        return -1;
+      }
+      ccdSimplexAdd(&s, &(f->edge[0]->vertex[0]->v));
+      ccdSimplexAdd(&s, &(f->edge[1]->vertex[0]->v));
+      ccdSimplexAdd(&s, &(f->edge[2]->vertex[0]->v));
+    } else {
+      throw std::logic_error(
+          "Unsupported point type. The closest point should be either a "
+          "vertex, on an edge, or an a face.\n");
+    }
+    // Now compute the closest point in the simplex.
+    // TODO(hongkai.dai@tri.global): we do not need to compute the closest point
+    // on the simplex, as that is already given in @p nearest. We only need to
+    // extract the deepest penetration points on each geometric object.
+    // Sean.Curtis@tri.global and I will refactor this code in the future, to
+    // avoid calling extractClosestPoints.
+    ccd_vec3_t p;
+    ccdVec3Copy(&p, &(nearest->witness));
+    extractClosestPoints(&s, p1, p2, &p);
+    return 0;
+  }
+  FCL_UNUSED(pt);
+/*
+  ccd_pt_vertex_t* v;
+  ccd_pt_vertex_t** vs;
+  size_t i, len;
+  // compute median
+  len = 0;
+  ccdListForEachEntry(&pt->vertices, v, ccd_pt_vertex_t, list) { len++; }
+
+  vs = CCD_ALLOC_ARR(ccd_pt_vertex_t*, len);
+  if (vs == NULL) return -1;
+
+  i = 0;
+  ccdListForEachEntry(&pt->vertices, v, ccd_pt_vertex_t, list) { vs[i++] = v; }
+
+  qsort(vs, len, sizeof(ccd_pt_vertex_t*), penEPAPosCmp);
+
+  ccdVec3Copy(p1, &vs[0]->v.v1);
+  ccdVec3Copy(p2, &vs[0]->v.v2);
+
+  free(vs);
+
+  return 0;*/
 }
 
 static inline ccd_real_t ccdGJKSignedDist(const void* obj1, const void* obj2, const ccd_t* ccd, ccd_vec3_t* p1, ccd_vec3_t* p2)

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl.cpp
@@ -42,7 +42,7 @@
 
 namespace fcl {
 namespace detail {
-
+/*
 // Given two spheres, sphere 1 has radius1, and centered at point A, whose
 // position is p_FA measured and expressed in frame F; sphere 2 has radius2,
 // and centered at point B, whose position is p_FB measured and expressed in
@@ -152,6 +152,92 @@ GTEST_TEST(FCL_GJKSignedDistance, sphere_sphere) {
   // only up to 1E-3. Should investigate why there is such a big difference.
   TestNonCollidingSphereGJKSignedDistance<double>(1E-3);
   TestNonCollidingSphereGJKSignedDistance<float>(1E-3);
+}*/
+
+//----------------------------------------------------------------------------
+//                 Box test
+// Given two boxes, by changing the pose of one orientation, the boxes can
+// either penetrate, touching or separating.
+template <typename S>
+struct BoxSpecification {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  BoxSpecification(const fcl::Vector3<S>& m_size) : size(m_size) {
+    X_FB.setIdentity();
+  }
+  fcl::Vector3<S> size;
+  fcl::Transform3<S> X_FB;
+};
+
+template <typename S>
+void TestBoxes(S tol) {
+  const fcl::Vector3<S> box1_size(1, 1, 1);
+  const fcl::Vector3<S> box2_size(0.6, 0.8, 1);
+  // Put the two boxes on the xy plane.
+  // B1 is the frame rigidly attached to box 1, B2 is the frame rigidly attached
+  // to box 2. W is the world frame. X_WB1 is the pose of box 1 expressed and
+  // measured in the world frame, X_WB2 is the pose of box 2 expressed and
+  // measured in the world frame.
+  fcl::Transform3<S> X_WB1, X_WB2;
+  // Box 1 is fixed.
+  X_WB1.setIdentity();
+  X_WB1.translation() << 0, 0, 0.5;
+
+  // First fix the orientation of box 2, such that one of its diagonal (the one
+  // connecting the vertex (0.3, -0.4, 1) and (-0.3, 0.4, 1) is horizontal. If
+  // we move the position of box 2, we get different signed distance.
+  X_WB2.setIdentity();
+  X_WB2.linear() << 0.6, -0.8, 0, 0.8, 0.6, 0, 0, 0, 1;
+
+  auto CheckDistance = [&box1_size, &box2_size, &X_WB1](
+      const Transform3<S>& X_WB2, S distance_expected,
+      const Vector2<S>& p_xy_WNa_expected, const Vector2<S>& p_xy_WNb_expected,
+      S tol) {
+    fcl::Box<S> box1(box1_size);
+    fcl::Box<S> box2(box2_size);
+    void* o1 = GJKInitializer<S, fcl::Box<S>>::createGJKObject(box1, X_WB1);
+    void* o2 = GJKInitializer<S, fcl::Box<S>>::createGJKObject(box2, X_WB2);
+    S dist;
+    Vector3<S> p1, p2;
+    GJKSolver_libccd<S> gjkSolver;
+    bool res = GJKSignedDistance(
+        o1, detail::GJKInitializer<S, Box<S>>::getSupportFunction(), o2,
+        detail::GJKInitializer<S, Box<S>>::getSupportFunction(),
+        gjkSolver.max_distance_iterations, gjkSolver.distance_tolerance, &dist,
+        &p1, &p2);
+
+    if (distance_expected < 0) {
+      EXPECT_FALSE(res);
+    } else if (distance_expected > 0) {
+      EXPECT_TRUE(res);
+    }
+
+    EXPECT_NEAR(dist, distance_expected, tol);
+    std::cout << "p1: " << p1.transpose() << "\n";
+    std::cout << "p2: " << p2.transpose() << "\n";
+    EXPECT_TRUE(p1.template head<2>().isApprox(p_xy_WNa_expected, tol));
+    EXPECT_TRUE(p2.template head<2>().isApprox(p_xy_WNb_expected, tol));
+    // The z height of the closest points should be the same.
+    EXPECT_NEAR(p1(2), p2(2), tol);
+    EXPECT_GE(p1(2), 0);
+    EXPECT_GE(p2(2), 0);
+    EXPECT_LE(p1(2), 1);
+    EXPECT_LE(p2(2), 1);
+
+    GJKInitializer<S, fcl::Sphere<S>>::deleteGJKObject(o1);
+    GJKInitializer<S, fcl::Sphere<S>>::deleteGJKObject(o2);
+  };
+
+  // An edge of box 2 is touching a face of box 1
+  X_WB2.translation() << -1, 0, 0.5;
+  CheckDistance(X_WB2, 0, Vector2<S>(-0.5, 0), Vector2<S>(-0.5, 0), tol);
+}
+
+GTEST_TEST(FCL_GJKSignedDistance, box_box) {
+  // TODO(hongkai.dai@tri.global): By setting gjkSolver.distance_tolerance to
+  // the default value (1E-6), the tolerance we get on the closest points are
+  // only up to 1E-3. Should investigate why there is such a big difference.
+  TestBoxes<double>(1E-3);
+  TestBoxes<float>(1E-3);
 }
 }  // namespace detail
 }  // namespace fcl

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl.cpp
@@ -227,9 +227,25 @@ void TestBoxes(S tol) {
     GJKInitializer<S, fcl::Sphere<S>>::deleteGJKObject(o2);
   };
 
+  //---------------------------------------------------------------
+  //                      Touching contact
   // An edge of box 2 is touching a face of box 1
   X_WB2.translation() << -1, 0, 0.5;
   CheckDistance(X_WB2, 0, Vector2<S>(-0.5, 0), Vector2<S>(-0.5, 0), tol);
+
+  // Shift box 2 on y axis by 0.1m. 
+  X_WB2.translation() << -1, 0.1, 0.5;
+  CheckDistance(X_WB2, 0, Vector2<S>(-0.5, 0.1), Vector2<S>(-0.5, 0.1), tol);
+
+  //--------------------------------------------------------------
+  //                      Penetrating contact
+  // An edge of box 2 penetrates into a face of box 1
+  X_WB2.translation() << -0.9, 0, 0.5;
+  CheckDistance(X_WB2, -0.1, Vector2<S>(-0.5, 0), Vector2<S>(-0.4, 0), tol);
+
+  // Shift box 2 on y axis by 0.1m. 
+  X_WB2.translation() << -0.9, 0.1, 0.5;
+  CheckDistance(X_WB2, -0.1, Vector2<S>(-0.5, 0.1), Vector2<S>(-0.4, 0.1), tol);
 }
 
 GTEST_TEST(FCL_GJKSignedDistance, box_box) {


### PR DESCRIPTION
FCL extracts the deepest penetration points `p1, p2` in the function `penEPAPosClosest`. The implementation within this function is wrong. It loops through all vertices of the polytope from EPA algorithm, and takes the vertex that is closest to the origin as the point `p1-p2`. But `p1-p2` should correspond to the point on the boundary of the polytope, that is nearest to the origin, not on the vertices. As a matter of fact, that nearest point on the polytope's boundary is computed through EPA algorithm already, so we only need to construct the simplex as the active feature of that nearest point, and then we can easily extract `p1, p2` from the simplex, same as we did in GJK algorithm.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/302)
<!-- Reviewable:end -->
