### PR TITLE
Fix FCL's EPA implementation, when calling libccd solver.

### DIFF
--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -884,17 +884,18 @@ static int expandPolytope(ccd_pt_t *pt, ccd_pt_el_t *el,
   std::unordered_set<ccd_pt_edge_t*> obsolete_edges;
   std::unordered_set<ccd_pt_edge_t*> silhouette_edges;
 
+  ccd_pt_face_t* start_face = NULL;
   // Start with the face on which the closest point lives
   if (el->type == CCD_PT_FACE) {
-    obsolete_faces.insert((ccd_pt_face_t*)el);
+    start_face = (ccd_pt_face_t*)el;
   } else if (el->type == CCD_PT_EDGE) {
     // Check the two neighbouring faces of the edge.
     ccd_pt_face_t* f[2];
     ccdPtEdgeFaces((ccd_pt_edge_t*)el, &f[0], &f[1]);
     if (outsidePolytopeFace(pt, f[0], &newv->v)) {
-      obsolete_faces.insert(f[0]);
+      start_face = f[0];
     } else if (outsidePolytopeFace(pt, f[1], &newv->v)) {
-      obsolete_faces.insert(f[1]);
+      start_face = f[1];
     } else {
       throw std::logic_error(
           "This should not happen. Both the nearest point and the new vertex "
@@ -903,78 +904,10 @@ static int expandPolytope(ccd_pt_t *pt, ccd_pt_el_t *el,
           "touching contact.");
     }
   }
+  obsolete_faces.insert(start_face);
   for (int i = 0; i < 3; ++i) {
-    floodFillSilhouette(pt, *(obsolete_faces.begin()), i, &newv->v,
-                        &silhouette_edges, &obsolete_faces, &obsolete_edges);
-  }
-  // ccd_pt_vertex_t.edges contain garbage value, so we cannot access the edges
-  // connected to a vertex directly, see
-  // https://github.com/danfis/libccd/issues/46
-  // As a result, we loop through each obsolete edges, if all the neighbouring
-  // faces of a vertex are obsolete, then the vertex is obsolete also.
-  // checked_vertices contains all the vertices, which has been checked whether
-  // it is obsolete or not.
-  std::unordered_set<ccd_pt_vertex_t*> checked_vertices;
-  std::vector<ccd_pt_vertex_t*> obsolete_vertices;
-  // We will rotate about a vertex by each neighbouring faces, to check if all
-  // the faces connected to that vertex are obsolete.
-  // To do so, given a face and an edge on the face connecting to the vertex,
-  // we will find the adjacent face, and another edge on that adjacent face,
-  // that also connects to the vertex.
-  // @param[in] cur_edge is an edge connecting to the vertex v.
-  // @param[in] cur_edge is on the face cur_face. 
-  // @param[out] next_face shares the common edge with cur_face.
-  // @retval next_edge is on next_face, also connects to the vertex v.
-  auto FindNextEdge= [](const ccd_pt_vertex_t* v,
-                         const ccd_pt_face_t* cur_face,
-                         const ccd_pt_edge_t* cur_edge,
-                         ccd_pt_face_t* next_face) {
-    if (cur_edge->faces[0] == cur_face) {
-      next_face = cur_edge->faces[1];
-    } else if (cur_edge->faces[1] == cur_face) {
-      next_face = cur_edge->faces[0];
-    } else {
-      throw std::runtime_error(
-          "cur_face is not a neighbouring face of cur_edge.");
-    }
-    // Now find next_edge.
-    for (int i = 0; i < 3; ++i) {
-      if (next_face->edge[i] == cur_edge) {
-        // next_edge is either next_face->edge[j[0]] or next_face->edge[j[1]];
-        int j[2] = {(i + 1) % 3, (i + 2) % 3};
-        for (int k = 0; k < 2; ++k) {
-          if (next_face->edge[j[k]]->vertex[0] == v ||
-              next_face->edge[j[k]]->vertex[1] == v) {
-            // next_face->edge[j[k]] connects to v.
-            ccd_pt_edge_t* next_edge = next_face->edge[j[k]];
-            return next_edge;
-          }
-        }
-      }
-    }
-    throw std::runtime_error("Cannot find the next edge.\n");
-  };
-
-  for (const auto& e : obsolete_edges) {
-    for (int i = 0; i < 2; ++i) {
-      ccd_pt_vertex_t* v = e->vertex[i];
-      if (checked_vertices.find(v) == checked_vertices.end()) {
-        ccd_pt_face_t* start_face = e->faces[0];
-        ccd_pt_face_t* cur_face = e->faces[1];
-        ccd_pt_edge_t* cur_edge = e;
-        ccd_pt_face_t* next_face = NULL;
-        while (cur_face != start_face &&
-               obsolete_faces.find(cur_face) != obsolete_faces.end()) {
-          // next_face is obsolete, and it is not the start_face.
-          cur_edge = FindNextEdge(v, cur_face, cur_edge, next_face);
-          cur_face = next_face;
-        }
-        if (cur_face == start_face) {
-          obsolete_vertices.push_back(v);
-        }
-        checked_vertices.insert(v);
-      }
-    }
+    floodFillSilhouette(pt, start_face, i, &newv->v, &silhouette_edges,
+                        &obsolete_faces, &obsolete_edges);
   }
 
   // Now remove all the obsolete faces.
@@ -986,10 +919,8 @@ static int expandPolytope(ccd_pt_t *pt, ccd_pt_el_t *el,
   for (const auto& e : obsolete_edges) {
     ccdPtDelEdge(pt, e);
   }
-  // Now remove all obsolete vertices.
-  for (const auto& v : obsolete_vertices) {
-    ccdPtDelVertex(pt, v);
-  }
+  // A vertex cannot be obsolete, since a vertex is always on the boundary of
+  // the Minkowski difference A⊖B.
   
   // Now add the new vertex.
   ccd_pt_vertex_t* new_vertex = ccdPtAddVertex(pt, newv);

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -828,6 +828,11 @@ static bool isOutsidePolytopeFace(const ccd_pt_t* polytope,
   return ccdVec3Dot(&n, &r_VP) > 0;
 }
 
+#ifndef NDEBUG
+// The function ComputeVisiblePatchRecursiveSanityCheck is only called in the
+// debug mode. In the release mode, this function is declared/defined but not
+// used. Without this NDEBUG macro, the function will cause a -Wunused-function
+// error on CI's release builds.
 /**
  * The invariant for computing the visible patch is that for each edge in the
  * polytope, if both neighbouring faces are visible, then the edge is an
@@ -873,6 +878,7 @@ static bool ComputeVisiblePatchRecursiveSanityCheck(
   }
   return true;
 }
+#endif
 
 /**
  * This function contains the implementation detail of ComputeVisiblePatch

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -1379,6 +1379,17 @@ static inline ccd_real_t _ccdDist(const void *obj1, const void *obj2,
   return -CCD_REAL(1.);
 }
 
+/**
+ * Given the nearest point on the polytope inside the Minkowski sum A⊖B, returns
+ * the point p1 on geometric object A and p2 on geometric object B, such that
+ * p1 is the deepest penetration point on A, and p2 is the deepest penetration
+ * point on B.
+ * @param[in] pt The polytope inside Minkowski sum A⊖B. Unused in this function.
+ * @param[in] nearest The point that is nearest to the origin on the boundary of
+ * the polytope.
+ * @param[out] p1 the deepest penetration point on A.
+ * @param[out] p2 the deepest penetration point on B.
+ */
 static int penEPAPosClosest(const ccd_pt_t *pt, const ccd_pt_el_t *nearest,
                             ccd_vec3_t *p1, ccd_vec3_t* p2)
 {
@@ -1400,18 +1411,51 @@ static int penEPAPosClosest(const ccd_pt_t *pt, const ccd_pt_el_t *nearest,
       if (e == NULL) {
         return -1;
       }
-      //std::cout << "edge vertex1:\n" << supportToString(e->vertex[0]->v) << "\n";
-      //std::cout << "edge vertex2:\n" << supportToString(e->vertex[1]->v) << "\n";
       ccdSimplexAdd(&s, &(e->vertex[0]->v));
       ccdSimplexAdd(&s, &(e->vertex[1]->v));
     } else if (nearest->type == CCD_PT_FACE) {
+      // TODO(hongkai.dai): this case is not properly tested in the unit test,
+      // as the test on this code exposes another bug in FCL, as summarized in
+      // the issue #301. I will properly test this branch once #301 if fixed.
       ccd_pt_face_t* f = ccdListEntry(&nearest->list, ccd_pt_face_t, list);
       if (f == NULL) {
         return -1;
       }
+      // The face triangle has three edges, each edge consists of two end
+      // points, so there are 6 end points in total, each vertex of the triangle
+      // appears twice among the 6 end points. We need to choose the three
+      // distinctive vertices out of these 6 end points.
+      // First we pick edge0, the two end points of edge0 are distinct.
       ccdSimplexAdd(&s, &(f->edge[0]->vertex[0]->v));
-      ccdSimplexAdd(&s, &(f->edge[1]->vertex[0]->v));
-      ccdSimplexAdd(&s, &(f->edge[2]->vertex[0]->v));
+      ccdSimplexAdd(&s, &(f->edge[0]->vertex[1]->v));
+      // Next we pick edge1, one of the two end points on edge1 is distinct from
+      // the end points in edge0. To find out the distinctive vertex, we compute
+      // d0 = min(|e1.v0 - e0.v0|, |e1.v0 - e0.v1|)
+      // d1 = min(|e1.v1 - e0.v0|, |e1.v1 - e0.v1|)
+      // namely d0 is the smallest distance from e1.v0 on edge1 to the two end 
+      // ponits on edge0, d1 is the smallest distance from e1.v1 on edge1 to the
+      // two end points on edge0. If d0 < d1, then we choose e1.v1 as the
+      // distinct vertex; otherwise we choose e1.v0.
+      // We denote
+      // d00 = | e1.v0 - e0.v0 | 
+      // d01 = | e1.v0 - e0.v1 |
+      // d10 = | e1.v1 - e0.v0 |
+      // d11 = | e1.v1 - e0.v1 |
+      const ccd_real_t d00 = ccdVec3Dist2(&f->edge[1]->vertex[0]->v.v,
+                                          &f->edge[0]->vertex[0]->v.v);
+      const ccd_real_t d01 = ccdVec3Dist2(&f->edge[1]->vertex[0]->v.v,
+                                          &f->edge[0]->vertex[1]->v.v);
+      const ccd_real_t d10 = ccdVec3Dist2(&f->edge[1]->vertex[1]->v.v,
+                                          &f->edge[0]->vertex[0]->v.v);
+      const ccd_real_t d11 = ccdVec3Dist2(&f->edge[1]->vertex[1]->v.v,
+                                          &f->edge[0]->vertex[1]->v.v);
+      ccd_real_t d0 = d00 < d01 ? d00 : d01;
+      ccd_real_t d1 = d10 < d11 ? d10 : d11;
+      if (d0 < d1) {
+        ccdSimplexAdd(&s, &(f->edge[1]->vertex[1]->v));
+      } else {
+        ccdSimplexAdd(&s, &(f->edge[1]->vertex[0]->v));
+      }
     } else {
       throw std::logic_error(
           "Unsupported point type. The closest point should be either a "
@@ -1429,28 +1473,6 @@ static int penEPAPosClosest(const ccd_pt_t *pt, const ccd_pt_el_t *nearest,
     return 0;
   }
   FCL_UNUSED(pt);
-/*
-  ccd_pt_vertex_t* v;
-  ccd_pt_vertex_t** vs;
-  size_t i, len;
-  // compute median
-  len = 0;
-  ccdListForEachEntry(&pt->vertices, v, ccd_pt_vertex_t, list) { len++; }
-
-  vs = CCD_ALLOC_ARR(ccd_pt_vertex_t*, len);
-  if (vs == NULL) return -1;
-
-  i = 0;
-  ccdListForEachEntry(&pt->vertices, v, ccd_pt_vertex_t, list) { vs[i++] = v; }
-
-  qsort(vs, len, sizeof(ccd_pt_vertex_t*), penEPAPosCmp);
-
-  ccdVec3Copy(p1, &vs[0]->v.v1);
-  ccdVec3Copy(p2, &vs[0]->v.v2);
-
-  free(vs);
-
-  return 0;*/
 }
 
 static inline ccd_real_t ccdGJKSignedDist(const void* obj1, const void* obj2, const ccd_t* ccd, ccd_vec3_t* p1, ccd_vec3_t* p2)

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -1113,7 +1113,7 @@ static ccd_vec3_t sampledEPADirection(const ccd_pt_t* polytope,
     }
   } else {
     ccdVec3Copy(&dir, &(nearest_pt->witness));
-    ccdVec3Scale(&dir, CCD_REAL(1) / std::sqrt(nearest_pt->dist));
+    ccdVec3Scale(&dir, ccd_real_t(1) / std::sqrt(nearest_pt->dist));
   }
   return dir;
 }

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -558,8 +558,8 @@ simplexToPolytope2_not_touching_contact:
     return 0;
 }
 
-/** Transforms a 2-simplex (triagnel) to polytope (tetrahedron), three vertices
- * required.
+/** Transforms a 2-simplex (triangle) to a polytope (tetrahedron), three
+ * vertices required.
  * Both the simplex and the transformed polytope contain the origin. The simplex
  * vertices lie on the surface of the Minkowski difference obj1 ⊖ obj2.
  * @param[in] obj1 object 1 on which the distance is queried.

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -1091,7 +1091,7 @@ static ccd_vec3_t sampledEPADirection(const ccd_pt_t* polytope,
     // nearest_pt is the origin.
     switch (nearest_pt->type) {
       case CCD_PT_VERTEX: {
-        throw std::logic_error(
+        throw std::runtime_error(
             "The nearest point to the origin is a vertex of the polytope. This "
             "should be identified as a touching contact, before calling this "
             "function.");
@@ -1119,7 +1119,6 @@ static ccd_vec3_t sampledEPADirection(const ccd_pt_t* polytope,
 }
 
 /** Finds next support point (and stores it in out argument).
- * Returns 0 on success, -1 otherwise
  * @param[in] polytope The current polytope contained inside the Minkowski sum
  * A⊖B.
  * @param[in] obj1 Geometric object A.
@@ -1128,6 +1127,14 @@ static ccd_vec3_t sampledEPADirection(const ccd_pt_t* polytope,
  * @param[in] el The current nearest point on the boundary of the polytope to
  * the origin. 
  * @param[out] out The next support point.
+ * @retval status If the program converges, then return -1. Otherwise return 0.
+ * There are several cases that the program could converge.
+ * 1. If the nearest point on the boundary of the polytope to the origin is a
+ * vertex of the polytope. Then we know the two objects A and B are in touching
+ * contact.
+ * 2. If the difference between the upper bound and lower bound of the distance
+ * is below sqrt(ccd->epa_tolerance), then we converge to a distance whose
+ * difference from the real distance is less than sqrt(ccd->epa_tolerance).
  */
 static int nextSupport(const ccd_pt_t* polytope, const void* obj1,
                        const void* obj2, const ccd_t* ccd,

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -621,7 +621,8 @@ static int simplexToPolytope3(const void* obj1, const void* obj2,
   // Form a tetrahedron with abc as one face, pick either d or d2, based
   // on which one has larger distance to the face abc.
 
-  auto FormTetrahedron = [pt, a, b, c, &v, &e](ccd_support_t& new_support) {
+  auto FormTetrahedron = [pt, a, b, c, &v,
+                          &e](ccd_support_t& new_support) -> int {
     v[0] = ccdPtAddVertex(pt, a);
     v[1] = ccdPtAddVertex(pt, b);
     v[2] = ccdPtAddVertex(pt, c);
@@ -633,10 +634,15 @@ static int simplexToPolytope3(const void* obj1, const void* obj2,
     e[3] = ccdPtAddEdge(pt, v[0], v[3]);
     e[4] = ccdPtAddEdge(pt, v[1], v[3]);
     e[5] = ccdPtAddEdge(pt, v[2], v[3]);
+
+    // ccdPtAdd*() functions return NULL either if the memory allocation
+    // failed of if any of the input pointers are NULL, so the bad
+    // allocation can be checked by the last calls of ccdPtAddFace()
+    // because the rest of the bad allocations eventually "bubble up" here
     if (ccdPtAddFace(pt, e[0], e[1], e[2]) == NULL ||
-        ccdPtAddFace(pt, e[0], e[3], e[4]) == NULL ||
-        ccdPtAddFace(pt, e[1], e[4], e[5]) == NULL ||
-        ccdPtAddFace(pt, e[2], e[5], e[3]) == NULL) {
+        ccdPtAddFace(pt, e[3], e[4], e[0]) == NULL ||
+        ccdPtAddFace(pt, e[4], e[5], e[1]) == NULL ||
+        ccdPtAddFace(pt, e[5], e[3], e[2]) == NULL) {
       return -2;
     }
     return 0;

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -558,7 +558,8 @@ simplexToPolytope2_not_touching_contact:
     return 0;
 }
 
-/** Transforms a 2-simplex to polytope (tetrahedron), three vertices required
+/** Transforms a 2-simplex (triagnel) to polytope (tetrahedron), three vertices
+ * required.
  * Both the simplex and the transformed polytope contain the origin. The simplex
  * vertices lie on the surface of the Minkowski difference obj1 ⊖ obj2.
  * @param[in] obj1 object 1 on which the distance is queried.
@@ -571,7 +572,7 @@ simplexToPolytope2_not_touching_contact:
  * then set *nearest to be the nearest points on obj1 and obj2 respectively;
  * otherwise set *nearest to NULL. @note nearest cannot be NULL.
  * @retval status return 0 on success, -1 if touching contact is detected, and
- * -2 on failure (mostly due to memory allocation bug).
+ * -2 on non-recoverable failure (mostly due to memory allocation bug).
  */
 static int Convert2SimplexToTetrahedron(const void* obj1, const void* obj2,
                               const ccd_t* ccd, const ccd_simplex_t* simplex,

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -889,9 +889,12 @@ static void ComputeVisiblePatchRecursive(
         }
       }
     }
+  } else {
+    // for f.edge[edge_index], its two neighbouring faces are
+    // f and f_neighbour, both faces are visible, so f.edge[edge_index]
+    // is an internal edge.
+    internal_edges->insert(f.edge[edge_index]);
   }
-  assert(ComputeVisiblePatchRecursiveSanityCheck(
-      polytope, *border_edges, *visible_faces, *internal_edges));
 }
 
 /** Defines the "visible" patch on the given convex `polytope` (with respect to
@@ -938,6 +941,8 @@ static void ComputeVisiblePatch(
     ComputeVisiblePatchRecursive(polytope, f, i, query_point, border_edges,
                                  visible_faces, internal_edges);
   }
+  assert(ComputeVisiblePatchRecursiveSanityCheck(
+      polytope, *border_edges, *visible_faces, *internal_edges));
 }
 
 /** Expands the polytope by adding a new vertex @p newv to the polytope. The
@@ -1021,12 +1026,6 @@ static int expandPolytope(ccd_pt_t *polytope, ccd_pt_el_t *el,
     ccdPtDelEdge(polytope, e);
   }
 
-  ccd_pt_edge_t* e;
-  ccdListForEachEntry(&polytope->edges, e, ccd_pt_edge_t, list) {
-    if (e->faces[0] == NULL && e->faces[1] == NULL) {
-      std::cout << "error";
-    }
-  }
   // A vertex cannot be obsolete, since a vertex is always on the boundary of
   // the Minkowski difference A ⊖ B.
   // TODO(hongkai.dai@tri.global): as a sanity check, we should make sure that
@@ -1057,11 +1056,6 @@ static int expandPolytope(ccd_pt_t *polytope, ccd_pt_el_t *el,
     }
     // Now add the face.
     ccdPtAddFace(polytope, border_edge, e[0], e[1]);
-  }
-  ccdListForEachEntry(&polytope->edges, e, ccd_pt_edge_t, list) {
-    if (e->faces[0] == NULL || e->faces[1] == NULL) {
-      std::cout << "error";
-    }
   }
 
   return 0;

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -1181,7 +1181,6 @@ static ccd_vec3_t supportEPADirection(const ccd_pt_t* polytope,
         const ccd_pt_edge_t* edge =
             reinterpret_cast<const ccd_pt_edge_t*>(nearest_feature);
         dir = faceNormalPointingOutward(polytope, edge->faces[0]);
-        ccdVec3Normalize(&dir);
         break;
       }
       case CCD_PT_FACE: {
@@ -1190,17 +1189,13 @@ static ccd_vec3_t supportEPADirection(const ccd_pt_t* polytope,
         const ccd_pt_face_t* face =
             reinterpret_cast<const ccd_pt_face_t*>(nearest_feature);
         dir = faceNormalPointingOutward(polytope, face);
-
-        ccdVec3Normalize(&dir);
         break;
       }
     }
   } else {
     ccdVec3Copy(&dir, &(nearest_feature->witness));
-    // The "dist" field in ccd_pt_el_t is actually the square of the distance.
-    const ccd_real_t dist = std::sqrt(nearest_feature->dist);
-    ccdVec3Scale(&dir, ccd_real_t(1.0) / dist);
   }
+  ccdVec3Normalize(&dir);
   return dir;
 }
 

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -558,7 +558,20 @@ simplexToPolytope2_not_touching_contact:
     return 0;
 }
 
-/** Transforms simplex to polytope, three vertices required */
+/** Transforms simplex to polytope (tetrahedron), three vertices required
+ * Both the simplex and the transformed polytope contain the origin.
+ * @param[in] obj1 object 1 on which the penetration depth is queried.
+ * @param[in] obj2 object 2 on which the penetration depth is queried.
+ * @param[in] ccd The ccd solver.
+ * @param[in] simplex The simplex (with three vertices) that contains the
+ * origin.
+ * @param[out] pt The polytope (tetrahedron) that also contains the origin.
+ * @param[out] nearest If the function detects that obj1 and obj2 are touching,
+ * then set nearest to be the nearest points on obj1 and obj2 respectively;
+ * otherwise set nearest to NULL.
+ * @retval status return 0 on success, -1 if touching contact is detected, and
+ * -2 on failure (mostly due to memory allocation bug).
+ */
 static int simplexToPolytope3(const void* obj1, const void* obj2,
                               const ccd_t* ccd, const ccd_simplex_t* simplex,
                               ccd_pt_t* pt, ccd_pt_el_t** nearest) {

--- a/test/narrowphase/detail/convexity_based_algorithm/CMakeLists.txt
+++ b/test/narrowphase/detail/convexity_based_algorithm/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(tests
-    test_gjk_libccd-inl_extractClosestPoints.cpp
     test_gjk_libccd-inl_epa.cpp
+    test_gjk_libccd-inl_extractClosestPoints.cpp
     test_gjk_libccd-inl_signed_distance.cpp
 )
 

--- a/test/narrowphase/detail/convexity_based_algorithm/CMakeLists.txt
+++ b/test/narrowphase/detail/convexity_based_algorithm/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(tests
     test_gjk_libccd-inl.cpp
     test_gjk_libccd-inl_extractClosestPoints.cpp
-    test_epa.cpp
+    test_gjk_libccd-inl_epa.cpp
 )
 
 # Build all the tests

--- a/test/narrowphase/detail/convexity_based_algorithm/CMakeLists.txt
+++ b/test/narrowphase/detail/convexity_based_algorithm/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(tests
     test_gjk_libccd-inl.cpp
     test_gjk_libccd-inl_extractClosestPoints.cpp
+    test_epa.cpp
 )
 
 # Build all the tests

--- a/test/narrowphase/detail/convexity_based_algorithm/CMakeLists.txt
+++ b/test/narrowphase/detail/convexity_based_algorithm/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(tests
-    test_gjk_libccd-inl.cpp
     test_gjk_libccd-inl_extractClosestPoints.cpp
     test_gjk_libccd-inl_epa.cpp
+    test_gjk_libccd-inl_signed_distance.cpp
 )
 
 # Build all the tests

--- a/test/narrowphase/detail/convexity_based_algorithm/test_epa.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_epa.cpp
@@ -270,10 +270,12 @@ GTEST_TEST(FCL_GJK_EPA, floodFillSilhouette1) {
   p.v[0] = 0;
   p.v[1] = 0;
   p.v[2] = 1.1;
-  CheckFloodFillSilhouette(hex, hex.f(0), {0}, p, {0}, {0}, {});
+  const std::unordered_set<int> empty_set;
+  CheckFloodFillSilhouette(hex, hex.f(0), {0}, p, {0}, {0}, empty_set);
 
   // Run silhouette algorithm for the other edges
-  CheckFloodFillSilhouette(hex, hex.f(0), {0, 1, 2}, p, {0, 1, 2}, {0}, {});
+  CheckFloodFillSilhouette(hex, hex.f(0), {0, 1, 2}, p, {0, 1, 2}, {0},
+                           empty_set);
 }
 
 GTEST_TEST(FCL_GJK_EPA, floodFillSilhouette2) {
@@ -377,7 +379,14 @@ bool TriangleMatch(
 
 // Construct the mapping from feature1_list to feature2_list. There should be a
 // one-to-one correspondence between feature1_list and feature2_list.
-// @param feature1_list[in]
+// @param feature1_list[in] A list of features to be mapped from.
+// @param feature2_list[in] A list of features to be mapped to.
+// @param cmp_feature[in] Returns true if two features are identical, otherwise
+// returns false.
+// @param feature1[out] The set of features in feature1_list.
+// @param feature2[out] The set of features in feature2_list.
+// @param map_feature1_to_feature2[out] Maps a feature in feature1_list to
+// a feature in feature2_list.
 template <typename T>
 void MapFeature1ToFeature2(
     const ccd_list_t* feature1_list, const ccd_list_t* feature2_list,

--- a/test/narrowphase/detail/convexity_based_algorithm/test_epa.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_epa.cpp
@@ -49,12 +49,21 @@ namespace fcl {
 namespace detail {
 class EquilateralTetrahedron {
  public:
-  EquilateralTetrahedron() : polytope_(new ccd_pt_t) {
+  EquilateralTetrahedron(ccd_real_t bottom_center_x = 0,
+                         ccd_real_t bottom_center_y = 0,
+                         ccd_real_t bottom_center_z = 0)
+      : polytope_(new ccd_pt_t) {
     ccdPtInit(polytope_);
-    v_[0] = ccdPtAddVertexCoords(polytope_, 0.5, -0.5 / std::sqrt(3), 0);
-    v_[1] = ccdPtAddVertexCoords(polytope_, -0.5, -0.5 / std::sqrt(3), 0);
-    v_[2] = ccdPtAddVertexCoords(polytope_, 0, 1 / std::sqrt(3), 0);
-    v_[3] = ccdPtAddVertexCoords(polytope_, 0, 0, std::sqrt(2.0 / 3.0));
+    auto AddTetrahedronVertex = [bottom_center_x, bottom_center_y,
+                                 bottom_center_z, this](
+        ccd_real_t x, ccd_real_t y, ccd_real_t z) {
+      return ccdPtAddVertexCoords(this->polytope_, x + bottom_center_x,
+                                  y + bottom_center_y, z + bottom_center_z);
+    };
+    v_[0] = AddTetrahedronVertex(0.5, -0.5 / std::sqrt(3), 0);
+    v_[1] = AddTetrahedronVertex(-0.5, -0.5 / std::sqrt(3), 0);
+    v_[2] = AddTetrahedronVertex(0, 1 / std::sqrt(3), 0);
+    v_[3] = AddTetrahedronVertex(0, 0, std::sqrt(2.0 / 3.0));
     e_[0] = ccdPtAddEdge(polytope_, v_[0], v_[1]);
     e_[1] = ccdPtAddEdge(polytope_, v_[1], v_[2]);
     e_[2] = ccdPtAddEdge(polytope_, v_[2], v_[0]);
@@ -134,6 +143,425 @@ GTEST_TEST(FCL_GJK_EPA, outsidePolytopeFace) {
   CheckPointOutsidePolytopeFace(0, 0, 0, 1, false);
   CheckPointOutsidePolytopeFace(0, 0, 0, 2, false);
   CheckPointOutsidePolytopeFace(0, 0, 0, 3, false);
+}
+
+// Construct a polytope with the following shape, namely an equilateral triangle
+// on the top, and an equilateral triangle of the same size, but rotate by 60
+// degrees on the bottom. We will then connect the vertices of the equilateral
+// triangles to form a convex polytope.
+//       __╱╲__
+//       ╲╱  ╲╱
+//       ╱____╲
+//         ╲╱
+class Hexagram {
+ public:
+  Hexagram() : polytope_(new ccd_pt_t) {
+    ccdPtInit(polytope_);
+    // right corner of upper triangle
+    v_[0] = ccdPtAddVertexCoords(polytope_, 0.5, -1 / std::sqrt(3), 1);
+    // bottom corner of lower triangle
+    v_[1] = ccdPtAddVertexCoords(polytope_, 0, -2 / std::sqrt(3), 0);
+    // left corner of upper triangle
+    v_[2] = ccdPtAddVertexCoords(polytope_, -0.5, -1 / std::sqrt(3), 1);
+    // left corner of lower triangle
+    v_[3] = ccdPtAddVertexCoords(polytope_, -0.5, 1 / std::sqrt(3), 0);
+    // top corner of upper triangle
+    v_[4] = ccdPtAddVertexCoords(polytope_, 0, 2 / std::sqrt(3), 1);
+    // right corner of lower triangle
+    v_[5] = ccdPtAddVertexCoords(polytope_, 0.5, 1 / std::sqrt(3), 0);
+
+    // edges on the upper triangle
+    e_[0] = ccdPtAddEdge(polytope_, v_[0], v_[2]);
+    e_[1] = ccdPtAddEdge(polytope_, v_[2], v_[4]);
+    e_[2] = ccdPtAddEdge(polytope_, v_[4], v_[0]);
+    // edges on the lower triangle
+    e_[3] = ccdPtAddEdge(polytope_, v_[1], v_[3]);
+    e_[4] = ccdPtAddEdge(polytope_, v_[3], v_[5]);
+    e_[5] = ccdPtAddEdge(polytope_, v_[5], v_[1]);
+    // edges connecting the upper triangle to the lower triangle
+    for (int i = 0; i < 6; ++i) {
+      e_[6 + i] = ccdPtAddEdge(polytope_, v_[i], v_[(i + 1) % 6]);
+    }
+
+    // upper triangle
+    f_[0] = ccdPtAddFace(polytope_, e_[0], e_[1], e_[2]);
+    // lower triangle
+    f_[1] = ccdPtAddFace(polytope_, e_[3], e_[4], e_[5]);
+    // triangles on the side
+    f_[2] = ccdPtAddFace(polytope_, e_[0], e_[7], e_[6]);
+    f_[3] = ccdPtAddFace(polytope_, e_[7], e_[8], e_[3]);
+    f_[4] = ccdPtAddFace(polytope_, e_[8], e_[9], e_[1]);
+    f_[5] = ccdPtAddFace(polytope_, e_[9], e_[10], e_[4]);
+    f_[6] = ccdPtAddFace(polytope_, e_[10], e_[11], e_[2]);
+    f_[7] = ccdPtAddFace(polytope_, e_[11], e_[6], e_[5]);
+  }
+
+  ~Hexagram() {
+    ccdPtDestroy(polytope_);
+    delete polytope_;
+  }
+
+  ccd_pt_t* polytope() const { return polytope_; }
+
+  ccd_pt_vertex_t* v(int i) const { return v_[i]; }
+
+  ccd_pt_edge_t* e(int i) const { return e_[i]; }
+
+  ccd_pt_face_t* f(int i) const { return f_[i]; }
+
+ private:
+  ccd_pt_t* polytope_;
+  ccd_pt_vertex_t* v_[6];
+  ccd_pt_edge_t* e_[12];
+  ccd_pt_face_t* f_[8];
+};
+
+template <typename T>
+bool IsElementInSet(const std::unordered_set<T>& S, const T& element) {
+  return S.find(element) != S.end();
+}
+
+GTEST_TEST(FCL_GJK_EPA, floodFillSilhouette1) {
+  Hexagram hex;
+  // Point P is just slightly above the top triangle. Only the top triangle can
+  // be seen from point P.
+  ccd_vec3_t p;
+  p.v[0] = 0;
+  p.v[1] = 0;
+  p.v[2] = 1.1;
+  std::unordered_set<ccd_pt_edge_t*> silhouette_edges;
+  std::unordered_set<ccd_pt_face_t*> obsolete_faces;
+  obsolete_faces.insert(hex.f(0));
+  std::unordered_set<ccd_pt_edge_t*> obsolete_edges;
+
+  libccd_extension::floodFillSilhouette(hex.polytope(), hex.f(0), 0, &p,
+                                        &silhouette_edges, &obsolete_faces,
+                                        &obsolete_edges);
+  EXPECT_TRUE(obsolete_edges.empty());
+  EXPECT_EQ(obsolete_faces.size(), 1u);
+  EXPECT_TRUE(IsElementInSet(obsolete_faces, hex.f(0)));
+  EXPECT_EQ(silhouette_edges.size(), 1u);
+  EXPECT_TRUE(IsElementInSet(silhouette_edges, hex.e(0)));
+
+  // Run silhouette algorithm for the other edges
+  libccd_extension::floodFillSilhouette(hex.polytope(), hex.f(0), 1, &p,
+                                        &silhouette_edges, &obsolete_faces,
+                                        &obsolete_edges);
+  libccd_extension::floodFillSilhouette(hex.polytope(), hex.f(0), 2, &p,
+                                        &silhouette_edges, &obsolete_faces,
+                                        &obsolete_edges);
+
+  EXPECT_TRUE(obsolete_edges.empty());
+  EXPECT_EQ(obsolete_faces.size(), 1u);
+  EXPECT_TRUE(IsElementInSet(obsolete_faces, hex.f(0)));
+  EXPECT_EQ(silhouette_edges.size(), 3u);
+  EXPECT_TRUE(IsElementInSet(silhouette_edges, hex.e(0)));
+  EXPECT_TRUE(IsElementInSet(silhouette_edges, hex.e(1)));
+  EXPECT_TRUE(IsElementInSet(silhouette_edges, hex.e(2)));
+}
+
+GTEST_TEST(FCL_GJK_EPA, floodFillSilhouette2) {
+  Hexagram hex;
+  // Point P is just above the top triangle by a certain height, such that it
+  // can see the triangles on the side, which connects two vertices on the upper
+  // triangle, and one vertex on the lower triangle.
+  ccd_vec3_t p;
+  p.v[0] = 0;
+  p.v[1] = 0;
+  p.v[2] = 2.1;
+  std::unordered_set<ccd_pt_edge_t*> silhouette_edges;
+  std::unordered_set<ccd_pt_face_t*> obsolete_faces;
+  obsolete_faces.insert(hex.f(0));
+  std::unordered_set<ccd_pt_edge_t*> obsolete_edges;
+
+  libccd_extension::floodFillSilhouette(hex.polytope(), hex.f(0), 0, &p,
+                                        &silhouette_edges, &obsolete_faces,
+                                        &obsolete_edges);
+  EXPECT_EQ(obsolete_edges.size(), 1u);
+  EXPECT_TRUE(IsElementInSet(obsolete_edges, hex.e(0)));
+  EXPECT_EQ(obsolete_faces.size(), 2u);
+  EXPECT_TRUE(IsElementInSet(obsolete_faces, hex.f(0)));
+  EXPECT_TRUE(IsElementInSet(obsolete_faces, hex.f(2)));
+  EXPECT_EQ(silhouette_edges.size(), 2u);
+  EXPECT_TRUE(IsElementInSet(silhouette_edges, hex.e(6)));
+  EXPECT_TRUE(IsElementInSet(silhouette_edges, hex.e(7)));
+
+  // Run silhouette algorithm for the other edges
+  libccd_extension::floodFillSilhouette(hex.polytope(), hex.f(0), 1, &p,
+                                        &silhouette_edges, &obsolete_faces,
+                                        &obsolete_edges);
+  libccd_extension::floodFillSilhouette(hex.polytope(), hex.f(0), 2, &p,
+                                        &silhouette_edges, &obsolete_faces,
+                                        &obsolete_edges);
+
+  EXPECT_EQ(obsolete_edges.size(), 3u);
+  EXPECT_TRUE(IsElementInSet(obsolete_edges, hex.e(0)));
+  EXPECT_TRUE(IsElementInSet(obsolete_edges, hex.e(1)));
+  EXPECT_TRUE(IsElementInSet(obsolete_edges, hex.e(2)));
+  EXPECT_EQ(obsolete_faces.size(), 4u);
+  EXPECT_TRUE(IsElementInSet(obsolete_faces, hex.f(0)));
+  EXPECT_TRUE(IsElementInSet(obsolete_faces, hex.f(2)));
+  EXPECT_TRUE(IsElementInSet(obsolete_faces, hex.f(4)));
+  EXPECT_TRUE(IsElementInSet(obsolete_faces, hex.f(6)));
+  EXPECT_EQ(silhouette_edges.size(), 6u);
+  EXPECT_TRUE(IsElementInSet(silhouette_edges, hex.e(6)));
+  EXPECT_TRUE(IsElementInSet(silhouette_edges, hex.e(7)));
+  EXPECT_TRUE(IsElementInSet(silhouette_edges, hex.e(8)));
+  EXPECT_TRUE(IsElementInSet(silhouette_edges, hex.e(9)));
+  EXPECT_TRUE(IsElementInSet(silhouette_edges, hex.e(10)));
+  EXPECT_TRUE(IsElementInSet(silhouette_edges, hex.e(11)));
+}
+
+GTEST_TEST(FCL_GJK_EPA, floodFillSilhouette3) {
+  Hexagram hex;
+  // Point P is just outside the upper triangle (face0) and the triangle face2,
+  // it can see both face0 and face2, but not the other triangles.
+  ccd_vec3_t p;
+  p.v[0] = 0;
+  p.v[1] = -1 / std::sqrt(3) - 0.1;
+  p.v[2] = 1.1;
+  std::unordered_set<ccd_pt_edge_t*> silhouette_edges;
+  std::unordered_set<ccd_pt_face_t*> obsolete_faces;
+  obsolete_faces.insert(hex.f(0));
+  std::unordered_set<ccd_pt_edge_t*> obsolete_edges;
+
+  libccd_extension::floodFillSilhouette(hex.polytope(), hex.f(0), 0, &p,
+                                        &silhouette_edges, &obsolete_faces,
+                                        &obsolete_edges);
+  EXPECT_EQ(obsolete_edges.size(), 1u);
+  EXPECT_TRUE(IsElementInSet(obsolete_edges, hex.e(0)));
+  EXPECT_EQ(obsolete_faces.size(), 2u);
+  EXPECT_TRUE(IsElementInSet(obsolete_faces, hex.f(0)));
+  EXPECT_TRUE(IsElementInSet(obsolete_faces, hex.f(2)));
+  EXPECT_EQ(silhouette_edges.size(), 2u);
+  EXPECT_TRUE(IsElementInSet(silhouette_edges, hex.e(6)));
+  EXPECT_TRUE(IsElementInSet(silhouette_edges, hex.e(7)));
+
+  // Run silhouette algorithm for the other edges
+  libccd_extension::floodFillSilhouette(hex.polytope(), hex.f(0), 1, &p,
+                                        &silhouette_edges, &obsolete_faces,
+                                        &obsolete_edges);
+  libccd_extension::floodFillSilhouette(hex.polytope(), hex.f(0), 2, &p,
+                                        &silhouette_edges, &obsolete_faces,
+                                        &obsolete_edges);
+
+  EXPECT_EQ(obsolete_edges.size(), 1u);
+  EXPECT_TRUE(IsElementInSet(obsolete_edges, hex.e(0)));
+  EXPECT_EQ(obsolete_faces.size(), 2u);
+  EXPECT_TRUE(IsElementInSet(obsolete_faces, hex.f(0)));
+  EXPECT_TRUE(IsElementInSet(obsolete_faces, hex.f(2)));
+  EXPECT_EQ(silhouette_edges.size(), 4u);
+  EXPECT_TRUE(IsElementInSet(silhouette_edges, hex.e(1)));
+  EXPECT_TRUE(IsElementInSet(silhouette_edges, hex.e(2)));
+  EXPECT_TRUE(IsElementInSet(silhouette_edges, hex.e(6)));
+  EXPECT_TRUE(IsElementInSet(silhouette_edges, hex.e(7)));
+}
+
+template <typename T>
+void ComparePolytopeFeature(const ccd_list_t* features_list1,
+                            const ccd_list_t* features_list2) {
+  std::unordered_set<T *> features1, features2;
+  T* feature;
+  ccdListForEachEntry(features_list1, feature, T, list) {
+    features1.insert(feature);
+  }
+  ccdListForEachEntry(features_list2, feature, T, list) {
+    features2.insert(feature);
+  }
+  EXPECT_EQ(features1.size(), features2.size());
+  for (const auto& f : features1) {
+    EXPECT_TRUE(IsElementInSet(features2, f));
+  }
+}
+
+// Returns true if the the position difference between the two vertices are
+// below tol.
+bool VertexPositionCoincide(const ccd_pt_vertex_t* v1,
+                            const ccd_pt_vertex_t* v2, ccd_real_t tol) {
+  return ccdVec3Dist2(&v1->v.v, &v2->v.v) < tol * tol;
+}
+
+// Return true, if the vertices in e1 are all mapped to the vertices in e2,
+// according to the mapping @p map_v1_to_v2.
+bool EdgeMatch(const ccd_pt_edge_t* e1, const ccd_pt_edge_t* e2,
+               const std::unordered_map<ccd_pt_vertex_t*, ccd_pt_vertex_t*>&
+                   map_v1_to_v2) {
+  ccd_pt_vertex_t* v2_expected[2];
+  for (int i = 0; i < 2; ++i) {
+    auto it = map_v1_to_v2.find(e1->vertex[i]);
+    if (it == map_v1_to_v2.end()) {
+      throw std::logic_error("vertex[" + std::to_string(i) +
+                             "] in e1 is not found in map_v1_to_v2");
+    }
+    v2_expected[i] = it->second;
+  }
+  return (v2_expected[0] == e2->vertex[0] && v2_expected[1] == e2->vertex[1]) ||
+         (v2_expected[0] == e2->vertex[1] && v2_expected[1] == e2->vertex[0]);
+}
+
+// Return true, if the edges in f1 are all mapped to the edges in f2, according
+// to the mapping @p map_e1_to_e2.
+bool TriangleMatch(
+    const ccd_pt_face_t* f1, const ccd_pt_face_t* f2,
+    const std::unordered_map<ccd_pt_edge_t*, ccd_pt_edge_t*>& map_e1_to_e2) {
+  std::unordered_set<ccd_pt_edge_t*> e2_expected;
+  for (int i = 0; i < 3; ++i) {
+    auto it = map_e1_to_e2.find(f1->edge[i]);
+    if (it == map_e1_to_e2.end()) {
+      throw std::logic_error("edge[" + std::to_string(i) +
+                             "] in f1 is not found in map_e1_to_e2");
+    }
+    e2_expected.insert(it->second);
+  }
+  for (int i = 0; i < 3; ++i) {
+    auto it = e2_expected.find(f2->edge[i]);
+    if (it == e2_expected.end()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename T>
+void MapFeature1ToFeature2(
+    const ccd_list_t* feature1_list, const ccd_list_t* feature2_list,
+    std::function<bool(const T*, const T*)> cmp_feature,
+    std::unordered_set<T*>* feature1, std::unordered_set<T*>* feature2,
+    std::unordered_map<T*, T*>* map_feature1_to_feature2) {
+  feature1->clear();
+  feature2->clear();
+  map_feature1_to_feature2->clear();
+  T* f;
+  ccdListForEachEntry(feature1_list, f, T, list) { feature1->insert(f); }
+  ccdListForEachEntry(feature2_list, f, T, list) { feature2->insert(f); }
+  EXPECT_EQ(feature1->size(), feature2->size());
+  for (const auto& f1 : *feature1) {
+    for (const auto& f2 : *feature2) {
+      if (cmp_feature(f1, f2)) {
+        map_feature1_to_feature2->emplace_hint(map_feature1_to_feature2->end(),
+                                               f1, f2);
+        break;
+      }
+    }
+  }
+  EXPECT_EQ(map_feature1_to_feature2->size(), feature1->size());
+}
+
+void ComparePolytope(const ccd_pt_t* polytope1, const ccd_pt_t* polytope2,
+                     ccd_real_t tol) {
+  // Build the mapping between the vertices in polytope1 to the vertices in
+  // polytope2.
+  std::unordered_set<ccd_pt_vertex_t *> v1_set, v2_set;
+  std::unordered_map<ccd_pt_vertex_t*, ccd_pt_vertex_t*> map_v1_to_v2;
+  MapFeature1ToFeature2<ccd_pt_vertex_t>(
+      &polytope1->vertices, &polytope2->vertices,
+      [tol](const ccd_pt_vertex_t* v1, const ccd_pt_vertex_t* v2) {
+        return VertexPositionCoincide(v1, v2, tol);
+      },
+      &v1_set, &v2_set, &map_v1_to_v2);
+
+  // Build the mapping between the edges in polytope1 to the edges in polytope2.
+  std::unordered_set<ccd_pt_edge_t *> e1_set, e2_set;
+  std::unordered_map<ccd_pt_edge_t*, ccd_pt_edge_t*> map_e1_to_e2;
+  MapFeature1ToFeature2<ccd_pt_edge_t>(
+      &polytope1->edges, &polytope2->edges,
+      [map_v1_to_v2](const ccd_pt_edge_t* e1, const ccd_pt_edge_t* e2) {
+        return EdgeMatch(e1, e2, map_v1_to_v2);
+      },
+      &e1_set, &e2_set, &map_e1_to_e2);
+
+  // Build the mapping between the faces in polytope1 to the faces in polytope2.
+  std::unordered_set<ccd_pt_face_t *> f1_set, f2_set;
+  std::unordered_map<ccd_pt_face_t*, ccd_pt_face_t*> map_f1_to_f2;
+  MapFeature1ToFeature2<ccd_pt_face_t>(
+      &polytope1->faces, &polytope2->faces,
+      [map_e1_to_e2](const ccd_pt_face_t* f1, const ccd_pt_face_t* f2) {
+        return TriangleMatch(f1, f2, map_e1_to_e2);
+      },
+      &f1_set, &f2_set, &map_f1_to_f2);
+
+  // Now make sure that the edges connected to a vertex in polytope 1, are the
+  // same edges connected to the corresponding vertex in polytope 2.
+  for (const auto& v1 : v1_set) {
+    auto v2 = map_v1_to_v2[v1];
+    std::unordered_set<ccd_pt_edge_t*> v1_edges, v2_edges;
+    ccd_pt_edge_t* e;
+    ccdListForEachEntry(&v1->edges, e, ccd_pt_edge_t, list) {
+      v1_edges.insert(e);
+    }
+    ccdListForEachEntry(&v2->edges, e, ccd_pt_edge_t, list) {
+      v2_edges.insert(e);
+    }
+    EXPECT_EQ(v1_edges.size(), v2_edges.size());
+    // Now check for each edge connecting to v1, the corresponding edge is
+    // connected to v2.
+    for (const auto& v1_e : v1_edges) {
+      auto it = map_e1_to_e2.find(v1_e);
+      if (it == map_e1_to_e2.end()) {
+        throw std::runtime_error("v1_e is not found in map_e1_to_e2.\n");
+      }
+      auto v2_e = it->second;
+      if (v2_edges.find(v2_e) == v2_edges.end()) {
+        std::cout << "error\n";
+      }
+      EXPECT_NE(v2_edges.find(v2_e), v2_edges.end());
+    }
+  }
+
+  // Make sure that the faces connected to each edge in polytope 1, are the same
+  // face connected to the corresponding face in polytope 2.
+  for (const auto& e1 : e1_set) {
+    auto e2 = map_e1_to_e2[e1];
+    ccd_pt_face_t* f2_expected[2];
+    for (int i = 0; i < 2; ++i) {
+      f2_expected[i] = map_f1_to_f2[e1->faces[i]];
+    }
+    EXPECT_TRUE(
+        (f2_expected[0] == e2->faces[0] && f2_expected[1] == e2->faces[1]) ||
+        (f2_expected[0] == e2->faces[1] && f2_expected[1] == e2->faces[0]));
+  }
+}
+
+GTEST_TEST(FCL_GJK_EPA, expandPolytope1) {
+  // Expand the equilateral tetrahedron by adding a point just outside one of
+  // the triangle face. That nearest triangle face will be deleted, and the
+  // three new faces will be added, by connecting the new vertex with the three
+  // vertices on the removed face.
+  EquilateralTetrahedron polytope(0, 0, -0.1);
+  // nearest point is on the bottom triangle
+  ccd_support_t newv;
+  newv.v.v[0] = 0;
+  newv.v.v[1] = 0;
+  newv.v.v[2] = -0.2;
+
+  const int result = libccd_extension::expandPolytope(
+      polytope.polytope(), (ccd_pt_el_t*)polytope.f(0), &newv);
+  EXPECT_EQ(result, 0);
+
+  // Construct the expanded polytope manually.
+  EquilateralTetrahedron tetrahedron(0, 0, -0.1);
+  ccd_pt_t* polytope_expected = tetrahedron.polytope();
+  // The bottom face is removed.
+  ccdPtDelFace(polytope_expected, tetrahedron.f(0));
+  // Insert the vertex.
+  ccd_pt_vertex_t* new_vertex =
+      ccdPtAddVertexCoords(polytope_expected, 0, 0, -0.2);
+  // Add new edges.
+  ccd_pt_edge_t* new_edges[3];
+  for (int i = 0; i < 3; ++i) {
+    new_edges[i] =
+        ccdPtAddEdge(polytope_expected, new_vertex, tetrahedron.v(i));
+  }
+  // Add new faces.
+  ccd_pt_face_t* new_faces[3];
+  new_faces[0] = ccdPtAddFace(polytope_expected, tetrahedron.e(0), new_edges[0],
+                              new_edges[1]);
+  new_faces[1] = ccdPtAddFace(polytope_expected, tetrahedron.e(1), new_edges[1],
+                              new_edges[2]);
+  new_faces[2] = ccdPtAddFace(polytope_expected, tetrahedron.e(2), new_edges[2],
+                              new_edges[0]);
+
+  ComparePolytope(polytope.polytope(), polytope_expected, 1E-3);
 }
 }  // namespace detail
 }  // namespace fcl

--- a/test/narrowphase/detail/convexity_based_algorithm/test_epa.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_epa.cpp
@@ -480,6 +480,9 @@ void ComparePolytope(const ccd_pt_t* polytope1, const ccd_pt_t* polytope2,
       },
       &f1_set, &f2_set, &map_f1_to_f2);
 
+  /* TODO(hongkai.dai@tri.global): enable the following check, when issue
+   https://github.com/danfis/libccd/issues/46 has been fixed. Currently 
+   ccd_pt_vertex_t.edges are garbage. 
   // Now make sure that the edges connected to a vertex in polytope 1, are the
   // same edges connected to the corresponding vertex in polytope 2.
   for (const auto& v1 : v1_set) {
@@ -506,7 +509,7 @@ void ComparePolytope(const ccd_pt_t* polytope1, const ccd_pt_t* polytope2,
       }
       EXPECT_NE(v2_edges.find(v2_e), v2_edges.end());
     }
-  }
+  }*/
 
   // Make sure that the faces connected to each edge in polytope 1, are the same
   // face connected to the corresponding face in polytope 2.

--- a/test/narrowphase/detail/convexity_based_algorithm/test_epa.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_epa.cpp
@@ -105,7 +105,7 @@ GTEST_TEST(FCL_GJK_EPA, faceNormalPointingOutward) {
         libccd_extension::faceNormalPointingOutward(p.polytope(), p.f(i));
     for (int j = 0; j < 4; ++j) {
       EXPECT_LE(ccdVec3Dot(&n, &p.v(j)->v.v),
-                ccdVec3Dot(&n, &p.f(i)->edge[0]->vertex[0]->v.v) + 1E-10);
+                ccdVec3Dot(&n, &p.f(i)->edge[0]->vertex[0]->v.v) + 1E-8);
     }
   }
 }

--- a/test/narrowphase/detail/convexity_based_algorithm/test_epa.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_epa.cpp
@@ -124,16 +124,17 @@ GTEST_TEST(FCL_GJK_EPA, sampledEPADirection) {
   // Nearest point is on the bottom triangle.
   // The sampled direction should be -z unit vector.
   EquilateralTetrahedron p1(0, 0, -0.1);
+  const ccd_real_t tol = 1E-6;
   CheckSampledEPADirection(p1.polytope(), (const ccd_pt_el_t*)p1.f(0), 0, 0, -1,
-                           1E-8);
+                           tol);
   // Nearest point is on an edge, as the origin is on an edge.
   EquilateralTetrahedron p2(0, 0.5 / std::sqrt(3), 0);
   if (p2.e(0)->faces[0] == p2.f(0)) {
     CheckSampledEPADirection(p2.polytope(), (const ccd_pt_el_t*)p2.e(0), 0, 0,
-                             -1, 1E-8);
+                             -1, tol);
   } else {
     CheckSampledEPADirection(p2.polytope(), (const ccd_pt_el_t*)p2.e(0), 0,
-                             -std::sqrt(6) / 3, std::sqrt(3) / 3, 1E-8);
+                             -std::sqrt(6) / 3, std::sqrt(3) / 3, tol);
   }
   // Nearest point is on a vertex, should throw an error.
   EquilateralTetrahedron p3(-0.5, 0.5 / std::sqrt(3), 0);

--- a/test/narrowphase/detail/convexity_based_algorithm/test_epa.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_epa.cpp
@@ -1,0 +1,145 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018. Toyota Research Institute
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of CNRS-LAAS and AIST nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @author Hongkai Dai (hongkai.dai@tri.global) */
+
+/** Tests the EPA implementation inside FCL. EPA computes the penetration
+ * depth and the points with the deepest penetration between two convex objects.
+ */
+
+#include "fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h"
+
+#include <gtest/gtest.h>
+#include <Eigen/Dense>
+
+#include "fcl/narrowphase/detail/convexity_based_algorithm/polytope.h"
+
+namespace fcl {
+namespace detail {
+class EquilateralTetrahedron {
+ public:
+  EquilateralTetrahedron() : polytope_(new ccd_pt_t) {
+    ccdPtInit(polytope_);
+    v_[0] = ccdPtAddVertexCoords(polytope_, 0.5, -0.5 / std::sqrt(3), 0);
+    v_[1] = ccdPtAddVertexCoords(polytope_, -0.5, -0.5 / std::sqrt(3), 0);
+    v_[2] = ccdPtAddVertexCoords(polytope_, 0, 1 / std::sqrt(3), 0);
+    v_[3] = ccdPtAddVertexCoords(polytope_, 0, 0, std::sqrt(2.0 / 3.0));
+    e_[0] = ccdPtAddEdge(polytope_, v_[0], v_[1]);
+    e_[1] = ccdPtAddEdge(polytope_, v_[1], v_[2]);
+    e_[2] = ccdPtAddEdge(polytope_, v_[2], v_[0]);
+    e_[3] = ccdPtAddEdge(polytope_, v_[3], v_[0]);
+    e_[4] = ccdPtAddEdge(polytope_, v_[3], v_[1]);
+    e_[5] = ccdPtAddEdge(polytope_, v_[3], v_[2]);
+    f_[0] = ccdPtAddFace(polytope_, e_[0], e_[1], e_[2]);
+    f_[1] = ccdPtAddFace(polytope_, e_[0], e_[3], e_[4]);
+    f_[2] = ccdPtAddFace(polytope_, e_[1], e_[4], e_[5]);
+    f_[3] = ccdPtAddFace(polytope_, e_[2], e_[3], e_[5]);
+  }
+
+  ccd_pt_vertex_t* v(int i) const { return v_[i]; }
+
+  ccd_pt_edge_t* e(int i) const { return e_[i]; }
+
+  ccd_pt_face_t* f(int i) const { return f_[i]; }
+
+  ccd_pt_t* polytope() const { return polytope_; }
+
+  ~EquilateralTetrahedron() {
+    ccdPtDestroy(polytope_);
+    delete polytope_;
+  }
+
+ private:
+  ccd_pt_t* polytope_;
+  ccd_pt_vertex_t* v_[4];
+  ccd_pt_edge_t* e_[6];
+  ccd_pt_face_t* f_[4];
+};
+
+GTEST_TEST(FCL_GJK_EPA, faceNormalPointingOutward) {
+  // Construct a equilateral tetrahedron, compute the normal on each face.
+  EquilateralTetrahedron p;
+
+  for (int i = 0; i < 4; ++i) {
+    const ccd_vec3_t n =
+        libccd_extension::faceNormalPointingOutward(p.polytope(), p.f(i));
+    for (int j = 0; j < 4; ++j) {
+      EXPECT_LE(ccdVec3Dot(&n, &p.v(j)->v.v),
+                ccdVec3Dot(&n, &p.f(i)->edge[0]->vertex[0]->v.v) + 1E-10);
+    }
+  }
+}
+
+GTEST_TEST(FCL_GJK_EPA, outsidePolytopeFace) {
+  EquilateralTetrahedron p;
+
+  auto CheckPointOutsidePolytopeFace = [&p](ccd_real_t x, ccd_real_t y,
+                                            ccd_real_t z, int face_index,
+                                            bool is_outside_expected) {
+    ccd_vec3_t pt;
+    pt.v[0] = x;
+    pt.v[1] = y;
+    pt.v[2] = z;
+    EXPECT_EQ(libccd_extension::outsidePolytopeFace(p.polytope(),
+                                                    p.f(face_index), &pt),
+              is_outside_expected);
+  };
+
+  // point (0, 0, 0.1) is inside the tetrahedron.
+  CheckPointOutsidePolytopeFace(0, 0, 0.1, 0, false);
+  CheckPointOutsidePolytopeFace(0, 0, 0.1, 1, false);
+  CheckPointOutsidePolytopeFace(0, 0, 0.1, 2, false);
+  CheckPointOutsidePolytopeFace(0, 0, 0.1, 3, false);
+
+  // point(0, 0, 2) is outside the tetrahedron. But it is on the "inner" side
+  // of the bottom face.
+  CheckPointOutsidePolytopeFace(0, 0, 2, 0, false);
+  CheckPointOutsidePolytopeFace(0, 0, 2, 1, true);
+  CheckPointOutsidePolytopeFace(0, 0, 2, 2, true);
+  CheckPointOutsidePolytopeFace(0, 0, 2, 3, true);
+
+  // point (0, 0, 0) is right on the bottom face.
+  CheckPointOutsidePolytopeFace(0, 0, 0, 0, false);
+  CheckPointOutsidePolytopeFace(0, 0, 0, 1, false);
+  CheckPointOutsidePolytopeFace(0, 0, 0, 2, false);
+  CheckPointOutsidePolytopeFace(0, 0, 0, 3, false);
+}
+}  // namespace detail
+}  // namespace fcl
+
+//==============================================================================
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl.cpp
@@ -231,15 +231,15 @@ void TestBoxes(S tol) {
   //---------------------------------------------------------------
   //                      Touching contact
   // An edge of box 2 is touching a face of box 1
-  //X_WB2.translation() << -1, 0, 0.5;
-  //CheckBoxEdgeBoxFaceDistance(X_WB2, tol);
+  X_WB2.translation() << -1, 0, 0.5;
+  CheckBoxEdgeBoxFaceDistance(X_WB2, tol);
 
   // Shift box 2 on y axis by 0.1m. 
   X_WB2.translation() << -1, 0.1, 0.5;
   CheckBoxEdgeBoxFaceDistance(X_WB2, tol);
 
   // Shift box 2 on y axis by -0.1m. 
-  /*X_WB2.translation() << -1, -0.1, 0.5;
+  X_WB2.translation() << -1, -0.1, 0.5;
   CheckBoxEdgeBoxFaceDistance(X_WB2, tol);
 
   //--------------------------------------------------------------
@@ -254,15 +254,11 @@ void TestBoxes(S tol) {
 
   // Shift box 2 on y axis by -0.05m. 
   X_WB2.translation() << -0.9, -0.05, 0.5;
-  CheckBoxEdgeBoxFaceDistance(X_WB2, tol);*/
+  CheckBoxEdgeBoxFaceDistance(X_WB2, tol);
 
-  /*
-   * TODO(hongkai.dai@tri.global): enable this test. This test case exposes a
-   * bug in FCL's code, as summarized in issue #301. I will enable this test
-   * once #301 is fixed.
   // Shift box 2 on y axis by -0.1m. 
-  X_WB2.translation() << -0.9, -0.1 0.5;
-  CheckBoxEdgeBoxFaceDistance(X_WB2, tol);*/
+  X_WB2.translation() << -0.9, -0.1, 0.5;
+  CheckBoxEdgeBoxFaceDistance(X_WB2, tol);
 }
 
 GTEST_TEST(FCL_GJKSignedDistance, box_box) {
@@ -270,7 +266,7 @@ GTEST_TEST(FCL_GJKSignedDistance, box_box) {
   // the default value (1E-6), the tolerance we get on the closest points are
   // only up to 1E-3. Should investigate why there is such a big difference.
   TestBoxes<double>(1E-3);
-  //TestBoxes<float>(1E-3);
+  TestBoxes<float>(1E-3);
 }
 }  // namespace detail
 }  // namespace fcl

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl.cpp
@@ -224,9 +224,12 @@ void TestBoxes(S tol) {
     GJKInitializer<S, fcl::Sphere<S>>::deleteGJKObject(o2);
   };
 
-  auto CheckBoxEdgeBoxFaceDistance = [&CheckDistance](const Transform3<S>& X_WB2, S tol) {
+  auto CheckBoxEdgeBoxFaceDistance = [&CheckDistance](
+      const Transform3<S>& X_WB2, S tol) {
     const double expected_distance = -X_WB2.translation()(0) - 1;
-    CheckDistance(X_WB2, expected_distance, Vector2<S>(-0.5, X_WB2.translation()(1)), Vector2<S>(X_WB2.translation()(0) + 0.5, X_WB2.translation()(1)), tol);
+    CheckDistance(
+        X_WB2, expected_distance, Vector2<S>(-0.5, X_WB2.translation()(1)),
+        Vector2<S>(X_WB2.translation()(0) + 0.5, X_WB2.translation()(1)), tol);
   };
   //---------------------------------------------------------------
   //                      Touching contact
@@ -234,11 +237,11 @@ void TestBoxes(S tol) {
   X_WB2.translation() << -1, 0, 0.5;
   CheckBoxEdgeBoxFaceDistance(X_WB2, tol);
 
-  // Shift box 2 on y axis by 0.1m. 
+  // Shift box 2 on y axis by 0.1m.
   X_WB2.translation() << -1, 0.1, 0.5;
   CheckBoxEdgeBoxFaceDistance(X_WB2, tol);
 
-  // Shift box 2 on y axis by -0.1m. 
+  // Shift box 2 on y axis by -0.1m.
   X_WB2.translation() << -1, -0.1, 0.5;
   CheckBoxEdgeBoxFaceDistance(X_WB2, tol);
 
@@ -248,23 +251,22 @@ void TestBoxes(S tol) {
   X_WB2.translation() << -0.9, 0, 0.5;
   CheckBoxEdgeBoxFaceDistance(X_WB2, tol);
 
-  // Shift box 2 on y axis by 0.1m. 
+  // Shift box 2 on y axis by 0.1m.
   X_WB2.translation() << -0.9, 0.1, 0.5;
   CheckBoxEdgeBoxFaceDistance(X_WB2, tol);
 
-  // Shift box 2 on y axis by -0.05m. 
+  // Shift box 2 on y axis by -0.05m.
   X_WB2.translation() << -0.9, -0.05, 0.5;
   CheckBoxEdgeBoxFaceDistance(X_WB2, tol);
 
-  // Shift box 2 on y axis by -0.1m. 
+  // Shift box 2 on y axis by -0.1m.
   X_WB2.translation() << -0.9, -0.1, 0.5;
   CheckBoxEdgeBoxFaceDistance(X_WB2, tol);
 }
 
 GTEST_TEST(FCL_GJKSignedDistance, box_box) {
-  // TODO(hongkai.dai@tri.global): By setting gjkSolver.distance_tolerance to
-  // the default value (1E-6), the tolerance we get on the closest points are
-  // only up to 1E-3. Should investigate why there is such a big difference.
+  // By setting gjkSolver.distance_tolerance to the default value (1E-6), the
+  // tolerance we get on the closest points are only up to 1E-3
   TestBoxes<double>(1E-3);
   TestBoxes<float>(1E-3);
 }

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl.cpp
@@ -231,15 +231,15 @@ void TestBoxes(S tol) {
   //---------------------------------------------------------------
   //                      Touching contact
   // An edge of box 2 is touching a face of box 1
-  X_WB2.translation() << -1, 0, 0.5;
-  CheckBoxEdgeBoxFaceDistance(X_WB2, tol);
+  //X_WB2.translation() << -1, 0, 0.5;
+  //CheckBoxEdgeBoxFaceDistance(X_WB2, tol);
 
   // Shift box 2 on y axis by 0.1m. 
   X_WB2.translation() << -1, 0.1, 0.5;
   CheckBoxEdgeBoxFaceDistance(X_WB2, tol);
 
   // Shift box 2 on y axis by -0.1m. 
-  X_WB2.translation() << -1, -0.1, 0.5;
+  /*X_WB2.translation() << -1, -0.1, 0.5;
   CheckBoxEdgeBoxFaceDistance(X_WB2, tol);
 
   //--------------------------------------------------------------
@@ -254,7 +254,7 @@ void TestBoxes(S tol) {
 
   // Shift box 2 on y axis by -0.05m. 
   X_WB2.translation() << -0.9, -0.05, 0.5;
-  CheckBoxEdgeBoxFaceDistance(X_WB2, tol);
+  CheckBoxEdgeBoxFaceDistance(X_WB2, tol);*/
 
   /*
    * TODO(hongkai.dai@tri.global): enable this test. This test case exposes a
@@ -270,7 +270,7 @@ GTEST_TEST(FCL_GJKSignedDistance, box_box) {
   // the default value (1E-6), the tolerance we get on the closest points are
   // only up to 1E-3. Should investigate why there is such a big difference.
   TestBoxes<double>(1E-3);
-  TestBoxes<float>(1E-3);
+  //TestBoxes<float>(1E-3);
 }
 }  // namespace detail
 }  // namespace fcl

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl.cpp
@@ -32,7 +32,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-/** @author Hongkai Dai*/
+/** @author Hongkai Dai */
 #include "fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h"
 
 #include <gtest/gtest.h>

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl.cpp
@@ -42,7 +42,7 @@
 
 namespace fcl {
 namespace detail {
-
+/*
 // Given two spheres, sphere 1 has radius1, and centered at point A, whose
 // position is p_FA measured and expressed in frame F; sphere 2 has radius2,
 // and centered at point B, whose position is p_FB measured and expressed in
@@ -152,6 +152,92 @@ GTEST_TEST(FCL_GJKSignedDistance, sphere_sphere) {
   // only up to 1E-3. Should investigate why there is such a big difference.
   TestNonCollidingSphereGJKSignedDistance<double>(1E-3);
   TestNonCollidingSphereGJKSignedDistance<float>(1E-3);
+}*/
+
+//----------------------------------------------------------------------------
+//                 Box test
+// Given two boxes, by changing the pose of one orientation, the boxes can
+// either penetrate, touching or separating.
+template <typename S>
+struct BoxSpecification {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  BoxSpecification(const fcl::Vector3<S>& m_size) : size(m_size) {
+    X_FB.setIdentity();
+  }
+  fcl::Vector3<S> size;
+  fcl::Transform3<S> X_FB;
+};
+
+template <typename S>
+void TestBoxes(S tol) {
+  const fcl::Vector3<S> box1_size(1, 1, 1);
+  const fcl::Vector3<S> box2_size(0.6, 0.8, 1);
+  // Put the two boxes on the xy plane.
+  // B1 is the frame rigidly attached to box 1, B2 is the frame rigidly attached
+  // to box 2. W is the world frame. X_WB1 is the pose of box 1 expressed and
+  // measured in the world frame, X_WB2 is the pose of box 2 expressed and
+  // measured in the world frame.
+  fcl::Transform3<S> X_WB1, X_WB2;
+  // Box 1 is fixed.
+  X_WB1.setIdentity();
+  X_WB1.translation() << 0, 0, 0.5;
+
+  // First fix the orientation of box 2, such that one of its diagonal (the one
+  // connecting the vertex (0.3, -0.4, 1) and (-0.3, 0.4, 1) is horizontal. If
+  // we move the position of box 2, we get different signed distance.
+  X_WB2.setIdentity();
+  X_WB2.linear() << 0.6, -0.8, 0, 0.8, 0.6, 0, 0, 0, 1;
+
+  auto CheckDistance = [&box1_size, &box2_size, &X_WB1](
+      const Transform3<S>& X_WB2, S distance_expected,
+      const Vector2<S>& p_xy_WNa_expected, const Vector2<S>& p_xy_WNb_expected,
+      S tol) {
+    fcl::Box<S> box1(box1_size);
+    fcl::Box<S> box2(box2_size);
+    void* o1 = GJKInitializer<S, fcl::Box<S>>::createGJKObject(box1, X_WB1);
+    void* o2 = GJKInitializer<S, fcl::Box<S>>::createGJKObject(box2, X_WB2);
+    S dist;
+    Vector3<S> p1, p2;
+    GJKSolver_libccd<S> gjkSolver;
+    bool res = GJKSignedDistance(
+        o1, detail::GJKInitializer<S, Box<S>>::getSupportFunction(), o2,
+        detail::GJKInitializer<S, Box<S>>::getSupportFunction(),
+        gjkSolver.max_distance_iterations, gjkSolver.distance_tolerance, &dist,
+        &p1, &p2);
+
+    if (distance_expected < 0) {
+      EXPECT_FALSE(res);
+    } else if (distance_expected > 0) {
+      EXPECT_TRUE(res);
+    }
+
+    EXPECT_NEAR(dist, distance_expected, tol);
+    std::cout << "p1: " << p1.transpose() << "\n";
+    std::cout << "p2: " << p2.transpose() << "\n";
+    EXPECT_TRUE(p1.template head<2>().isApprox(p_xy_WNa_expected, tol));
+    EXPECT_TRUE(p2.template head<2>().isApprox(p_xy_WNb_expected, tol));
+    // The z height of the closest points should be the same.
+    EXPECT_NEAR(p1(2), p2(2), tol);
+    EXPECT_GE(p1(2), 0);
+    EXPECT_GE(p2(2), 0);
+    EXPECT_LE(p1(2), 1);
+    EXPECT_LE(p2(2), 1);
+
+    GJKInitializer<S, fcl::Sphere<S>>::deleteGJKObject(o1);
+    GJKInitializer<S, fcl::Sphere<S>>::deleteGJKObject(o2);
+  };
+
+  // An edge of box 2 is touching a face of box 1
+  X_WB2.translation() << -1, 0, 0.5;
+  CheckDistance(X_WB2, 0, Vector2<S>(-0.5, 0), Vector2<S>(-0.5, 0), tol);
+}
+
+GTEST_TEST(FCL_GJKSignedDistance, box_box) {
+  // TODO(hongkai.dai@tri.global): By setting gjkSolver.distance_tolerance to
+  // the default value (1E-6), the tolerance we get on the closest points are
+  // only up to 1E-3. Should investigate why there is such a big difference.
+  TestBoxes<double>(1E-3);
+  TestBoxes<float>(1E-3);
 }
 }  // namespace detail
 }  // namespace fcl

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl.cpp
@@ -227,9 +227,25 @@ void TestBoxes(S tol) {
     GJKInitializer<S, fcl::Sphere<S>>::deleteGJKObject(o2);
   };
 
+  //---------------------------------------------------------------
+  //                      Touching contact
   // An edge of box 2 is touching a face of box 1
   X_WB2.translation() << -1, 0, 0.5;
   CheckDistance(X_WB2, 0, Vector2<S>(-0.5, 0), Vector2<S>(-0.5, 0), tol);
+
+  // Shift box 2 on y axis by 0.1m. 
+  X_WB2.translation() << -1, 0.1, 0.5;
+  CheckDistance(X_WB2, 0, Vector2<S>(-0.5, 0.1), Vector2<S>(-0.5, 0.1), tol);
+
+  //--------------------------------------------------------------
+  //                      Penetrating contact
+  // An edge of box 2 penetrates into a face of box 1
+  X_WB2.translation() << -0.9, 0, 0.5;
+  CheckDistance(X_WB2, -0.1, Vector2<S>(-0.5, 0), Vector2<S>(-0.4, 0), tol);
+
+  // Shift box 2 on y axis by 0.1m. 
+  X_WB2.translation() << -0.9, 0.1, 0.5;
+  CheckDistance(X_WB2, -0.1, Vector2<S>(-0.5, 0.1), Vector2<S>(-0.4, 0.1), tol);
 }
 
 GTEST_TEST(FCL_GJKSignedDistance, box_box) {

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
@@ -240,7 +240,7 @@ GTEST_TEST(FCL_GJK_EPA, supportEPADirection) {
   EXPECT_THROW(
       libccd_extension::supportEPADirection(
           &p3.polytope(), reinterpret_cast<const ccd_pt_el_t*>(&p3.v(0))),
-      std::runtime_error);
+      std::logic_error);
 
   // Origin is an internal point of the bottom triangle
   EquilateralTetrahedron p4(0, 0, 0);
@@ -613,9 +613,8 @@ void MapFeature1ToFeature2(
               map_feature1_to_feature2->end(), f1, f2);
           found_match = true;
         } else {
-          throw std::logic_error(
-              "There should be only one element in feature2_list that matches "
-              "with an element in feature1_list.");
+          GTEST_FAIL() << "There should be only one element in feature2_list "
+                          "that matches with an element in feature1_list.";
         }
       }
     }
@@ -1246,7 +1245,7 @@ void TestSimplexToPolytope3InGivenFrame(const Transform3<S>& X_WF) {
   ccdPtAddFace(&polytope_expected, edges_expected[0], edges_expected[1],
                edges_expected[2]);
 
-  ComparePolytope(&polytope, &polytope_expected, 1E-3);
+  ComparePolytope(&polytope, &polytope_expected, constants<S>::eps_34());
 
   ccdPtDestroy(&polytope_expected);
   ccdPtDestroy(&polytope);

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
@@ -1097,14 +1097,16 @@ void TestSimplexToPolytope3InGivenFrame(const Transform3<S>& X_WF) {
   const Vector3<S> b = ToEigenVector<S>(pts[1].v);
   const Vector3<S> c = ToEigenVector<S>(pts[2].v);
   // We first check if the origin is co-planar with vertices a, b, and c.
-  // If a, b, c and origin are co-planar, then aᵀ(b.cross(c)) = 0
+  // If a, b, c and origin are co-planar, then aᵀ · (b × c)) = 0
   EXPECT_NEAR(a.dot(b.cross(c)), 0, 1E-10);
   // Now check if origin is within the triangle, by checking the condition
-  // (a.cross(b))ᵀ(b.cross(c)) >= 0
-  // (b.cross(c))ᵀ(c.cross(a)) >= 0
-  // (c.cross(a))ᵀ(a.cross(b)) >= 0
-  // Namely the cross product a x b, b x c, c x a all points to the same
+  // (a × b)ᵀ · (b × c) >= 0
+  // (b × c)ᵀ · (c × a) >= 0
+  // (c × a)ᵀ · (a × b) >= 0
+  // Namely the cross product a × b, b × c, c × a all point to the same
   // direction.
+  // Note the check above is valid when either a, b, c is a zero vector, or
+  // they are co-linear.
   EXPECT_GE(a.cross(b).dot(b.cross(c)), 0);
   EXPECT_GE(b.cross(c).dot(c.cross(a)), 0);
   EXPECT_GE(c.cross(a).dot(a.cross(b)), 0);

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
@@ -1137,7 +1137,7 @@ void TestSimplexToPolytope3InGivenFrame(const Transform3<S>& X_WF) {
   EXPECT_EQ(polytope_vertices.size(), 4u);
   // We need to find out the vertex on the polytope, that is not the vertex
   // of the simplex.
-  ccd_pt_vertex_t* non_simplex_vertex;
+  ccd_pt_vertex_t* non_simplex_vertex = NULL;
   // A simplex vertex matches with a polytope vertex if they coincide.
   int num_matched_vertices = 0;
   for (const auto& v : polytope_vertices) {
@@ -1154,6 +1154,7 @@ void TestSimplexToPolytope3InGivenFrame(const Transform3<S>& X_WF) {
     }
   }
   EXPECT_EQ(num_matched_vertices, 3);
+  EXPECT_TRUE(non_simplex_vertex);
   // Make sure that the non-simplex vertex has the maximal support along the
   // simplex normal direction.
   // Find the two normal directions of the 3-simplex.

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
@@ -1100,9 +1100,9 @@ void TestSimplexToPolytope3InGivenFrame(const Transform3<S>& X_WF) {
   // If a, b, c and origin are co-planar, then aᵀ · (b × c)) = 0
   EXPECT_NEAR(a.dot(b.cross(c)), 0, 1E-10);
   // Now check if origin is within the triangle, by checking the condition
-  // (a × b)ᵀ · (b × c) >= 0
-  // (b × c)ᵀ · (c × a) >= 0
-  // (c × a)ᵀ · (a × b) >= 0
+  // (a × b)ᵀ · (b × c) ≥ 0
+  // (b × c)ᵀ · (c × a) ≥ 0
+  // (c × a)ᵀ · (a × b) ≥ 0
   // Namely the cross product a × b, b × c, c × a all point to the same
   // direction.
   // Note the check above is valid when either a, b, c is a zero vector, or

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
@@ -150,7 +150,8 @@ GTEST_TEST(FCL_GJK_EPA, supportEPADirection) {
   // Nearest point is on the bottom triangle.
   // The sampled direction should be -z unit vector.
   EquilateralTetrahedron p1(0, 0, -0.1);
-  const ccd_real_t tol = 1E-6;
+  // The computation on Mac is very imprecise, thus the tolerance is big.
+  const ccd_real_t tol = 3E-5;
   CheckSupportEPADirection(p1.polytope(),
                            reinterpret_cast<const ccd_pt_el_t*>(p1.f(0)),
                            Vector3<ccd_real_t>(0, 0, -1), tol);
@@ -523,12 +524,12 @@ void MapFeature1ToFeature2(
   ccdListForEachEntry(feature1_list, f, T, list) {
     auto it = feature1->find(f);
     assert(it == feature1->end());
-    feature1->insert(f);
+    feature1->emplace_hint(it, f);
   }
   ccdListForEachEntry(feature2_list, f, T, list) {
     auto it = feature2->find(f);
     assert(it == feature2->end());
-    feature2->insert(f);
+    feature2->emplace_hint(it, f);
   }
   EXPECT_EQ(feature1->size(), feature2->size());
   for (const auto& f1 : *feature1) {

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
@@ -999,7 +999,7 @@ GTEST_TEST(FCL_GJK_EPA, penEPAPosClosest_face) {
   CompareCcdVec3(p2, p2_expected, constants<ccd_real_t>::eps_78());
 }
 
-// Test Convert2SimplexToTetrahedron function.
+// Test convert2SimplexToTetrahedron function.
 // We construct a test scenario that two boxes are on the xy plane of frame F.
 // The two boxes penetrate to each other, as shown in the bottom plot.
 //              y
@@ -1114,7 +1114,7 @@ void TestSimplexToPolytope3InGivenFrame(const Transform3<S>& X_WF) {
   ccd_pt_t polytope;
   ccdPtInit(&polytope);
   ccd_pt_el_t* nearest{};
-  libccd_extension::Convert2SimplexToTetrahedron(o1, o2, &ccd, &simplex,
+  libccd_extension::convert2SimplexToTetrahedron(o1, o2, &ccd, &simplex,
                                                  &polytope, &nearest);
   // Box1 and Box2 are not touching, so nearest is set to null.
   EXPECT_EQ(nearest, nullptr);
@@ -1214,7 +1214,7 @@ void TestSimplexToPolytope3InGivenFrame(const Transform3<S>& X_WF) {
   // Now that we make sure the vertices of the polytope is correct, we will
   // check the edges and faces of the polytope. We do so by constructing an
   // expected polytope, and compare it with the polytope obtained from
-  // Convert2SimplexToTetrahedron().
+  // convert2SimplexToTetrahedron().
   ccd_pt_t polytope_expected;
   ccdPtInit(&polytope_expected);
 
@@ -1265,7 +1265,7 @@ void TestSimplexToPolytope3() {
   TestSimplexToPolytope3InGivenFrame(X_WF);
 }
 
-GTEST_TEST(FCL_GJK_EPA, Convert2SimplexToTetrahedron) {
+GTEST_TEST(FCL_GJK_EPA, convert2SimplexToTetrahedron) {
   TestSimplexToPolytope3<double>();
   TestSimplexToPolytope3<float>();
 }

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_signed_distance.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_signed_distance.cpp
@@ -307,8 +307,9 @@ void TestBoxes(S tol) {
 
   // Frame F is rotated from the world frame W.
   X_WF.setIdentity();
+  const S kPi = fcl::constants<S>::pi();
   X_WF.linear() =
-      Eigen::AngleAxis<S>(0.1 * M_PI, Vector3<S>::UnitZ()).toRotationMatrix();
+      Eigen::AngleAxis<S>(0.1 * kPi, Vector3<S>::UnitZ()).toRotationMatrix();
   TestBoxesInFrameF(tol, X_WF);
 
   // TODO(hongkai.dai): This test exposes an error in simplexToPolytope4, that
@@ -316,7 +317,7 @@ void TestBoxes(S tol) {
   // degenerate simplex in simplexToPolytope4.
   /*X_WF.translation() << 0, 0, 0;
   X_WF.linear() =
-      Eigen::AngleAxis<S>(0.1 * M_PI, Vector3<S>(1.0 / 3, 2.0 / 3, -2.0 / 3))
+      Eigen::AngleAxis<S>(0.1 * kPi, Vector3<S>(1.0 / 3, 2.0 / 3, -2.0 / 3))
           .toRotationMatrix();
   TestBoxesInFrameF(tol, X_WF);*/
 

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_signed_distance.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_signed_distance.cpp
@@ -150,9 +150,9 @@ void TestNonCollidingSphereGJKSignedDistance(S tol) {
 }
 
 GTEST_TEST(FCL_GJKSignedDistance, sphere_sphere) {
-  // TODO(hongkai.dai@tri.global): By setting gjkSolver.distance_tolerance to
-  // the default value (1E-6), the tolerance we get on the closest points are
-  // only up to the square root of 1E-6, namely 1E-3.
+  // By setting gjkSolver.distance_tolerance to the default value (1E-6), the
+  // tolerance we get on the closest points are only up to the square root of
+  // 1E-6, namely 1E-3.
   TestNonCollidingSphereGJKSignedDistance<double>(1E-3);
   TestNonCollidingSphereGJKSignedDistance<float>(1E-3);
 }

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_signed_distance.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_signed_distance.cpp
@@ -216,7 +216,7 @@ void TestBoxesInFrameF(S tol, const Transform3<S>& X_WF) {
       EXPECT_TRUE(res);
     }
 
-    //EXPECT_NEAR(dist, distance_expected, tol);
+    EXPECT_NEAR(dist, distance_expected, tol);
     const Vector3<S> p_FNa =
         X_WF.linear().transpose() * (p_WNa - X_WF.translation());
     const Vector3<S> p_FNb =
@@ -247,12 +247,12 @@ void TestBoxesInFrameF(S tol, const Transform3<S>& X_WF) {
   //---------------------------------------------------------------
   //                      Touching contact
   // An edge of box 2 is touching a face of box 1
-  /*X_FB2.translation() << -1, 0, 0.5;
+  X_FB2.translation() << -1, 0, 0.5;
   CheckBoxEdgeBoxFaceDistance(X_FB2, tol);
 
   // Shift box 2 on y axis by 0.1m.
   X_FB2.translation() << -1, 0.1, 0.5;
-  CheckBoxEdgeBoxFaceDistance(X_FB2, tol);*/
+  CheckBoxEdgeBoxFaceDistance(X_FB2, tol);
 
   // Shift box 2 on y axis by -0.1m.
   X_FB2.translation() << -1, -0.1, 0.5;
@@ -261,7 +261,7 @@ void TestBoxesInFrameF(S tol, const Transform3<S>& X_WF) {
   //--------------------------------------------------------------
   //                      Penetrating contact
   // An edge of box 2 penetrates into a face of box 1
-  /*X_FB2.translation() << -0.9, 0, 0.5;
+  X_FB2.translation() << -0.9, 0, 0.5;
   CheckBoxEdgeBoxFaceDistance(X_FB2, tol);
 
   // Shift box 2 on y axis by 0.1m.
@@ -274,14 +274,14 @@ void TestBoxesInFrameF(S tol, const Transform3<S>& X_WF) {
 
   // Shift box 2 on y axis by -0.1m.
   X_FB2.translation() << -0.9, -0.1, 0.5;
-  CheckBoxEdgeBoxFaceDistance(X_FB2, tol);*/
+  CheckBoxEdgeBoxFaceDistance(X_FB2, tol);
 }
 
 template <typename S>
 void TestBoxes(S tol) {
   // Frame F coincides with the world frame W.
   Transform3<S> X_WF;
-  /*X_WF.setIdentity();
+  X_WF.setIdentity();
   TestBoxesInFrameF(tol, X_WF);
 
   // Frame F is shifted from the world frame W.
@@ -292,26 +292,32 @@ void TestBoxes(S tol) {
   TestBoxesInFrameF(tol, X_WF);
 
   X_WF.translation() << 1, 0, 0;
-  TestBoxesInFrameF(tol, X_WF);*/
+  TestBoxesInFrameF(tol, X_WF);
 
   // Frame F is rotated from the world frame W.
   X_WF.setIdentity();
-  X_WF.linear() = Eigen::AngleAxis<S>(0.1 * M_PI, Vector3<S>::UnitZ()).toRotationMatrix();
+  X_WF.linear() =
+      Eigen::AngleAxis<S>(0.1 * M_PI, Vector3<S>::UnitZ()).toRotationMatrix();
   TestBoxesInFrameF(tol, X_WF);
-  /*X_WF.linear() =
+
+  // TODO(hongkai.dai): This test exposes an error in simplexToPolytope4, that
+  // the initial simplex can be degenerate. Should add the special case on
+  // degenerate simplex in simplexToPolytope4.
+  /*X_WF.translation() << 0, 0, 0;
+  X_WF.linear() =
       Eigen::AngleAxis<S>(0.1 * M_PI, Vector3<S>(1.0 / 3, 2.0 / 3, -2.0 / 3))
           .toRotationMatrix();
-  TestBoxesInFrameF(tol, X_WF);
+  TestBoxesInFrameF(tol, X_WF);*/
 
   // Frame F is rotated and shifted from the world frame W.
   X_WF.translation() << 0.1, 0.2, 0.3;
-  TestBoxesInFrameF(tol, X_WF);*/
+  TestBoxesInFrameF(tol, X_WF);
 }
 
 GTEST_TEST(FCL_GJKSignedDistance, box_box) {
   // By setting gjkSolver.distance_tolerance to the default value (1E-6), the
   // tolerance we get on the closest points are only up to 1E-3
-  //TestBoxes<double>(1E-3);
+  TestBoxes<double>(1E-3);
   TestBoxes<float>(1E-3);
 }
 }  // namespace detail

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_signed_distance.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_signed_distance.cpp
@@ -186,11 +186,16 @@ void TestBoxesInFrameF(S tol, const Transform3<S>& X_WF) {
   X_FB1.translation() << 0, 0, 0.5;
 
   // First fix the orientation of box 2, such that one of its diagonal (the one
-  // connecting the vertex (0.3, -0.4, 1) and (-0.3, 0.4, 1) is horizontal. If
-  // we move the position of box 2, we get different signed distance.
+  // connecting the vertex (0.3, -0.4, 1) and (-0.3, 0.4, 1) is parallel to the
+  // x axis in frame F. If we move the position of box 2, we get different
+  // signed distance.
   X_FB2.setIdentity();
   X_FB2.linear() << 0.6, -0.8, 0, 0.8, 0.6, 0, 0, 0, 1;
 
+  // p_xy_FNa is the xy position of point Na (the deepest penetration point on
+  // box 1) measured and expressed in the frame F.
+  // p_xy_FNb is the xy position of point Nb (the deepest penetration point on
+  // box 2) measured and expressed in the frame F.
   auto CheckDistance = [&box1_size, &box2_size, &X_FB1, &X_WF](
       const Transform3<S>& X_FB2, S distance_expected,
       const Vector2<S>& p_xy_FNa_expected, const Vector2<S>& p_xy_FNb_expected,
@@ -210,6 +215,8 @@ void TestBoxesInFrameF(S tol, const Transform3<S>& X_WF) {
         gjkSolver.max_distance_iterations, gjkSolver.distance_tolerance, &dist,
         &p_WNa, &p_WNb);
 
+    // It is unclear how FCL handles touching contact. It could return either
+    // true or false for touching contact.
     if (distance_expected < 0) {
       EXPECT_FALSE(res);
     } else if (distance_expected > 0) {
@@ -250,13 +257,16 @@ void TestBoxesInFrameF(S tol, const Transform3<S>& X_WF) {
   X_FB2.translation() << -1, 0, 0.5;
   CheckBoxEdgeBoxFaceDistance(X_FB2, tol);
 
-  // Shift box 2 on y axis by 0.1m.
+  // The touching face on box 1 is parallel to the y axis, so shifting box 2 on
+  // y axis still gives touching contact. Shift box 2 on y axis by 0.1m.
   X_FB2.translation() << -1, 0.1, 0.5;
   CheckBoxEdgeBoxFaceDistance(X_FB2, tol);
 
   // Shift box 2 on y axis by -0.1m.
   X_FB2.translation() << -1, -0.1, 0.5;
   CheckBoxEdgeBoxFaceDistance(X_FB2, tol);
+  // TODO(hongkai.dai@tri.global): Add other touching contact cases, including
+  // face-face, face-vertex, edge-edge, edge-vertex and vertex-vertex.
 
   //--------------------------------------------------------------
   //                      Penetrating contact

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_signed_distance.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_signed_distance.cpp
@@ -216,7 +216,7 @@ void TestBoxesInFrameF(S tol, const Transform3<S>& X_WF) {
       EXPECT_TRUE(res);
     }
 
-    EXPECT_NEAR(dist, distance_expected, tol);
+    //EXPECT_NEAR(dist, distance_expected, tol);
     const Vector3<S> p_FNa =
         X_WF.linear().transpose() * (p_WNa - X_WF.translation());
     const Vector3<S> p_FNb =
@@ -247,12 +247,12 @@ void TestBoxesInFrameF(S tol, const Transform3<S>& X_WF) {
   //---------------------------------------------------------------
   //                      Touching contact
   // An edge of box 2 is touching a face of box 1
-  X_FB2.translation() << -1, 0, 0.5;
+  /*X_FB2.translation() << -1, 0, 0.5;
   CheckBoxEdgeBoxFaceDistance(X_FB2, tol);
 
   // Shift box 2 on y axis by 0.1m.
   X_FB2.translation() << -1, 0.1, 0.5;
-  CheckBoxEdgeBoxFaceDistance(X_FB2, tol);
+  CheckBoxEdgeBoxFaceDistance(X_FB2, tol);*/
 
   // Shift box 2 on y axis by -0.1m.
   X_FB2.translation() << -1, -0.1, 0.5;
@@ -261,7 +261,7 @@ void TestBoxesInFrameF(S tol, const Transform3<S>& X_WF) {
   //--------------------------------------------------------------
   //                      Penetrating contact
   // An edge of box 2 penetrates into a face of box 1
-  X_FB2.translation() << -0.9, 0, 0.5;
+  /*X_FB2.translation() << -0.9, 0, 0.5;
   CheckBoxEdgeBoxFaceDistance(X_FB2, tol);
 
   // Shift box 2 on y axis by 0.1m.
@@ -274,7 +274,7 @@ void TestBoxesInFrameF(S tol, const Transform3<S>& X_WF) {
 
   // Shift box 2 on y axis by -0.1m.
   X_FB2.translation() << -0.9, -0.1, 0.5;
-  CheckBoxEdgeBoxFaceDistance(X_FB2, tol);
+  CheckBoxEdgeBoxFaceDistance(X_FB2, tol);*/
 }
 
 template <typename S>

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_signed_distance.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_signed_distance.cpp
@@ -34,7 +34,7 @@
 
 /** @author Hongkai Dai */
 /**
- * Test the signed distance query between two convex objects, whcn calling with
+ * Test the signed distance query between two convex objects, when calling with
  * solver = GST_LIBCCD.
  */
 #include "fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h"
@@ -216,7 +216,8 @@ void TestBoxesInFrameF(S tol, const Transform3<S>& X_WF) {
         &p_WNa, &p_WNb);
 
     // It is unclear how FCL handles touching contact. It could return either
-    // true or false for touching contact.
+    // true or false for touching contact. So, we ignore the condition where
+    // expected distance is zero.
     if (distance_expected < 0) {
       EXPECT_FALSE(res);
     } else if (distance_expected > 0) {

--- a/test/test_fcl_signed_distance.cpp
+++ b/test/test_fcl_signed_distance.cpp
@@ -78,10 +78,12 @@ void test_distance_spheresphere(GJKSolverType solver_type)
   res = distance(&s1, tf1, &s2, tf2, request, result);
 
   EXPECT_TRUE(res);
+  // request.distance_tolerance is actually the square of the distance
+  // tolerance, namely the difference between distance returned from FCL's EPA
+  // implementation and the actual distance, is less than
+  // sqrt(request.distance_tolerance).
   const S distance_tolerance = std::sqrt(request.distance_tolerance);
-  EXPECT_TRUE(std::abs(result.min_distance - (-5)) < distance_tolerance);
-  // TODO(JS): The negative distance computation using libccd requires
-  // unnecessarily high error tolerance.
+  EXPECT_NEAR(result.min_distance, -5, distance_tolerance);
 
   // TODO(JS): Only GST_LIBCCD can compute the pair of nearest points on the
   // surface of the spheres.

--- a/test/test_fcl_signed_distance.cpp
+++ b/test/test_fcl_signed_distance.cpp
@@ -78,7 +78,8 @@ void test_distance_spheresphere(GJKSolverType solver_type)
   res = distance(&s1, tf1, &s2, tf2, request, result);
 
   EXPECT_TRUE(res);
-  EXPECT_TRUE(std::abs(result.min_distance - (-5)) < 1.5e-1);
+  const S distance_tolerance = std::sqrt(request.distance_tolerance);
+  EXPECT_TRUE(std::abs(result.min_distance - (-5)) < distance_tolerance);
   // TODO(JS): The negative distance computation using libccd requires
   // unnecessarily high error tolerance.
 
@@ -86,8 +87,10 @@ void test_distance_spheresphere(GJKSolverType solver_type)
   // surface of the spheres.
   if (solver_type == GST_LIBCCD)
   {
-    EXPECT_TRUE(result.nearest_points[0].isApprox(Vector3<S>(20, 0, 0)));
-    EXPECT_TRUE(result.nearest_points[1].isApprox(Vector3<S>(-10, 0, 0)));
+    EXPECT_TRUE(result.nearest_points[0].isApprox(Vector3<S>(20, 0, 0),
+                                                  distance_tolerance));
+    EXPECT_TRUE(result.nearest_points[1].isApprox(Vector3<S>(-10, 0, 0),
+                                                  distance_tolerance));
   }
 }
 


### PR DESCRIPTION
This PR aims at computing the signed distance function with option `solver_type == GST_LIBCCD`, which is the only solver in FCL that can compute the nearest points when the objects penetrate.

Prior to this PR, the implementation in FCL has several flaws.

1. As described already in #301, that the distance from the boundary of the polytope to the origin, is computed using an un-normalized vector. Also the termination criteria is incorrect. This issue is caused by libccd's implementation, and also reported in a libccd [issue](https://github.com/danfis/libccd/issues/44).
2. FCL doesn't extract the nearest points correctly. What it did before is to loop over all the vertices of the polytope, and pick the one that is closest to the origin. But due to the convexity of the polytope, it is proved that unless the origin is on one of the vertex, the closest point from the boundary of the polytope to the origin, is always an interior point of the triangle. Thus the closest point should not be a vertex.
3. When expanding the polytope in the EPA algorithm, FCL (and LIBCCD, where the code comes from) only delete the face where the closest point lives, and then add three faces which connects the new vertex to the edges of the removed triangle. This operation does not preserve the convexity of the expanded polytope. As a result, in many cases, the closest point from the boundary of the polytope to the origin, lies on an edge of the (nonconvex) polytope, instead of an interior point of the triangle. The correct way is to remove all the faces in the old polytope, that can be seen from the new vertex.

This PR also adds unit tests to the EPA implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/305)
<!-- Reviewable:end -->
