### PR TITLE
Clean up Convex geometry (including fixing AABB computation error)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   * Switched to Eigen for math operations: [#96](https://github.com/flexible-collision-library/fcl/issues/96), [#150](https://github.com/flexible-collision-library/fcl/pull/150)
   * fcl::Transform defined to be an Isometry to facilitate inverses [#318](https://github.com/flexible-collision-library/fcl/pull/318)
 
+* Geometry
+
+  * Simplified Convex class, deprecating old constructor in favor of simpler, documented constructor: [#325](https://github.com/flexible-collision-library/fcl/pull/325)
+
 * Broadphase
 
   * Fixed redundant pair checking of SpatialHashingCollisionManager: [#156](https://github.com/flexible-collision-library/fcl/pull/156)

--- a/include/fcl/geometry/collision_geometry-inl.h
+++ b/include/fcl/geometry/collision_geometry-inl.h
@@ -141,6 +141,13 @@ S CollisionGeometry<S>::computeVolume() const
 template <typename S>
 Matrix3<S> CollisionGeometry<S>::computeMomentofInertiaRelatedToCOM() const
 {
+  // TODO(SeanCurtis-TRI): This is *horribly* inefficient. In complex cases,
+  // this will require computing volume integrals three times. The
+  // CollisionGeometry class should have a single virtual function that will
+  // return all three quantities in one call so that particular sub-classes can
+  // override this to process this answer more efficiently. The default
+  // implementation can be exactly these three calls.
+  // See: https://github.com/flexible-collision-library/fcl/issues/327.
   Matrix3<S> C = computeMomentofInertia();
   Vector3<S> com = computeCOM();
   S V = computeVolume();

--- a/include/fcl/geometry/shape/convex.h
+++ b/include/fcl/geometry/shape/convex.h
@@ -34,6 +34,7 @@
  */
 
 /** @author Jia Pan */
+/** @author Sean Curtis (2018)  Streamline API and document. */
 
 #ifndef FCL_SHAPE_CONVEX_H
 #define FCL_SHAPE_CONVEX_H
@@ -43,7 +44,37 @@
 namespace fcl
 {
 
-/// @brief Convex polytope
+/// @brief A convex polytope
+///
+/// The %Convex class represents a subset of general meshes: convex meshes.
+/// The class represents its underlying mesh quite simply: an ordered list of
+/// vertices, `V = [v₀, v₁, ..., vₙ₋₁]`, and an ordered list of faces,
+/// `F = [f₀, f₁, ..., fₘ₋₁]`, built on those vertices (via vertex _indices_).
+///
+/// A mesh is only compatible with %Convex if it satisfies the following
+/// properties:
+///   - Each face, fᵢ, must be planar and completely lies on a supporting
+///     plane πᵢ. The ordered sets `F = [f₀, f₁, ..., fₙ₋₁]` and
+///     `Π = [π₀, π₁, ..., πₙ₋₁]` are defined such that face fᵢ has supporting
+///     plane πᵢ.
+///   - A face fᵢ is defined by an ordered list of vertex indices (e.g.,
+///     `fᵢ = [iᵢ₀, iᵢ₁, ..., iᵢₖ₋₁]` (for a face with k vertices and k edges).
+///     The _ordering_ of the vertex indices must visit the face's vertices in a
+///     _counter-clockwise_ order when viewed from outside the mesh and the
+///     vertices must all lie on the face's supporting plane.
+///   - Define functions `πᵢ(x)` which report the signed distance from point `x`
+///     to plane `πᵢ`. To be convex, it must be true that
+///     `π(v) ≤ 0, ∀ π ∈ Π ∧ v ∈ V`.
+///
+/// If those requirements are satisfied, for a given convex region, the mesh
+/// with the smallest number of faces *may* have non-triangular faces. In fact,
+/// they could be polygons with an arbitrary number of edges/vertices. The
+/// %Convex class supports compact representation. But it *also* supports
+/// representations that decompose a large n-gon into a set of smaller polygons
+/// or triangles. In this case, each of the triangles supporting planes would
+/// be the same and the requirements listed above would still be satisfied.
+///
+/// @tparam S_  The scalar type; must be a valid Eigen scalar.
 template <typename S_>
 class FCL_EXPORT Convex : public ShapeBase<S_>
 {
@@ -51,65 +82,85 @@ public:
 
   using S = S_;
 
-  /// @brief Constructing a convex, providing normal and offset of each polytype surface, and the points and shape topology information 
-  Convex(Vector3<S>* plane_normals,
-         S* plane_dis,
-         int num_planes,
-         Vector3<S>* points,
-         int num_points,
-         int* polygons);
+  // TODO(SeanCurtis-TRI): A huge shopping list of issues with this class are
+  // enumerated in https://github.com/flexible-collision-library/fcl/issues/326.
+
+  /// @brief Constructor
+  ///
+  /// @note: The %Convex geometry does *not* take ownership of any of the data
+  /// provided. The data must remain valid for as long as the %Convex instance
+  /// and must be cleaned up explicitly.
+  ///
+  /// @warning: The %Convex class does *not* validate the input; it trusts that
+  /// the inputs truly represent a coherent convex polytope.
+  ///
+  /// @param num_vertices   The number of vertices defined in `vertices`.
+  /// @param vertices       The positions of the polytope vertices.
+  /// @param num_faces      The number of faces defined in `faces`.
+  /// @param faces          Encoding of the polytope faces. Must encode
+  ///                       `num_faces` number of faces. See member
+  ///                       documentation for details on encoding.
+  Convex(int num_vertices, Vector3<S>* vertices, int num_faces, int* faces);
 
   /// @brief Copy constructor 
-  Convex(const Convex& other);
+  Convex(const Convex& other) = default;
 
-  ~Convex();
+  ~Convex() = default;
 
-  /// @brief Compute AABB<S>
+  /// @brief Compute AABB<S> in the geometry's canonical frame.
   void computeLocalAABB() override;
 
-  /// @brief Get node type: a conex polytope 
+  /// @brief Get node type: a convex polytope.
   NODE_TYPE getNodeType() const override;
 
-  
-  Vector3<S>* plane_normals;
-  S* plane_dis;
+  /// @brief The total number of vertices in the convex mesh.
+  int num_vertices;
 
-  /// @brief An array of indices to the points of each polygon, it should be the number of vertices
-  /// followed by that amount of indices to "points" in counter clockwise order
-  int* polygons;
+  /// @brief The vertex positions in the geometry's frame G.
+  Vector3<S>* vertices;
 
-  Vector3<S>* points;
-  int num_points;
-  int num_edges;
-  int num_planes;
+  /// @brief The total number of faces in the convex mesh.
+  int num_faces;
 
-  struct Edge
-  {
-    int first, second;
-  };
+  /// @brief The representation of the *faces* of the convex hull.
+  ///
+  /// The array is the concatenation of an integer-based representations of each
+  /// face. A single face is encoded as a sub-array of ints where the first int
+  /// is the *number* n of vertices in the face, and the following n values
+  /// are ordered indices into `vertices` which visit the vertex values in a
+  /// *counter-clockwise* order (viewed from the outside).
+  ///
+  /// For a well-formed face `f` consisting of indices [i₀, i₁, ..., iₘ₋₁], it
+  /// should be the case that:
+  ///
+  ///    `eⱼ × eⱼ₊₁ · n̂ₚ = |eⱼ × eⱼ₊₁|, ∀ 0 ≤ j < m, j ∈ ℤ`, where
+  ///    `n̂ₚ` is the normal for plane `π` on which face `f` lies.
+  ///    `eⱼ = vertices[iⱼ] - vertices[iⱼ₋₁]` is the edge vector of face `f`
+  ///    defined by adjacent vertex indices at jᵗʰ vertex (wrapping around such
+  ///    that `j - 1 = m - 1` for `j = 0`).
+  ///
+  /// Satisfying this condition implies the following:
+  ///    1. vertices are not coincident and
+  ///    3. the indices of the face correspond to a proper counter-clockwise
+  ///       ordering.
+  int* faces;
 
-  Edge* edges;
+  /// @brief A point guaranteed to be on the interior of the convex polytope,
+  /// used for collision.
+  Vector3<S> interior_point;
 
-  /// @brief center of the convex polytope, this is used for collision: center is guaranteed in the internal of the polytope (as it is convex) 
-  Vector3<S> center;
-
-  /// based on http://number-none.com/blow/inertia/bb_inertia.doc
+  // Documentation inherited.
   Matrix3<S> computeMomentofInertia() const override;
 
-  // Documentation inherited
+  // Documentation inherited.
   Vector3<S> computeCOM() const override;
 
-  // Documentation inherited
+  // Documentation inherited.
   S computeVolume() const override;
 
   /// @brief get the vertices of some convex shape which can bound this shape in
   /// a specific configuration
   std::vector<Vector3<S>> getBoundVertices(const Transform3<S>& tf) const;
-
-protected:
-
-  /// @brief Get edge information 
-  void fillEdges();
 };
 
 using Convexf = Convex<float>;

--- a/include/fcl/geometry/shape/utility-inl.h
+++ b/include/fcl/geometry/shape/utility-inl.h
@@ -234,9 +234,9 @@ struct FCL_EXPORT ComputeBVImpl<S, AABB<S>, Convex<S>>
     const Vector3<S>& T = tf.translation();
 
     AABB<S> bv_;
-    for(int i = 0; i < s.num_points; ++i)
+    for(int i = 0; i < s.num_vertices; ++i)
     {
-      Vector3<S> new_p = R * s.points[i] + T;
+      Vector3<S> new_p = R * s.vertices[i] + T;
       bv_ += new_p;
     }
 
@@ -250,7 +250,7 @@ struct FCL_EXPORT ComputeBVImpl<S, OBB<S>, Convex<S>>
 {
   static void run(const Convex<S>& s, const Transform3<S>& tf, OBB<S>& bv)
   {
-    fit(s.points, s.num_points, bv);
+    fit(s.vertices, s.num_vertices, bv);
 
     bv.axis = tf.linear();
     bv.To = tf * bv.To;

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -2105,15 +2105,15 @@ static void supportConvex(const void* obj, const ccd_vec3_t* dir_, ccd_vec3_t* v
   ccd_real_t maxdot, dot;
   int i;
   Vector3<S>* curp;
-  const auto& center = c->convex->center;
+  const auto& center = c->convex->interior_point;
 
   ccdVec3Copy(&dir, dir_);
   ccdQuatRotVec(&dir, &c->rot_inv);
 
   maxdot = -CCD_REAL_MAX;
-  curp = c->convex->points;
+  curp = c->convex->vertices;
 
-  for(i = 0; i < c->convex->num_points; ++i, curp += 1)
+  for(i = 0; i < c->convex->num_vertices; ++i, curp += 1)
   {
     ccdVec3Set(&p, (*curp)[0] - center[0], (*curp)[1] - center[1], (*curp)[2] - center[2]);
     dot = ccdVec3Dot(&dir, &p);
@@ -2167,7 +2167,8 @@ template <typename S>
 static void centerConvex(const void* obj, ccd_vec3_t* c)
 {
   const auto *o = static_cast<const ccd_convex_t<S>*>(obj);
-  ccdVec3Set(c, o->convex->center[0], o->convex->center[1], o->convex->center[2]);
+  const Vector3<S>& p = o->convex->interior_point;
+  ccdVec3Set(c, p[0], p[1], p[2]);
   ccdQuatRotVec(c, &o->rot);
   ccdVec3Add(c, &o->pos);
 }

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/minkowski_diff-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/minkowski_diff-inl.h
@@ -183,9 +183,9 @@ Vector3<S> getSupport(
     {
       const Convex<S>* convex = static_cast<const Convex<S>*>(shape);
       S maxdot = - std::numeric_limits<S>::max();
-      Vector3<S>* curp = convex->points;
+      Vector3<S>* curp = convex->vertices;
       Vector3<S> bestv = Vector3<S>::Zero();
-      for(int i = 0; i < convex->num_points; ++i, curp+=1)
+      for(int i = 0; i < convex->num_vertices; ++i, curp+=1)
       {
         S dot = dir.dot(*curp);
         if(dot > maxdot)

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/halfspace-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/halfspace-inl.h
@@ -500,9 +500,9 @@ bool convexHalfspaceIntersect(const Convex<S>& s1, const Transform3<S>& tf1,
   Vector3<S> v;
   S depth = std::numeric_limits<S>::max();
 
-  for(int i = 0; i < s1.num_points; ++i)
+  for(int i = 0; i < s1.num_vertices; ++i)
   {
-    Vector3<S> p = tf1 * s1.points[i];
+    Vector3<S> p = tf1 * s1.vertices[i];
 
     S d = new_s2.signedDistance(p);
     if(d < depth)

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/plane-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/plane-inl.h
@@ -648,9 +648,9 @@ bool convexPlaneIntersect(const Convex<S>& s1, const Transform3<S>& tf1,
   Vector3<S> v_min, v_max;
   S d_min = std::numeric_limits<S>::max(), d_max = -std::numeric_limits<S>::max();
 
-  for(int i = 0; i < s1.num_points; ++i)
+  for(int i = 0; i < s1.num_vertices; ++i)
   {
-    Vector3<S> p = tf1 * s1.points[i];
+    Vector3<S> p = tf1 * s1.vertices[i];
 
     S d = new_s2.signedDistance(p);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -97,4 +97,5 @@ foreach(test ${tests})
   add_fcl_test(${test})
 endforeach(test)
 
+add_subdirectory(geometry)
 add_subdirectory(narrowphase)

--- a/test/geometry/CMakeLists.txt
+++ b/test/geometry/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(shape)

--- a/test/geometry/shape/CMakeLists.txt
+++ b/test/geometry/shape/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(tests
+        test_convex.cpp
+        )
+
+# Build all the tests
+foreach(test ${tests})
+    add_fcl_test(${test})
+endforeach(test)

--- a/test/geometry/shape/test_convex.cpp
+++ b/test/geometry/shape/test_convex.cpp
@@ -1,0 +1,522 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018. Toyota Research Institute
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of CNRS-LAAS and AIST nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @author Sean Curtis (sean@tri.global) (2018) */
+
+// Tests the implementation of a convex polytope geometry.
+
+#include "fcl/geometry/shape/convex.h"
+
+#include <vector>
+
+#include <Eigen/StdVector>
+#include <gtest/gtest.h>
+
+#include "eigen_matrix_compare.h"
+#include "fcl/common/types.h"
+
+namespace fcl {
+namespace {
+
+using std::max;
+
+// Necessary to satisfy Eigen's alignment requirements. See
+// http://eigen.tuxfamily.org/dox-devel/group__TopicStlContainers.html#StlContainers_vector
+template <typename S>
+using PoseVector = std::vector<Transform3<S>,
+                               Eigen::aligned_allocator<Transform3<S>>>;
+
+// Utilities to print scalar type in error messages.
+template <typename S>
+struct ScalarString {
+  static std::string value() { return "unknown"; }
+};
+
+template <>
+struct ScalarString<double> {
+  static std::string value() { return "double"; }
+};
+
+template <>
+struct ScalarString<float> {
+  static std::string value() { return "float"; }
+};
+
+// Base definition of a "unit" convex polytope. Specific instances should define
+// faces, vertices, and quantities such as volume, center of mass, and moment of
+// inertia in terms of a scale factor.
+template <typename S>
+class Polytope {
+ public:
+  explicit Polytope(S scale) : scale_(scale) {}
+
+  virtual int face_count() const = 0;
+  virtual int vertex_count() const = 0;
+  virtual S volume() const = 0;
+  virtual Vector3<S> com() const = 0;
+  virtual Matrix3<S> principal_inertia_tensor() const = 0;
+  virtual std::string description() const = 0;
+
+  // The scale of the polytope to use with test tolerances.
+  S scale() const { return scale_; }
+  const Vector3<S>* points() const { return &vertices_[0]; }
+  const int* polygons() const { return &polygons_[0]; }
+  Convex<S> MakeConvex() const {
+    // The Polytope class makes the pointers to vertices and faces const access.
+    // The Convex class calls for non-const pointers. Temporarily const-casting
+    // them to make it compatible.
+    return Convex<S>(vertex_count(), const_cast<Vector3<S>*>(points()),
+                     face_count(), const_cast<int*>(polygons()));
+  }
+  Vector3<S> min_point() const {
+    Vector3<S> m;
+    m.setConstant(std::numeric_limits<S>::max());
+    for (const Vector3<S>& v : vertices_) {
+      for (int i = 0; i < 3; ++i) {
+        if (v(i) < m(i)) m(i) = v(i);
+      }
+    }
+    return m;
+  }
+  Vector3<S> max_point() const {
+    Vector3<S> m;
+    m.setConstant(-std::numeric_limits<S>::max());
+    for (const Vector3<S>& v : vertices_) {
+      for (int i = 0; i < 3; ++i) {
+        if (v(i) > m(i)) m(i) = v(i);
+      }
+    }
+    return m;
+  }
+  Vector3<S> aabb_center() const {
+    return (max_point() + min_point()) / 2;
+  }
+  S aabb_radius() const { return (min_point() - aabb_center()).norm(); }
+  void SetPose(const Transform3<S>& X_WP) {
+    for (auto& v : vertices_) {
+      v = X_WP * v;
+    }
+  }
+
+ protected:
+  void add_vertex(const Vector3<S>& vertex) { vertices_.push_back(vertex); }
+  void add_face(std::initializer_list<int> indices) {
+    polygons_.push_back(static_cast<int>(indices.size()));
+    polygons_.insert(polygons_.end(), indices);
+  }
+  // Confirms the number of vertices and number of polygons matches the counts
+  // implied by vertex_count() and face_count(), respectively.
+  void confirm_data() {
+    // Confirm point count.
+    GTEST_ASSERT_EQ(vertex_count(), static_cast<int>(vertices_.size()));
+
+    // Confirm face count.
+    // Count the number of faces encoded in polygons_;
+    int count = 0;
+    int i = 0;
+    while (i < static_cast<int>(polygons_.size())) {
+      ++count;
+      i += polygons_[i] + 1;
+    }
+    GTEST_ASSERT_EQ(i, static_cast<int>(polygons_.size()))
+                  << "Badly defined polygons";
+    GTEST_ASSERT_EQ(face_count(), count);
+  }
+
+ private:
+  std::vector<Vector3<S>> vertices_;
+  std::vector<int> polygons_;
+  S scale_{1};
+};
+
+// A simple regular tetrahedron with edges of length `scale` centered on the
+// origin.
+template <typename S>
+class EquilateralTetrahedron : public Polytope<S> {
+ public:
+  // Constructs the tetrahedron (of edge length `s`).
+  explicit EquilateralTetrahedron(S scale) : Polytope<S>(scale), scale_(scale) {
+    // Tetrahedron vertices in the tet's canonical frame T. The tet is
+    // "centered" on the origin so that it's center of mass is simple [0, 0, 0].
+    const S z_base = -1 / S(2 * sqrt(6.));
+    Vector3<S> points_T[] = {{S(0.5), S(-0.5 / sqrt(3.)), z_base},
+                             {S(-0.5), S(-0.5 / sqrt(3.)), z_base},
+                             {S(0), S(1. / sqrt(3.)), z_base},
+                             {S(0), S(0), S(sqrt(3. / 8))}};
+    for (const auto& v : points_T) {
+      this->add_vertex(scale * v);
+    };
+
+    // Now add the polygons
+    this->add_face({0, 1, 2});
+    this->add_face({1, 0, 3});
+    this->add_face({0, 2, 3});
+    this->add_face({2, 1, 3});
+
+    this->confirm_data();
+  }
+  // Properties of the polytope.
+  int face_count() const final { return 4; }
+  int vertex_count() const final { return 4; }
+  virtual S volume() const final {
+    // This assumes unit mass.
+    S s = this->scale();
+    return S(sqrt(2) / 12) * s * s * s;
+  }
+  virtual Vector3<S> com() const final { return Vector3<S>::Zero(); }
+  virtual Matrix3<S> principal_inertia_tensor() const {
+    // TODO(SeanCurtis-TRI): Replace this with a legitimate tensor.
+    throw std::logic_error("Not implemented yet");
+  };
+  std::string description() const final {
+    return "Tetrahedron with scale: " + std::to_string(this->scale());
+  }
+
+ private:
+  S scale_{0};
+};
+
+// A simple cube with sides of length `scale`.
+template <typename S>
+class Cube : public Polytope<S> {
+ public:
+  Cube(S scale) : Polytope<S>(scale) {
+    // Cube vertices in the cube's canonical frame C.
+    Vector3<S> points_C[] = {{S(-0.5), S(-0.5), S(-0.5)},   // v0
+                             {S(0.5), S(-0.5), S(-0.5)},    // v1
+                             {S(-0.5), S(0.5), S(-0.5)},    // v2
+                             {S(0.5), S(0.5), S(-0.5)},     // v3
+                             {S(-0.5), S(-0.5), S(0.5)},    // v4
+                             {S(0.5), S(-0.5), S(0.5)},     // v5
+                             {S(-0.5), S(0.5), S(0.5)},     // v6
+                             {S(0.5), S(0.5), S(0.5)}};     // v7
+    for (const auto& v : points_C) {
+      this->add_vertex(scale * v);
+    }
+
+    // Now add the polygons
+    this->add_face({1, 3, 7, 5});    // +x
+    this->add_face({0, 4, 6, 2});    // -x
+    this->add_face({4, 5, 7, 6});    // +y
+    this->add_face({0, 2, 3, 1});    // -y
+    this->add_face({6, 7, 3, 2});    // +z
+    this->add_face({0, 1, 5, 4});    // -z
+
+    this->confirm_data();
+  }
+
+  // Polytope properties
+  int face_count() const final { return 6; }
+  int vertex_count() const final { return 8; }
+  virtual S volume() const final {
+    S s = this->scale();
+    return s * s * s;
+  }
+  virtual Vector3<S> com() const final { return Vector3<S>::Zero(); }
+  virtual Matrix3<S> principal_inertia_tensor() const {
+    S scale_sqd = this->scale() * this->scale();
+    // This assumes unit mass.
+    return Eigen::DiagonalMatrix<S, 3>(1. / 6., 1. / 6., 1. / 6.) * scale_sqd;
+  };
+  std::string description() const final {
+    return "Cube with scale: " + std::to_string(this->scale());
+  }
+};
+
+void testConvexConstruction() {
+  Cube<double> cube{1};
+  // Set the cube at some other location to make sure that the interior point
+  // test/ doesn't pass just because it initialized to zero.
+  Vector3<double> p_WB(1, 2, 3);
+  cube.SetPose(Transform3<double>(Eigen::Translation3d(p_WB)));
+  Convex<double> convex = cube.MakeConvex();
+
+  // This doesn't depend on the correct logic in the constructor. But this is
+  // as convenient a time as any to test that it reports the right node type.
+  EXPECT_EQ(convex.getNodeType(), GEOM_CONVEX);
+
+  // The constructor computes the interior point.
+  EXPECT_TRUE(CompareMatrices(convex.interior_point, p_WB));
+}
+
+template <template <typename> class Shape, typename S>
+void testAABBComputation(const Shape<S>& model, const Transform3<S>& X_WS) {
+  Shape<S> shape(model);
+  shape.SetPose(X_WS);
+  Convex<S> convex = shape.MakeConvex();
+  convex.computeLocalAABB();
+
+  typename constants<S>::Real eps = constants<S>::eps();
+  EXPECT_NEAR(shape.aabb_radius(), convex.aabb_radius, eps);
+  EXPECT_TRUE(CompareMatrices(shape.aabb_center(), convex.aabb_center, eps));
+  EXPECT_TRUE(CompareMatrices(shape.min_point(), convex.aabb_local.min_, eps));
+  EXPECT_TRUE(CompareMatrices(shape.max_point(), convex.aabb_local.max_, eps));
+}
+
+template <template <typename> class Shape, typename S>
+void testVolume(const Shape<S>& model, const Transform3<S>& X_WS,
+                int bits_lost) {
+  // If we're losing more than 10 bits, then we have a major problem.
+  GTEST_ASSERT_LE(bits_lost, 10);
+
+  Shape<S> shape(model);
+  shape.SetPose(X_WS);
+  Convex<S> convex = shape.MakeConvex();
+
+  // We want the basic tolerance to be near machine precision. The invocation
+  // of this function indicates how many bits of precision are expected to be
+  // lost and the machine epsilon is modified to account for this.
+  typename constants<S>::Real eps = (1 << bits_lost) * constants<S>::eps();
+
+  // We want to do a *relative* comparison. We scale our eps by the volume so
+  // that large volumes have tolerances proportional to the actual true value.
+  S scale = max(shape.volume(), S(1));
+  EXPECT_NEAR(shape.volume(), convex.computeVolume(), eps * scale)
+            << shape.description() << " at\n" << X_WS.matrix()
+            << "\nusing scalar: " << ScalarString<S>::value();
+}
+
+template <template <typename> class Shape, typename S>
+void testCenterOfMass(const Shape<S>& model, const Transform3<S>& X_WS,
+                      int bits_lost) {
+  // If we're losing more than 10 bits, then we have a major problem.
+  GTEST_ASSERT_LE(bits_lost, 10);
+
+  Shape<S> shape(model);
+  shape.SetPose(X_WS);
+  Convex<S> convex = shape.MakeConvex();
+
+  // We want the basic tolerance to be near machine precision. The invocation
+  // of this function indicates how many bits of precision are expected to be
+  // lost and the machine epsilon is modified to account for this.
+  typename constants<S>::Real eps = (1 << bits_lost) * constants<S>::eps();
+
+  // We want to do a *relative* comparison. The center-of-mass calculation is a
+  // volume-weighted calculation. So, the relative tolerance should scale with
+  // volume.
+  S scale = max(shape.volume(), S(1));
+  EXPECT_TRUE(
+      CompareMatrices(X_WS * shape.com(), convex.computeCOM(), eps * scale))
+            << shape.description() << " at\n" << X_WS.matrix()
+            << "\nusing scalar: " << ScalarString<S>::value();
+}
+
+template <template <typename> class Shape, typename S>
+void testMomentOfInertia(const Shape<S>& model, const Transform3<S>& X_WS,
+                         int bits_lost) {
+  // If we're losing more than 10 bits, then we have a major problem.
+  GTEST_ASSERT_LE(bits_lost, 10);
+
+  Shape<S> shape(model);
+  shape.SetPose(X_WS);
+  Convex<S> convex = shape.MakeConvex();
+
+  // We want the basic tolerance to be near machine precision. The invocation
+  // of this function indicates how many bits of precision are expected to be
+  // lost and the machine epsilon is modified to account for this.
+  typename constants<S>::Real eps = (1 << bits_lost) * constants<S>::eps();
+
+  // We want to do a *relative* comparison. The inertia calculation is a
+  // volume-weighted calculation. So, the relative tolerance should scale with
+  // volume.
+  S scale = max(shape.volume(), S(1));
+  EXPECT_TRUE(
+      CompareMatrices(X_WS.linear().transpose() *
+                          shape.principal_inertia_tensor() * X_WS.linear(),
+                      convex.computeMomentofInertiaRelatedToCOM(), eps * scale))
+            << shape.description() << " at\n" << X_WS.matrix()
+            << "\nusing scalar: " << ScalarString<S>::value();
+}
+
+template <typename S>
+PoseVector<S> GetPoses() {
+  PoseVector<S> poses;
+  // Identity.
+  poses.push_back(Transform3<S>::Identity());
+
+  Transform3<S> X_WS;
+  // 90-degree rotation around each axis, in turn.
+  for (int i = 0; i < 3; ++i) {
+    X_WS = Transform3<S>::Identity();
+    X_WS.linear() = AngleAxis<S>(constants<S>::pi() / 2,
+                                 Vector3<S>::Unit(i)).matrix();
+    poses.push_back(X_WS);
+  }
+
+  // Small angle away from identity.
+  X_WS.linear() = AngleAxis<S>(S(1e-5), Vector3<S>{1, 2, 3}.normalized())
+      .matrix();
+  poses.push_back(X_WS);
+
+  // 45-degree angle to move away from axis-aligned as much as possible.
+  X_WS.linear() = AngleAxis<S>(constants<S>::pi() / 4,
+                               Vector3<S>{1, 2, 3}.normalized()).matrix();
+  poses.push_back(X_WS);
+
+  // We don't test translation because that would imply the geometry is
+  // defined away from its own frame's origin. And that's just a recklessly
+  // stupid thing to do. Given the *current* algorithms, this will degrade
+  // the answers based on the *distance* to the origin.
+  // TODO(SeanCurtis-TRI): When the algorithms are no longer sensitive to vertex
+  // position relative to the origin, add tests that show that.
+
+  return poses;
+}
+
+std::vector<double> get_test_scales() {
+  return std::vector<double>{0.001, 1, 1000.};
+}
+
+template <template <typename> class Shape, typename S>
+void testLocalAABBComputation(const Shape<S>& shape) {
+  for (const auto& X_WP : GetPoses<S>()) {
+    testAABBComputation<Shape>(shape, X_WP);
+  }
+}
+
+template <template <typename> class Shape, typename S>
+void testVolumeComputation(const Shape<S>& shape, int bits_lost) {
+  for (const auto& X_WP : GetPoses<S>()) {
+    testVolume<Shape>(shape, X_WP, bits_lost);
+  }
+}
+
+template <template <typename> class Shape, typename S>
+void testCenterOfMassComputation(const Shape<S>& shape, int bits_lost) {
+  for (const auto& X_WP : GetPoses<S>()) {
+    testCenterOfMass<Shape>(shape, X_WP, bits_lost);
+  }
+}
+
+template <template <typename> class Shape, typename S>
+void testMomentOfInertiaComputation(const Shape<S>& shape, int bits_lost) {
+  for (const auto& X_WP : GetPoses<S>()) {
+    testMomentOfInertia<Shape>(shape, X_WP, bits_lost);
+  }
+}
+
+GTEST_TEST(ConvexGeometry, Constructor) {
+  testConvexConstruction();
+}
+
+GTEST_TEST(ConvexGeometry, LocalAABBComputation_Cube) {
+  for (double scale : get_test_scales()) {
+    Cube<double> cube_d(scale);
+    testLocalAABBComputation(cube_d);
+    Cube<float> cube_f(static_cast<float>(scale));
+    testLocalAABBComputation(cube_f);
+  }
+}
+
+GTEST_TEST(ConvexGeometry, Volume_Cube) {
+  for (double scale : get_test_scales()) {
+    Cube<double> cube_d(scale);
+    testVolumeComputation(cube_d, 0);
+    Cube<float> cube_f(static_cast<float>(scale));
+    // Apparently, no bits of precision are lost (relative to machine precision)
+    // on the cube volume *except* for the *large* cube in single precision.
+    // The reason for this isn't obvious, but probably a coincidental artifact
+    // of the particular configuration.
+    const int bits_lost = scale > 1 ? 2 : 0;
+    testVolumeComputation(cube_f, bits_lost);
+  }
+}
+
+GTEST_TEST(ConvexGeometry, CenterOfMass_Cube) {
+  for (double scale : get_test_scales()) {
+    Cube<double> cube_d(scale);
+    testCenterOfMassComputation(cube_d, 0);
+    Cube<float> cube_f(static_cast<float>(scale));
+    testCenterOfMassComputation(cube_f, 0);
+  }
+}
+
+GTEST_TEST(ConvexGeometry, MomentOfInertia_Cube) {
+  for (double scale : get_test_scales()) {
+    Cube<double> cube_d(scale);
+    testMomentOfInertiaComputation(cube_d, 0);
+    Cube<float> cube_f(static_cast<float>(scale));
+    testMomentOfInertiaComputation(cube_f, 0);
+  }
+}
+
+GTEST_TEST(ConvexGeometry, LocalAABBComputation_Tetrahedron) {
+  for (double scale : get_test_scales()) {
+    EquilateralTetrahedron<double> tet_d(scale);
+    testLocalAABBComputation(tet_d);
+    EquilateralTetrahedron<float> tet_f(static_cast<float>(scale));
+    testLocalAABBComputation(tet_f);
+  }
+}
+
+GTEST_TEST(ConvexGeometry, Volume_Tetrahedron) {
+  for (double scale : get_test_scales()) {
+    EquilateralTetrahedron<double> tet_d(scale);
+    // Apparently, no bits of precision are lost (relative to machine precision)
+    // on the tet volume *except* for the *large* test in double precision.
+    // The reason for this isn't obvious, but probably a coincidental artifact
+    // of the particular configuration.
+    const int bits_lost = scale > 1 ? 1 : 0;
+    testVolumeComputation(tet_d, bits_lost);
+    EquilateralTetrahedron<float> tet_f(static_cast<float>(scale));
+    testVolumeComputation(tet_f, 0);
+  }
+}
+
+GTEST_TEST(ConvexGeometry, CenterOfMass_Tetrahedron) {
+  for (double scale : get_test_scales()) {
+    EquilateralTetrahedron<double> tet_d(scale);
+    testCenterOfMassComputation(tet_d, 0);
+    EquilateralTetrahedron<float> tet_f(static_cast<float>(scale));
+    testCenterOfMassComputation(tet_f, 0);
+  }
+}
+
+// TODO(SeanCurtis-TRI): Add Tetrahedron inertia unit test.
+
+// TODO(SeanCurtis-TRI): Extend the moment of inertia test.
+//   Tesselate smooth geometries (sphere, ellipsoid, cone, etc) which have
+//   well-known closed-form values for the tensor product. Confirm that as
+//   the tesselation gets finer, that the answer converges to the reference
+//   solution.
+
+}  // namespace
+}  // namespace fcl
+
+//==============================================================================
+int main(int argc, char *argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
The Convex geometry had an error in computing its local AABB. This fixes that error.

It includes a unit test that exposes the error without the fix and validates the fix.

This also, incidentally, cleans up some of the documentation.

NOTE: The unit tests on the `Convex` geometry are incomplete. This is noted in the new tests.
replaces #250 (this is part of that PR).

resolves #248 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/325)
<!-- Reviewable:end -->
