### PR TITLE
Fix face normal pointing outward

### DIFF
--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -887,7 +887,7 @@ static ccd_vec3_t faceNormalPointingOutward(const ccd_pt_t* polytope,
     // value implies that the normal vector is pointing in the wrong direction;
     // flip it.
     ccdVec3Scale(&dir, ccd_real_t(-1));
-  } else if (projection_to_origin >= -tol && projection_to_origin <= tol) {
+  } else if (-tol <= projection_to_origin && projection_to_origin <= tol) {
     // The origin is close to the plane of the face. Pick another vertex to test
     // the normal direction.
     ccd_real_t max_projection_to_plane = -CCD_REAL_MAX;

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -902,11 +902,11 @@ static ccd_vec3_t faceNormalPointingOutward(const ccd_pt_t* polytope,
         // direction of `dir`. So we flip dir to point it outward from the
         // polytope.
         ccdVec3Scale(&dir, ccd_real_t(-1));
-        break;
+        return dir;
       } else if (projection < -tol) {
         // The vertex is at least 1cm away from the face plane, on the opposite
         // direction of `dir`. So `dir` points outward already.
-        break;
+        return dir;
       } else {
         max_projection = std::max(max_projection, projection);
         min_projection = std::min(min_projection, projection);

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -879,48 +879,48 @@ static ccd_vec3_t faceNormalPointingOutward(const ccd_pt_t* polytope,
   // seems large, the fall through case of comparing the maximum distance will
   // always guarantee correctness.
   const ccd_real_t dist_tol = 0.01;
-  ccd_real_t tol = dist_tol * dir_norm;
-  // origin_distance_to_plane computes the signed (and scaled) distance from the
-  // origin to the plane nᵀ * (x - v) = 0 where v is a point on the triangle.
-  ccd_real_t origin_distance_to_plane =
-      ccdVec3Dot(&dir, &(face->edge[0]->vertex[0]->v.v));
-  if (origin_distance_to_plane < -tol) {
+  // origin_distance_to_plane computes the signed distance from the origin to
+  // the plane nᵀ * (x - v) = 0 coinciding with the triangle,  where v is a
+  // point on the triangle.
+  const ccd_real_t origin_distance_to_plane =
+      ccdVec3Dot(&dir, &(face->edge[0]->vertex[0]->v.v)) / dir_norm;
+  if (origin_distance_to_plane < -dist_tol) {
     // Origin is more than `dist_tol` away from the plane, but the negative
     // value implies that the normal vector is pointing in the wrong direction;
     // flip it.
     ccdVec3Scale(&dir, ccd_real_t(-1));
-  } else if (-tol <= origin_distance_to_plane &&
-             origin_distance_to_plane <= tol) {
+  } else if (-dist_tol <= origin_distance_to_plane &&
+             origin_distance_to_plane <= dist_tol) {
     // The origin is close to the plane of the face. Pick another vertex to test
     // the normal direction.
     ccd_real_t max_distance_to_plane = -CCD_REAL_MAX;
     ccd_real_t min_distance_to_plane = CCD_REAL_MAX;
     ccd_pt_vertex_t* v;
-    // If the magnitude of the scaled_distance_to_plane is larger than
-    // tolerance, then it means one of the vertices is at least `dist_tol` away
-    // from the plane coinciding with the face.
+    // If the magnitude of the distance_to_plane is larger than dist_tol,
+    // then it means one of the vertices is at least `dist_tol` away from the
+    // plane coinciding with the face.
     ccdListForEachEntry(&polytope->vertices, v, ccd_pt_vertex_t, list) {
-      // scaled_distance_to_plane is the scaled (and signed) distance from the
-      // vertex v->v.v to the face, i.e., scaled_distance_to_plane = nᵀ *
+      // distance_to_plane is the signed distance from the
+      // vertex v->v.v to the face, i.e., distance_to_plane = nᵀ *
       // (v->v.v - face_point). Note that origin_distance_to_plane = nᵀ *
       // face_point.
-      ccd_real_t scaled_distance_to_plane =
-          ccdVec3Dot(&dir, &(v->v.v)) - origin_distance_to_plane;
-      if (scaled_distance_to_plane > tol) {
+      const ccd_real_t distance_to_plane =
+          ccdVec3Dot(&dir, &(v->v.v)) / dir_norm - origin_distance_to_plane;
+      if (distance_to_plane > dist_tol) {
         // The vertex is at least dist_tol away from the face plane, on the same
         // direction of `dir`. So we flip dir to point it outward from the
         // polytope.
         ccdVec3Scale(&dir, ccd_real_t(-1));
         return dir;
-      } else if (scaled_distance_to_plane < -tol) {
+      } else if (distance_to_plane < -dist_tol) {
         // The vertex is at least `dist_tol` away from the face plane, on the
         // opposite direction of `dir`. So `dir` points outward already.
         return dir;
       } else {
         max_distance_to_plane =
-            std::max(max_distance_to_plane, scaled_distance_to_plane);
+            std::max(max_distance_to_plane, distance_to_plane);
         min_distance_to_plane =
-            std::min(min_distance_to_plane, scaled_distance_to_plane);
+            std::min(min_distance_to_plane, distance_to_plane);
       }
     }
     // If max_distance_to_plane > |min_distance_to_plane|, it means that the

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -880,43 +880,47 @@ static ccd_vec3_t faceNormalPointingOutward(const ccd_pt_t* polytope,
   // always guarantee correctness.
   const ccd_real_t dist_tol = 0.01;
   ccd_real_t tol = dist_tol * dir_norm;
-  ccd_real_t projection = ccdVec3Dot(&dir, &(face->edge[0]->vertex[0]->v.v));
-  if (projection < -tol) {
+  ccd_real_t projection_to_origin =
+      ccdVec3Dot(&dir, &(face->edge[0]->vertex[0]->v.v));
+  if (projection_to_origin < -tol) {
     // Origin is more than `dist_tol` away from the plane, but the negative
     // value implies that the normal vector is pointing in the wrong direction;
     // flip it.
     ccdVec3Scale(&dir, ccd_real_t(-1));
-  } else if (projection >= -tol && projection <= tol) {
+  } else if (projection_to_origin >= -tol && projection_to_origin <= tol) {
     // The origin is close to the plane of the face. Pick another vertex to test
     // the normal direction.
-    ccd_real_t max_projection = -CCD_REAL_MAX;
-    ccd_real_t min_projection = CCD_REAL_MAX;
+    ccd_real_t max_projection_to_plane = -CCD_REAL_MAX;
+    ccd_real_t min_projection_to_plane = CCD_REAL_MAX;
     ccd_pt_vertex_t* v;
-    // If the magnitude of the projection is larger than tolerance, then it
-    // means one of the vertices is at least 1cm away from the plane coinciding
-    // with the face.
+    // If the magnitude of the projection_to_plane is larger than tolerance,
+    // then it means one of the vertices is at least 1cm away from the plane
+    // coinciding with the face.
     ccdListForEachEntry(&polytope->vertices, v, ccd_pt_vertex_t, list) {
-      projection = ccdVec3Dot(&dir, &(v->v.v)); 
-      if (projection > tol) {
+      ccd_real_t projection_to_plane =
+          ccdVec3Dot(&dir, &(v->v.v)) - projection_to_origin;
+      if (projection_to_plane > tol) {
         // The vertex is at least dist_tol away from the face plane, on the same
         // direction of `dir`. So we flip dir to point it outward from the
         // polytope.
         ccdVec3Scale(&dir, ccd_real_t(-1));
         return dir;
-      } else if (projection < -tol) {
+      } else if (projection_to_plane < -tol) {
         // The vertex is at least 1cm away from the face plane, on the opposite
         // direction of `dir`. So `dir` points outward already.
         return dir;
       } else {
-        max_projection = std::max(max_projection, projection);
-        min_projection = std::min(min_projection, projection);
+        max_projection_to_plane =
+            std::max(max_projection_to_plane, projection_to_plane);
+        min_projection_to_plane =
+            std::min(min_projection_to_plane, projection_to_plane);
       }
     }
-    // If max_projection > |min_projection|, it means that the vertices that are 
-    // on the positive side of the plane, has a larger maximal distance than the
-    // vertices on the negative side of the plane. Thus we regard that `dir`
-    // points into the polytope. Hence we flip `dir`. 
-    if (max_projection > std::abs(min_projection)) {
+    // If max_projection_to_plane > |min_projection_to_plane|, it means that the
+    // vertices that are on the positive side of the plane, has a larger maximal
+    // distance than the vertices on the negative side of the plane. Thus we
+    // regard that `dir` points into the polytope. Hence we flip `dir`.
+    if (max_projection_to_plane > std::abs(min_projection_to_plane)) {
       ccdVec3Scale(&dir, ccd_real_t(-1));
     }
   }

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -860,6 +860,8 @@ static ccd_vec3_t faceNormalPointingOutward(const ccd_pt_t* polytope,
   // this corner case.
   ccdVec3Cross(&dir, &e1, &e2);
   const ccd_real_t dir_norm = std::sqrt(ccdVec3Len2(&dir));
+  ccd_vec3_t unit_dir = dir;
+  ccdVec3Scale(&unit_dir, 1.0 / dir_norm);
   // The winding of the triangle is *not* guaranteed. The normal `n = e₁ × e₂`
   // may point inside or outside. We rely on the fact that the origin lies
   // within the polytope to resolve this ambiguity. A vector from the origin to
@@ -883,7 +885,7 @@ static ccd_vec3_t faceNormalPointingOutward(const ccd_pt_t* polytope,
   // the plane nᵀ * (x - v) = 0 coinciding with the triangle,  where v is a
   // point on the triangle.
   const ccd_real_t origin_distance_to_plane =
-      ccdVec3Dot(&dir, &(face->edge[0]->vertex[0]->v.v)) / dir_norm;
+      ccdVec3Dot(&unit_dir, &(face->edge[0]->vertex[0]->v.v));
   if (origin_distance_to_plane < -dist_tol) {
     // Origin is more than `dist_tol` away from the plane, but the negative
     // value implies that the normal vector is pointing in the wrong direction;
@@ -905,7 +907,7 @@ static ccd_vec3_t faceNormalPointingOutward(const ccd_pt_t* polytope,
       // (v->v.v - face_point). Note that origin_distance_to_plane = nᵀ *
       // face_point.
       const ccd_real_t distance_to_plane =
-          ccdVec3Dot(&dir, &(v->v.v)) / dir_norm - origin_distance_to_plane;
+          ccdVec3Dot(&unit_dir, &(v->v.v)) - origin_distance_to_plane;
       if (distance_to_plane > dist_tol) {
         // The vertex is at least dist_tol away from the face plane, on the same
         // direction of `dir`. So we flip dir to point it outward from the

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
@@ -221,15 +221,13 @@ GTEST_TEST(FCL_GJK_EPA, faceNormalPointingOutward) {
 }
 
 GTEST_TEST(FCL_GJK_EPA, faceNormalPointingOutwardOriginNearFace1) {
-  // The top face of the tetrahedron is right above the origin, and the origin
-  // is near the top face (with distance being 0.5mm, this distance is less
-  // than the threshold, such that the origin is not regarded as a good witness
-  // point to determine the direction of the top face normal). In this
-  // tetrahedron, e₀ × e₁ on the top face points upward (and outward from the
-  // tetrahedron). The bottom vertex vertices[3] is far away from the top face,
-  // that this vertex serves as a good witness point to determine the direction
-  // of the normal vector of the top face. This test is created when addressing
-  // the test failure from PR 334.
+  // Creates a downward pointing tetrahedron which contains the origin. The
+  // origin is just below "top" face of this tetrahedron. The remaining vertex
+  // is far enough away from the top face that it is considered a reliable
+  // witness to determine the direction of the face's normal. The top face is
+  // not quite parallel with the z = 0 plane. This test captures the failure
+  // condition reported in PR 334 -- a logic error made it so the reliable
+  // witness could be ignored.
   const double face0_origin_distance = 0.005;
   std::array<fcl::Vector3<ccd_real_t>, 4> vertices;
   vertices[0] << 0.5, -0.5, face0_origin_distance;
@@ -256,16 +254,11 @@ GTEST_TEST(FCL_GJK_EPA, faceNormalPointingOutwardOriginNearFace1) {
 }
 
 GTEST_TEST(FCL_GJK_EPA, faceNormalPointingOutwardOriginNearFace2) {
-  // The top face of the tetrahedron is right above the origin, and the origin
-  // is near the top face (with distance being 0.5mm, this distance is less
-  // than the threshold, such that the origin is not regarded as a good witness
-  // point to determine the direction of the top face normal). In this
-  // tetrahedron, e₀ × e₁ on the top face points upward (and outward from the
-  // tetrahedron). The bottom vertex vertices[3] is also close to the top face,
-  // such that the bottom vertex won't be regarded as a definitive good witness
-  // point to determine the direction of the top face normal.
-  // faceNormalPointingOutward will loop through all vertices, and check along
-  // which direction the vertices has larger projection to the top face.
+  // Similar to faceNormalPointingOutwardOriginNearFace1 with an important
+  // difference: the fourth vertex is no longer a reliable witness; it lies
+  // within the distance tolerance. However, it is unambiguously farther off the
+  // plane of the top face than those that form the face. This confirms when
+  // there are no obviously reliable witness that the most distant point serves.
   const double face0_origin_distance = 0.005;
   std::array<fcl::Vector3<ccd_real_t>, 4> vertices;
   vertices[0] << 0.5, -0.5, face0_origin_distance;

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
@@ -495,8 +495,8 @@ GTEST_TEST(FCL_GJK_EPA, isOutsidePolytopeFace_DegenerateFace_Colinear) {
 
   // This test point should pass w.r.t. the big face.
   ccd_vec3_t pt{{0, 0, -10}};
-  EXPECT_TRUE(libccd_extension::isOutsidePolytopeFace(&p.polytope(), &p.f(0),
-                                                      &pt));
+  EXPECT_TRUE(
+      libccd_extension::isOutsidePolytopeFace(&p.polytope(), &p.f(0), &pt));
   // Face 1, however, is definitely colinear.
   // NOTE: For platform compatibility, the assertion message is pared down to
   // the simplest component: the actual function call in the assertion.
@@ -505,7 +505,6 @@ GTEST_TEST(FCL_GJK_EPA, isOutsidePolytopeFace_DegenerateFace_Colinear) {
       ".*!triangle_area_is_zero.*");
 }
 #endif
-
 
 // Construct a polytope with the following shape, namely an equilateral triangle
 // on the top, and an equilateral triangle of the same size, but rotate by 60

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
@@ -41,6 +41,7 @@
 
 #include "fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h"
 
+#include <array>
 #include <memory>
 
 #include <gtest/gtest.h>

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
@@ -222,11 +222,14 @@ GTEST_TEST(FCL_GJK_EPA, faceNormalPointingOutward) {
 
 GTEST_TEST(FCL_GJK_EPA, faceNormalPointingOutwardOriginNearFace1) {
   // The top face of the tetrahedron is right above the origin, and the origin
-  // is near the top face (with distance being 0.5mm). In this tetrahedron,
-  // e₀ × e₁ on the top face points upward (and outward from the tetrahedron).
-  // The bottom vertex vertices[3] is far away from the top face, that this
-  // vertex serves as a good witness point to determine the direction of the
-  // normal vector of the top face.
+  // is near the top face (with distance being 0.5mm, this distance is less
+  // than the threshold, such that the origin is not regarded as a good witness
+  // point to determine the direction of the top face normal). In this
+  // tetrahedron, e₀ × e₁ on the top face points upward (and outward from the
+  // tetrahedron). The bottom vertex vertices[3] is far away from the top face,
+  // that this vertex serves as a good witness point to determine the direction
+  // of the normal vector of the top face. This test is created when addressing
+  // the test failure from PR 334.
   const double face0_origin_distance = 0.005;
   std::array<fcl::Vector3<ccd_real_t>, 4> vertices;
   vertices[0] << 0.5, -0.5, face0_origin_distance;
@@ -253,6 +256,16 @@ GTEST_TEST(FCL_GJK_EPA, faceNormalPointingOutwardOriginNearFace1) {
 }
 
 GTEST_TEST(FCL_GJK_EPA, faceNormalPointingOutwardOriginNearFace2) {
+  // The top face of the tetrahedron is right above the origin, and the origin
+  // is near the top face (with distance being 0.5mm, this distance is less
+  // than the threshold, such that the origin is not regarded as a good witness
+  // point to determine the direction of the top face normal). In this
+  // tetrahedron, e₀ × e₁ on the top face points upward (and outward from the
+  // tetrahedron). The bottom vertex vertices[3] is also close to the top face,
+  // such that the bottom vertex won't be regarded as a definitive good witness
+  // point to determine the direction of the top face normal.
+  // faceNormalPointingOutward will loop through all vertices, and check along
+  // which direction the vertices has larger projection to the top face.
   const double face0_origin_distance = 0.005;
   std::array<fcl::Vector3<ccd_real_t>, 4> vertices;
   vertices[0] << 0.5, -0.5, face0_origin_distance;

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
@@ -95,6 +95,9 @@ class Polytope {
 
 /**
  * A tetrahedron with some specific ordering on its edges, and faces.
+ * The user should notice that due to the specific order of the edges, each face
+ * has its own orientations. Namely for some faces f, f.e(0).cross(f.e(1))
+ * points inward to the tetrahedron, for some other faces it points outward.
  */
 class Tetrahedron : public Polytope {
  public:
@@ -222,12 +225,12 @@ GTEST_TEST(FCL_GJK_EPA, faceNormalPointingOutward) {
 
 GTEST_TEST(FCL_GJK_EPA, faceNormalPointingOutwardOriginNearFace1) {
   // Creates a downward pointing tetrahedron which contains the origin. The
-  // origin is just below "top" face of this tetrahedron. The remaining vertex
-  // is far enough away from the top face that it is considered a reliable
-  // witness to determine the direction of the face's normal. The top face is
-  // not quite parallel with the z = 0 plane. This test captures the failure
-  // condition reported in PR 334 -- a logic error made it so the reliable
-  // witness could be ignored.
+  // origin is just below the "top" face of this tetrahedron. The remaining
+  // vertex is far enough away from the top face that it is considered a
+  // reliable witness to determine the direction of the face's normal. The top
+  // face is not quite parallel with the z = 0 plane. This test captures the
+  // failure condition reported in PR 334 -- a logic error made it so the
+  // reliable witness could be ignored.
   const double face0_origin_distance = 0.005;
   std::array<fcl::Vector3<ccd_real_t>, 4> vertices;
   vertices[0] << 0.5, -0.5, face0_origin_distance;
@@ -257,8 +260,9 @@ GTEST_TEST(FCL_GJK_EPA, faceNormalPointingOutwardOriginNearFace2) {
   // Similar to faceNormalPointingOutwardOriginNearFace1 with an important
   // difference: the fourth vertex is no longer a reliable witness; it lies
   // within the distance tolerance. However, it is unambiguously farther off the
-  // plane of the top face than those that form the face. This confirms when
-  // there are no obviously reliable witness that the most distant point serves.
+  // plane of the top face than those that form the face. This confirms that
+  // when there are no obviously reliable witness that the most distant point
+  // serves.
   const double face0_origin_distance = 0.005;
   std::array<fcl::Vector3<ccd_real_t>, 4> vertices;
   vertices[0] << 0.5, -0.5, face0_origin_distance;


### PR DESCRIPTION
Fix two problems in `faceNormalPointingOutward`

1. One problem is exposed in @Levi-Armstrong's PR #334, that when we find a vertex as a good witness point that can determine the direction of the face normal, we should return directly, instead of break.
2. When computing the projection from a vertex to the plane, we incorrectly computed the projection to the origin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/336)
<!-- Reviewable:end -->
