### PR TITLE
Change convex shape constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@
 
 * Geometry
 
-  * Simplified Convex class, deprecating old constructor in favor of simpler, documented constructor: [#325](https://github.com/flexible-collision-library/fcl/pull/325)
+  * Simplified Convex class, deprecating old constructor in favor of
+    simpler, documented constructor:
+     [#325](https://github.com/flexible-collision-library/fcl/pull/325),
+     [#338](https://github.com/flexible-collision-library/fcl/pull/338)
 
 * Broadphase
 

--- a/include/fcl/geometry/shape/convex-inl.h
+++ b/include/fcl/geometry/shape/convex-inl.h
@@ -61,7 +61,9 @@ Convex<S>::Convex(const std::shared_ptr<const std::vector<Vector3<S>>>& vertices
   // Compute an interior point. We're computing the mean point and *not* some
   // alternative such as the centroid or bounding box center.
   Vector3<S> sum = Vector3<S>::Zero();
-  sum = std::accumulate(vertices_->begin(), vertices_->end(), sum);
+  for(const auto& vertex : *vertices_) {
+    sum += vertex;
+  }
   interior_point_ = sum * (S)(1.0 / vertices_->size());
 }
 

--- a/include/fcl/geometry/shape/convex-inl.h
+++ b/include/fcl/geometry/shape/convex-inl.h
@@ -120,18 +120,10 @@ Matrix3<S> Convex<S>::computeMomentofInertia() const {
     // Compute the volume of tetrahedron formed by the vertices on one of the
     // polygon's edges, the center point, and the shape's frame's origin.
     const Vector3<S>& v3 = face_center;
-    for (int j = 1; j <= vertex_count; ++j) {
-      // Each edge of the polygon is defined where faces[face_index + j] is
-      // the first edge vertex and faces[face_index + (j % vertex_count) + 1]
-      // is the second edge vertex. The use of (j % vertex_count) is required
-      // to handle the last polygon edge which is defined by the last polygon
-      // vertex and the first vertex. When j < vertex_count then
-      // (j % vertex_count) == j resulting in faces[face_index + j + 1] which
-      // is the next polygon vertex. When j == vertex_count then
-      // (j % vertex_count) == 0 resulting in faces[face_index + 1] which is
-      // the first vertex of the polygon.
-      int e_first = faces[face_index + j];
-      int e_second = faces[face_index + (j % vertex_count) + 1];
+    const int vertex_base = face_index + 1;
+    for (int j = 0; j < vertex_count; ++j) {
+      int e_first = faces[vertex_base + j];
+      int e_second = faces[vertex_base + (j + 1) % vertex_count];
       const Vector3<S>& v1 = vertices[e_first];
       const Vector3<S>& v2 = vertices[e_second];
       S d_six_vol = (v1.cross(v2)).dot(v3);

--- a/include/fcl/geometry/shape/convex-inl.h
+++ b/include/fcl/geometry/shape/convex-inl.h
@@ -50,8 +50,9 @@ class FCL_EXPORT Convex<double>;
 
 //==============================================================================
 template <typename S>
-Convex<S>::Convex(const std::shared_ptr<const std::vector<Vector3<S>>>& vertices,
-                  int num_faces, const std::shared_ptr<const std::vector<int>>& faces)
+Convex<S>::Convex(
+    const std::shared_ptr<const std::vector<Vector3<S>>>& vertices,
+    int num_faces, const std::shared_ptr<const std::vector<int>>& faces)
   : ShapeBase<S>(),
     vertices_(vertices),
     num_faces_(num_faces),
@@ -61,7 +62,7 @@ Convex<S>::Convex(const std::shared_ptr<const std::vector<Vector3<S>>>& vertices
   // Compute an interior point. We're computing the mean point and *not* some
   // alternative such as the centroid or bounding box center.
   Vector3<S> sum = Vector3<S>::Zero();
-  for(const auto& vertex : *vertices_) {
+  for (const auto& vertex : *vertices_) {
     sum += vertex;
   }
   interior_point_ = sum * (S)(1.0 / vertices_->size());
@@ -73,7 +74,7 @@ void Convex<S>::computeLocalAABB() {
   this->aabb_local.min_.setConstant(std::numeric_limits<S>::max());
   this->aabb_local.max_.setConstant(-std::numeric_limits<S>::max());
 
-  for(const auto& v : *vertices_) {
+  for (const auto& v : *vertices_) {
     this->aabb_local += v;
   }
 
@@ -106,12 +107,12 @@ Matrix3<S> Convex<S>::computeMomentofInertia() const {
 
   S vol_times_six = 0;
   int face_index = 0;
-  for(int i = 0; i < num_faces_; ++i) {
+  for (int i = 0; i < num_faces_; ++i) {
     const int vertex_count = faces[face_index];
     Vector3<S> face_center = Vector3<S>::Zero();
 
     // Compute the center of the face.
-    for(int j = 1; j <= vertex_count; ++j) {
+    for (int j = 1; j <= vertex_count; ++j) {
       face_center += vertices[faces[face_index + j]];
     }
     face_center = face_center * (1.0 / vertex_count);
@@ -119,7 +120,16 @@ Matrix3<S> Convex<S>::computeMomentofInertia() const {
     // Compute the volume of tetrahedron formed by the vertices on one of the
     // polygon's edges, the center point, and the shape's frame's origin.
     const Vector3<S>& v3 = face_center;
-    for(int j = 1; j <= vertex_count; ++j) {
+    for (int j = 1; j <= vertex_count; ++j) {
+      // Each edge of the polygon is defined where faces[face_index + j] is
+      // the first edge vertex and faces[face_index + (j % vertex_count) + 1]
+      // is the second edge vertex. The use of (j % vertex_count) is required
+      // to handle the last polygon edge which is defined by the last polygon
+      // vertex and the first vertex. When j < vertex_count then
+      // (j % vertex_count) == j resulting in faces[face_index + j + 1] which
+      // is the next polygon vertex. When j == vertex_count then
+      // (j % vertex_count) == 0 resulting in faces[face_index + 1] which is
+      // the first vertex of the polygon.
       int e_first = faces[face_index + j];
       int e_second = faces[face_index + (j % vertex_count) + 1];
       const Vector3<S>& v1 = vertices[e_first];
@@ -154,7 +164,7 @@ Vector3<S> Convex<S>::computeCOM() const {
   Vector3<S> com = Vector3<S>::Zero();
   S vol = 0;
   int face_index = 0;
-  for(int i = 0; i < num_faces_; ++i) {
+  for (int i = 0; i < num_faces_; ++i) {
     const int vertex_count = faces[face_index];
     Vector3<S> face_center = Vector3<S>::Zero();
 
@@ -162,7 +172,7 @@ Vector3<S> Convex<S>::computeCOM() const {
     // this approach.
 
     // Compute the center of the polygon.
-    for(int j = 1; j <= vertex_count; ++j) {
+    for (int j = 1; j <= vertex_count; ++j) {
       face_center += vertices[faces[face_index + j]];
     }
     face_center = face_center * (1.0 / vertex_count);
@@ -170,7 +180,7 @@ Vector3<S> Convex<S>::computeCOM() const {
     // Compute the volume of tetrahedron formed by the vertices on one of the
     // polygon's edges, the center point, and the shape's frame's origin.
     const Vector3<S>& v3 = face_center;
-    for(int j = 1; j <= vertex_count; ++j) {
+    for (int j = 1; j <= vertex_count; ++j) {
       int e_first = faces[face_index + j];
       int e_second = faces[face_index + (j % vertex_count) + 1];
       const Vector3<S>& v1 = vertices[e_first];
@@ -192,7 +202,7 @@ template <typename S> S Convex<S>::computeVolume() const {
   const std::vector<int>& faces = *faces_;
   S vol = 0;
   int face_index = 0;
-  for(int i = 0; i < num_faces_; ++i) {
+  for (int i = 0; i < num_faces_; ++i) {
     const int vertex_count = faces[face_index];
     Vector3<S> face_center = Vector3<S>::Zero();
 
@@ -204,7 +214,7 @@ template <typename S> S Convex<S>::computeVolume() const {
     // falling through to this.
 
     // Compute the center of the polygon.
-    for(int j = 1; j <= vertex_count; ++j) {
+    for (int j = 1; j <= vertex_count; ++j) {
       face_center += vertices[faces[face_index + j]];
     }
     face_center = face_center * (1.0 / vertex_count);
@@ -217,7 +227,7 @@ template <typename S> S Convex<S>::computeVolume() const {
     // Compute the volume of tetrahedron formed by the vertices on one of the
     // polygon's edges, the center point, and the shape's frame's origin.
     const Vector3<S>& v3 = face_center;
-    for(int j = 1; j <= vertex_count; ++j) {
+    for (int j = 1; j <= vertex_count; ++j) {
       int e_first = faces[face_index + j];
       int e_second = faces[face_index + (j % vertex_count) + 1];
       const Vector3<S>& v1 = vertices[e_first];
@@ -239,7 +249,7 @@ std::vector<Vector3<S>> Convex<S>::getBoundVertices(
   std::vector<Vector3<S>> result;
   result.reserve(vertices_->size());
 
-  for(const auto& v : *vertices_) {
+  for (const auto& v : *vertices_) {
     result.push_back(tf * v);
   }
 

--- a/include/fcl/geometry/shape/convex.h
+++ b/include/fcl/geometry/shape/convex.h
@@ -88,7 +88,7 @@ public:
   /// @brief Constructor
   ///
   /// @note: The %Convex geometry assumes that the input data %vertices and
-  /// %faces do not change through the life of the object.
+  /// %faces does not change through the life of the object.
   ///
   /// @warning: The %Convex class does *not* validate the input; it trusts that
   /// the inputs truly represent a coherent convex polytope.
@@ -112,10 +112,8 @@ public:
   /// @brief Get node type: a convex polytope.
   NODE_TYPE getNodeType() const override;
 
-  /// @brief Get the vertex positions in the geometry's frame G.
-  const std::shared_ptr<const std::vector<Vector3<S>>>& getVertices() const {
-    return vertices_;
-  }
+  /// @brief Gets the vertex positions in the geometry's frame G.
+  const std::vector<Vector3<S>>& getVertices() const { return *vertices_; }
 
   /// @brief Get the total number of faces in the convex mesh.
   int getFaceCount() const { return num_faces_; }
@@ -141,15 +139,11 @@ public:
   ///    1. vertices are not coincident and
   ///    3. the indices of the face correspond to a proper counter-clockwise
   ///       ordering.
-  const std::shared_ptr<const std::vector<int>>& getFaces() const {
-    return faces_;
-  }
-
+  const std::vector<int>& getFaces() const { return *faces_; }
 
   /// @brief A point guaranteed to be on the interior of the convex polytope,
   /// used for collision.
   const Vector3<S>& getInteriorPoint() const { return interior_point_; }
-
 
   // Documentation inherited.
   Matrix3<S> computeMomentofInertia() const override;
@@ -166,7 +160,7 @@ public:
 
 private:
   const std::shared_ptr<const std::vector<Vector3<S>>> vertices_;
-  int num_faces_;
+  const int num_faces_;
   const std::shared_ptr<const std::vector<int>> faces_;
   Vector3<S> interior_point_;
 };

--- a/include/fcl/geometry/shape/convex.h
+++ b/include/fcl/geometry/shape/convex.h
@@ -88,7 +88,7 @@ public:
   /// @brief Constructor
   ///
   /// @note: The %Convex geometry assumes that the input data %vertices and
-  /// %faces does not change through the life of the object.
+  /// %faces do not change through the life of the object.
   ///
   /// @warning: The %Convex class does *not* validate the input; it trusts that
   /// the inputs truly represent a coherent convex polytope.
@@ -106,19 +106,19 @@ public:
 
   ~Convex() = default;
 
-  /// @brief Compute AABB<S> in the geometry's canonical frame.
+  /// @brief Computes AABB<S> in the geometry's canonical frame.
   void computeLocalAABB() override;
 
-  /// @brief Get node type: a convex polytope.
+  /// @brief Gets node type: a convex polytope.
   NODE_TYPE getNodeType() const override;
 
   /// @brief Gets the vertex positions in the geometry's frame G.
   const std::vector<Vector3<S>>& getVertices() const { return *vertices_; }
 
-  /// @brief Get the total number of faces in the convex mesh.
+  /// @brief Gets the total number of faces in the convex mesh.
   int getFaceCount() const { return num_faces_; }
 
-  /// @brief Get the representation of the *faces* of the convex hull.
+  /// @brief Gets the representation of the *faces* of the convex hull.
   ///
   /// The array is the concatenation of an integer-based representations of each
   /// face. A single face is encoded as a sub-array of ints where the first int
@@ -154,7 +154,7 @@ public:
   // Documentation inherited.
   S computeVolume() const override;
 
-  /// @brief get the vertices of some convex shape which can bound this shape in
+  /// @brief Gets the vertices of some convex shape which can bound this shape in
   /// a specific configuration
   std::vector<Vector3<S>> getBoundVertices(const Transform3<S>& tf) const;
 

--- a/include/fcl/geometry/shape/convex.h
+++ b/include/fcl/geometry/shape/convex.h
@@ -87,20 +87,19 @@ public:
 
   /// @brief Constructor
   ///
-  /// @note: The %Convex geometry does *not* take ownership of any of the data
-  /// provided. The data must remain valid for as long as the %Convex instance
-  /// and must be cleaned up explicitly.
+  /// @note: The %Convex geometry assumes that the input data %vertices and
+  /// %faces do not change through the life of the object.
   ///
   /// @warning: The %Convex class does *not* validate the input; it trusts that
   /// the inputs truly represent a coherent convex polytope.
   ///
-  /// @param num_vertices   The number of vertices defined in `vertices`.
   /// @param vertices       The positions of the polytope vertices.
   /// @param num_faces      The number of faces defined in `faces`.
   /// @param faces          Encoding of the polytope faces. Must encode
   ///                       `num_faces` number of faces. See member
   ///                       documentation for details on encoding.
-  Convex(int num_vertices, Vector3<S>* vertices, int num_faces, int* faces);
+  Convex(const std::shared_ptr<const std::vector<Vector3<S>>>& vertices,
+         int num_faces, const std::shared_ptr<const std::vector<int>>& faces);
 
   /// @brief Copy constructor 
   Convex(const Convex& other) = default;
@@ -113,16 +112,15 @@ public:
   /// @brief Get node type: a convex polytope.
   NODE_TYPE getNodeType() const override;
 
-  /// @brief The total number of vertices in the convex mesh.
-  int num_vertices;
+  /// @brief Get the vertex positions in the geometry's frame G.
+  const std::shared_ptr<const std::vector<Vector3<S>>>& getVertices() const {
+    return vertices_;
+  }
 
-  /// @brief The vertex positions in the geometry's frame G.
-  Vector3<S>* vertices;
+  /// @brief Get the total number of faces in the convex mesh.
+  int getFaceCount() const { return num_faces_; }
 
-  /// @brief The total number of faces in the convex mesh.
-  int num_faces;
-
-  /// @brief The representation of the *faces* of the convex hull.
+  /// @brief Get the representation of the *faces* of the convex hull.
   ///
   /// The array is the concatenation of an integer-based representations of each
   /// face. A single face is encoded as a sub-array of ints where the first int
@@ -143,11 +141,15 @@ public:
   ///    1. vertices are not coincident and
   ///    3. the indices of the face correspond to a proper counter-clockwise
   ///       ordering.
-  int* faces;
+  const std::shared_ptr<const std::vector<int>>& getFaces() const {
+    return faces_;
+  }
+
 
   /// @brief A point guaranteed to be on the interior of the convex polytope,
   /// used for collision.
-  Vector3<S> interior_point;
+  const Vector3<S>& getInteriorPoint() const { return interior_point_; }
+
 
   // Documentation inherited.
   Matrix3<S> computeMomentofInertia() const override;
@@ -161,6 +163,12 @@ public:
   /// @brief get the vertices of some convex shape which can bound this shape in
   /// a specific configuration
   std::vector<Vector3<S>> getBoundVertices(const Transform3<S>& tf) const;
+
+private:
+  const std::shared_ptr<const std::vector<Vector3<S>>> vertices_;
+  int num_faces_;
+  const std::shared_ptr<const std::vector<int>> faces_;
+  Vector3<S> interior_point_;
 };
 
 using Convexf = Convex<float>;

--- a/include/fcl/geometry/shape/utility-inl.h
+++ b/include/fcl/geometry/shape/utility-inl.h
@@ -127,7 +127,8 @@ struct FCL_EXPORT ComputeBVImpl
   static void run(const Shape& s, const Transform3<S>& tf, BV& bv)
   {
     std::vector<Vector3<S>> convex_bound_vertices = s.getBoundVertices(tf);
-    fit(convex_bound_vertices.data(), (int)convex_bound_vertices.size(), bv);
+    fit(convex_bound_vertices.data(),
+        static_cast<int>(convex_bound_vertices.size()), bv);
   }
 };
 
@@ -234,7 +235,7 @@ struct FCL_EXPORT ComputeBVImpl<S, AABB<S>, Convex<S>>
     const Vector3<S>& T = tf.translation();
 
     AABB<S> bv_;
-    for(const auto& vertex : *(s.getVertices()))
+    for (const auto& vertex : s.getVertices())
     {
       Vector3<S> new_p = R * vertex + T;
       bv_ += new_p;
@@ -250,7 +251,7 @@ struct FCL_EXPORT ComputeBVImpl<S, OBB<S>, Convex<S>>
 {
   static void run(const Convex<S>& s, const Transform3<S>& tf, OBB<S>& bv)
   {
-    fit(s.getVertices()->data(), (int)s.getVertices()->size(), bv);
+    fit(s.getVertices().data(), static_cast<int>(s.getVertices().size()), bv);
 
     bv.axis = tf.linear();
     bv.To = tf * bv.To;

--- a/include/fcl/geometry/shape/utility-inl.h
+++ b/include/fcl/geometry/shape/utility-inl.h
@@ -127,7 +127,7 @@ struct FCL_EXPORT ComputeBVImpl
   static void run(const Shape& s, const Transform3<S>& tf, BV& bv)
   {
     std::vector<Vector3<S>> convex_bound_vertices = s.getBoundVertices(tf);
-    fit(&convex_bound_vertices[0], (int)convex_bound_vertices.size(), bv);
+    fit(convex_bound_vertices.data(), (int)convex_bound_vertices.size(), bv);
   }
 };
 
@@ -234,9 +234,9 @@ struct FCL_EXPORT ComputeBVImpl<S, AABB<S>, Convex<S>>
     const Vector3<S>& T = tf.translation();
 
     AABB<S> bv_;
-    for(int i = 0; i < s.num_vertices; ++i)
+    for(const auto& vertex : *(s.getVertices()))
     {
-      Vector3<S> new_p = R * s.vertices[i] + T;
+      Vector3<S> new_p = R * vertex + T;
       bv_ += new_p;
     }
 
@@ -250,7 +250,7 @@ struct FCL_EXPORT ComputeBVImpl<S, OBB<S>, Convex<S>>
 {
   static void run(const Convex<S>& s, const Transform3<S>& tf, OBB<S>& bv)
   {
-    fit(s.vertices, s.num_vertices, bv);
+    fit(s.getVertices()->data(), (int)s.getVertices()->size(), bv);
 
     bv.axis = tf.linear();
     bv.To = tf * bv.To;

--- a/include/fcl/math/bv/utility-inl.h
+++ b/include/fcl/math/bv/utility-inl.h
@@ -63,7 +63,7 @@ namespace OBB_fit_functions {
 //==============================================================================
 template <typename S>
 FCL_EXPORT
-void fit1(Vector3<S>* ps, OBB<S>& bv)
+void fit1(const Vector3<S>* const ps, OBB<S>& bv)
 {
   bv.To = ps[0];
   bv.axis.setIdentity();
@@ -73,7 +73,7 @@ void fit1(Vector3<S>* ps, OBB<S>& bv)
 //==============================================================================
 template <typename S>
 FCL_EXPORT
-void fit2(Vector3<S>* ps, OBB<S>& bv)
+void fit2(const Vector3<S>* const ps, OBB<S>& bv)
 {
   const Vector3<S>& p1 = ps[0];
   const Vector3<S>& p2 = ps[1];
@@ -91,7 +91,7 @@ void fit2(Vector3<S>* ps, OBB<S>& bv)
 //==============================================================================
 template <typename S>
 FCL_EXPORT
-void fit3(Vector3<S>* ps, OBB<S>& bv)
+void fit3(const Vector3<S>* const ps, OBB<S>& bv)
 {
   const Vector3<S>& p1 = ps[0];
   const Vector3<S>& p2 = ps[1];
@@ -121,7 +121,7 @@ void fit3(Vector3<S>* ps, OBB<S>& bv)
 //==============================================================================
 template <typename S>
 FCL_EXPORT
-void fit6(Vector3<S>* ps, OBB<S>& bv)
+void fit6(const Vector3<S>* const ps, OBB<S>& bv)
 {
   OBB<S> bv1, bv2;
   fit3(ps, bv1);
@@ -132,7 +132,7 @@ void fit6(Vector3<S>* ps, OBB<S>& bv)
 //==============================================================================
 template <typename S>
 FCL_EXPORT
-void fitn(Vector3<S>* ps, int n, OBB<S>& bv)
+void fitn(const Vector3<S>* const ps, int n, OBB<S>& bv)
 {
   Matrix3<S> M;
   Matrix3<S> E;
@@ -148,23 +148,23 @@ void fitn(Vector3<S>* ps, int n, OBB<S>& bv)
 
 //==============================================================================
 extern template
-void fit1(Vector3<double>* ps, OBB<double>& bv);
+void fit1(const Vector3d* const ps, OBB<double>& bv);
 
 //==============================================================================
 extern template
-void fit2(Vector3<double>* ps, OBB<double>& bv);
+void fit2(const Vector3d* const ps, OBB<double>& bv);
 
 //==============================================================================
 extern template
-void fit3(Vector3<double>* ps, OBB<double>& bv);
+void fit3(const Vector3d* const ps, OBB<double>& bv);
 
 //==============================================================================
 extern template
-void fit6(Vector3<double>* ps, OBB<double>& bv);
+void fit6(const Vector3d* const ps, OBB<double>& bv);
 
 //==============================================================================
 extern template
-void fitn(Vector3<double>* ps, int n, OBB<double>& bv);
+void fitn(const Vector3d* const ps, int n, OBB<double>& bv);
 
 //==============================================================================
 } // namespace OBB_fit_functions
@@ -177,7 +177,7 @@ namespace RSS_fit_functions {
 //==============================================================================
 template <typename S>
 FCL_EXPORT
-void fit1(Vector3<S>* ps, RSS<S>& bv)
+void fit1(const Vector3<S>* const ps, RSS<S>& bv)
 {
   bv.To = ps[0];
   bv.axis.setIdentity();
@@ -189,7 +189,7 @@ void fit1(Vector3<S>* ps, RSS<S>& bv)
 //==============================================================================
 template <typename S>
 FCL_EXPORT
-void fit2(Vector3<S>* ps, RSS<S>& bv)
+void fit2(const Vector3<S>* const ps, RSS<S>& bv)
 {
   const Vector3<S>& p1 = ps[0];
   const Vector3<S>& p2 = ps[1];
@@ -209,7 +209,7 @@ void fit2(Vector3<S>* ps, RSS<S>& bv)
 //==============================================================================
 template <typename S>
 FCL_EXPORT
-void fit3(Vector3<S>* ps, RSS<S>& bv)
+void fit3(const Vector3<S>* const ps, RSS<S>& bv)
 {
   const Vector3<S>& p1 = ps[0];
   const Vector3<S>& p2 = ps[1];
@@ -237,7 +237,7 @@ void fit3(Vector3<S>* ps, RSS<S>& bv)
 //==============================================================================
 template <typename S>
 FCL_EXPORT
-void fit6(Vector3<S>* ps, RSS<S>& bv)
+void fit6(const Vector3<S>* const ps, RSS<S>& bv)
 {
   RSS<S> bv1, bv2;
   fit3(ps, bv1);
@@ -248,7 +248,7 @@ void fit6(Vector3<S>* ps, RSS<S>& bv)
 //==============================================================================
 template <typename S>
 FCL_EXPORT
-void fitn(Vector3<S>* ps, int n, RSS<S>& bv)
+void fitn(const Vector3<S>* const ps, int n, RSS<S>& bv)
 {
   Matrix3<S> M; // row first matrix
   Matrix3<S> E; // row first eigen-vectors
@@ -265,27 +265,27 @@ void fitn(Vector3<S>* ps, int n, RSS<S>& bv)
 //==============================================================================
 extern template
 FCL_EXPORT
-void fit1(Vector3<double>* ps, RSS<double>& bv);
+void fit1(const Vector3d* const ps, RSS<double>& bv);
 
 //==============================================================================
 extern template
 FCL_EXPORT
-void fit2(Vector3<double>* ps, RSS<double>& bv);
+void fit2(const Vector3d* const ps, RSS<double>& bv);
 
 //==============================================================================
 extern template
 FCL_EXPORT
-void fit3(Vector3<double>* ps, RSS<double>& bv);
+void fit3(const Vector3d* const ps, RSS<double>& bv);
 
 //==============================================================================
 extern template
 FCL_EXPORT
-void fit6(Vector3<double>* ps, RSS<double>& bv);
+void fit6(const Vector3d* const ps, RSS<double>& bv);
 
 //==============================================================================
 extern template
 FCL_EXPORT
-void fitn(Vector3<double>* ps, int n, RSS<double>& bv);
+void fitn(const Vector3d* const ps, int n, RSS<double>& bv);
 
 //==============================================================================
 } // namespace RSS_fit_functions
@@ -298,7 +298,7 @@ namespace kIOS_fit_functions {
 //==============================================================================
 template <typename S>
 FCL_EXPORT
-void fit1(Vector3<S>* ps, kIOS<S>& bv)
+void fit1(const Vector3<S>* const ps, kIOS<S>& bv)
 {
   bv.num_spheres = 1;
   bv.spheres[0].o = ps[0];
@@ -312,7 +312,7 @@ void fit1(Vector3<S>* ps, kIOS<S>& bv)
 //==============================================================================
 template <typename S>
 FCL_EXPORT
-void fit2(Vector3<S>* ps, kIOS<S>& bv)
+void fit2(const Vector3<S>* const ps, kIOS<S>& bv)
 {
   bv.num_spheres = 5;
 
@@ -350,7 +350,7 @@ void fit2(Vector3<S>* ps, kIOS<S>& bv)
 //==============================================================================
 template <typename S>
 FCL_EXPORT
-void fit3(Vector3<S>* ps, kIOS<S>& bv)
+void fit3(const Vector3<S>* const ps, kIOS<S>& bv)
 {
   bv.num_spheres = 3;
 
@@ -396,7 +396,7 @@ void fit3(Vector3<S>* ps, kIOS<S>& bv)
 //==============================================================================
 template <typename S>
 FCL_EXPORT
-void fitn(Vector3<S>* ps, int n, kIOS<S>& bv)
+void fitn(const Vector3<S>* const ps, int n, kIOS<S>& bv)
 {
   Matrix3<S> M;
   Matrix3<S> E;
@@ -464,22 +464,22 @@ void fitn(Vector3<S>* ps, int n, kIOS<S>& bv)
 //==============================================================================
 extern template
 FCL_EXPORT
-void fit1(Vector3<double>* ps, kIOS<double>& bv);
+void fit1(const Vector3d* const ps, kIOS<double>& bv);
 
 //==============================================================================
 extern template
 FCL_EXPORT
-void fit2(Vector3<double>* ps, kIOS<double>& bv);
+void fit2(const Vector3d* const ps, kIOS<double>& bv);
 
 //==============================================================================
 extern template
 FCL_EXPORT
-void fit3(Vector3<double>* ps, kIOS<double>& bv);
+void fit3(const Vector3d* const ps, kIOS<double>& bv);
 
 //==============================================================================
 extern template
 FCL_EXPORT
-void fitn(Vector3<double>* ps, int n, kIOS<double>& bv);
+void fitn(const Vector3d* const ps, int n, kIOS<double>& bv);
 
 //==============================================================================
 } // namespace kIOS_fit_functions
@@ -492,7 +492,7 @@ namespace OBBRSS_fit_functions {
 //==============================================================================
 template <typename S>
 FCL_EXPORT
-void fit1(Vector3<S>* ps, OBBRSS<S>& bv)
+void fit1(const Vector3<S>* const ps, OBBRSS<S>& bv)
 {
   OBB_fit_functions::fit1(ps, bv.obb);
   RSS_fit_functions::fit1(ps, bv.rss);
@@ -501,7 +501,7 @@ void fit1(Vector3<S>* ps, OBBRSS<S>& bv)
 //==============================================================================
 template <typename S>
 FCL_EXPORT
-void fit2(Vector3<S>* ps, OBBRSS<S>& bv)
+void fit2(const Vector3<S>* const ps, OBBRSS<S>& bv)
 {
   OBB_fit_functions::fit2(ps, bv.obb);
   RSS_fit_functions::fit2(ps, bv.rss);
@@ -510,7 +510,7 @@ void fit2(Vector3<S>* ps, OBBRSS<S>& bv)
 //==============================================================================
 template <typename S>
 FCL_EXPORT
-void fit3(Vector3<S>* ps, OBBRSS<S>& bv)
+void fit3(const Vector3<S>* const ps, OBBRSS<S>& bv)
 {
   OBB_fit_functions::fit3(ps, bv.obb);
   RSS_fit_functions::fit3(ps, bv.rss);
@@ -519,7 +519,7 @@ void fit3(Vector3<S>* ps, OBBRSS<S>& bv)
 //==============================================================================
 template <typename S>
 FCL_EXPORT
-void fitn(Vector3<S>* ps, int n, OBBRSS<S>& bv)
+void fitn(const Vector3<S>* const ps, int n, OBBRSS<S>& bv)
 {
   OBB_fit_functions::fitn(ps, n, bv.obb);
   RSS_fit_functions::fitn(ps, n, bv.rss);
@@ -527,19 +527,19 @@ void fitn(Vector3<S>* ps, int n, OBBRSS<S>& bv)
 
 //==============================================================================
 extern template
-void fit1(Vector3<double>* ps, OBBRSS<double>& bv);
+void fit1(const Vector3d* const ps, OBBRSS<double>& bv);
 
 //==============================================================================
 extern template
-void fit2(Vector3<double>* ps, OBBRSS<double>& bv);
+void fit2(const Vector3d* const ps, OBBRSS<double>& bv);
 
 //==============================================================================
 extern template
-void fit3(Vector3<double>* ps, OBBRSS<double>& bv);
+void fit3(const Vector3d* const ps, OBBRSS<double>& bv);
 
 //==============================================================================
 extern template
-void fitn(Vector3<double>* ps, int n, OBBRSS<double>& bv);
+void fitn(const Vector3d* const ps, int n, OBBRSS<double>& bv);
 
 //==============================================================================
 } // namespace OBBRSS_fit_functions
@@ -549,7 +549,7 @@ void fitn(Vector3<double>* ps, int n, OBBRSS<double>& bv);
 template <typename S, typename BV>
 struct FCL_EXPORT Fitter
 {
-  static void fit(Vector3<S>* ps, int n, BV& bv)
+  static void fit(const Vector3<S>* const ps, int n, BV& bv)
   {
     for(int i = 0; i < n; ++i)
       bv += ps[i];
@@ -560,7 +560,7 @@ struct FCL_EXPORT Fitter
 template <typename S>
 struct FCL_EXPORT Fitter<S, OBB<S>>
 {
-  static void fit(Vector3<S>* ps, int n, OBB<S>& bv)
+  static void fit(const Vector3<S>* const ps, int n, OBB<S>& bv)
   {
     switch(n)
     {
@@ -586,7 +586,7 @@ struct FCL_EXPORT Fitter<S, OBB<S>>
 template <typename S>
 struct FCL_EXPORT Fitter<S, RSS<S>>
 {
-  static void fit(Vector3<S>* ps, int n, RSS<S>& bv)
+  static void fit(const Vector3<S>* const ps, int n, RSS<S>& bv)
   {
     switch(n)
     {
@@ -609,7 +609,7 @@ struct FCL_EXPORT Fitter<S, RSS<S>>
 template <typename S>
 struct FCL_EXPORT Fitter<S, kIOS<S>>
 {
-  static void fit(Vector3<S>* ps, int n, kIOS<S>& bv)
+  static void fit(const Vector3<S>* const ps, int n, kIOS<S>& bv)
   {
     switch(n)
     {
@@ -632,7 +632,7 @@ struct FCL_EXPORT Fitter<S, kIOS<S>>
 template <typename S>
 struct FCL_EXPORT Fitter<S, OBBRSS<S>>
 {
-  static void fit(Vector3<S>* ps, int n, OBBRSS<S>& bv)
+  static void fit(const Vector3<S>* const ps, int n, OBBRSS<S>& bv)
   {
     switch(n)
     {
@@ -674,7 +674,7 @@ struct Fitter<double, OBBRSS<double>>;
 //==============================================================================
 template <typename BV>
 FCL_EXPORT
-void fit(Vector3<typename BV::S>* ps, int n, BV& bv)
+void fit(const Vector3<typename BV::S>* const ps, int n, BV& bv)
 {
   detail::Fitter<typename BV::S, BV>::fit(ps, n, bv);
 }

--- a/include/fcl/math/bv/utility.h
+++ b/include/fcl/math/bv/utility.h
@@ -47,7 +47,7 @@ namespace fcl
 /// @brief Compute a bounding volume that fits a set of n points.
 template <typename BV>
 FCL_EXPORT
-void fit(Vector3<typename BV::S>* ps, int n, BV& bv);
+void fit(const Vector3<typename BV::S>* const ps, int n, BV& bv);
 
 /// @brief Convert a bounding volume of type BV1 in configuration tf1 to
 /// bounding volume of type BV2 in identity configuration.

--- a/include/fcl/math/geometry-inl.h
+++ b/include/fcl/math/geometry-inl.h
@@ -80,8 +80,8 @@ void generateCoordinateSystem(Transform3d& tf);
 //==============================================================================
 extern template
 void getRadiusAndOriginAndRectangleSize(
-    Vector3d* ps,
-    Vector3d* ps2,
+    const Vector3d* const ps,
+    const Vector3d* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
@@ -93,8 +93,8 @@ void getRadiusAndOriginAndRectangleSize(
 //==============================================================================
 extern template
 void getRadiusAndOriginAndRectangleSize(
-    Vector3d* ps,
-    Vector3d* ps2,
+    const Vector3d* const ps,
+    const Vector3d* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
@@ -114,8 +114,8 @@ void circumCircleComputation(
 //==============================================================================
 extern template
 double maximumDistance(
-    Vector3d* ps,
-    Vector3d* ps2,
+    const Vector3d* const ps,
+    const Vector3d* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
@@ -124,8 +124,8 @@ double maximumDistance(
 //==============================================================================
 extern template
 void getExtentAndCenter(
-    Vector3d* ps,
-    Vector3d* ps2,
+    const Vector3d* const ps,
+    const Vector3d* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
@@ -136,8 +136,8 @@ void getExtentAndCenter(
 //==============================================================================
 extern template
 void getCovariance(
-    Vector3d* ps,
-    Vector3d* ps2,
+    const Vector3d* const ps,
+    const Vector3d* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n, Matrix3d& M);
@@ -150,8 +150,8 @@ namespace detail {
 template <typename S>
 FCL_EXPORT
 S maximumDistance_mesh(
-    Vector3<S>* ps,
-    Vector3<S>* ps2,
+    const Vector3<S>* const ps,
+    const Vector3<S>* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
@@ -195,8 +195,8 @@ S maximumDistance_mesh(
 template <typename S>
 FCL_EXPORT
 S maximumDistance_pointcloud(
-    Vector3<S>* ps,
-    Vector3<S>* ps2,
+    const Vector3<S>* const ps,
+    const Vector3<S>* const ps2,
     unsigned int* indices,
     int n,
     const Vector3<S>& query)
@@ -230,8 +230,8 @@ S maximumDistance_pointcloud(
 template <typename S>
 FCL_EXPORT
 void getExtentAndCenter_pointcloud(
-    Vector3<S>* ps,
-    Vector3<S>* ps2,
+    const Vector3<S>* const ps,
+    const Vector3<S>* const ps2,
     unsigned int* indices,
     int n,
     const Matrix3<S>& axis,
@@ -295,8 +295,8 @@ void getExtentAndCenter_pointcloud(
 template <typename S>
 FCL_EXPORT
 void getExtentAndCenter_mesh(
-    Vector3<S>* ps,
-    Vector3<S>* ps2,
+    const Vector3<S>* const ps,
+    const Vector3<S>* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
@@ -367,8 +367,8 @@ void getExtentAndCenter_mesh(
 //==============================================================================
 extern template
 double maximumDistance_mesh(
-    Vector3d* ps,
-    Vector3d* ps2,
+    const Vector3d* const ps,
+    const Vector3d* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
@@ -377,8 +377,8 @@ double maximumDistance_mesh(
 //==============================================================================
 extern template
 double maximumDistance_pointcloud(
-    Vector3d* ps,
-    Vector3d* ps2,
+    const Vector3d* const ps,
+    const Vector3d* const ps2,
     unsigned int* indices,
     int n,
     const Vector3d& query);
@@ -386,25 +386,25 @@ double maximumDistance_pointcloud(
 //==============================================================================
 extern template
 void getExtentAndCenter_pointcloud(
-    Vector3<double>* ps,
-    Vector3<double>* ps2,
+    const Vector3d* const ps,
+    const Vector3d* const ps2,
     unsigned int* indices,
     int n,
-    const Matrix3<double>& axis,
-    Vector3<double>& center,
-    Vector3<double>& extent);
+    const Matrix3d& axis,
+    Vector3d& center,
+    Vector3d& extent);
 
 //==============================================================================
 extern template
 void getExtentAndCenter_mesh(
-    Vector3<double>* ps,
-    Vector3<double>* ps2,
+    const Vector3d* const ps,
+    const Vector3d* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
-    const Matrix3<double>& axis,
-    Vector3<double>& center,
-    Vector3<double>& extent);
+    const Matrix3d& axis,
+    Vector3d& center,
+    Vector3d& extent);
 
 //==============================================================================
 } // namespace detail
@@ -826,8 +826,8 @@ void relativeTransform(
 template <typename S>
 FCL_EXPORT
 void getRadiusAndOriginAndRectangleSize(
-    Vector3<S>* ps,
-    Vector3<S>* ps2,
+    const Vector3<S>* const ps,
+    const Vector3<S>* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
@@ -1109,8 +1109,8 @@ void getRadiusAndOriginAndRectangleSize(
 template <typename S>
 FCL_EXPORT
 void getRadiusAndOriginAndRectangleSize(
-    Vector3<S>* ps,
-    Vector3<S>* ps2,
+    const Vector3<S>* const ps,
+    const Vector3<S>* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
@@ -1416,8 +1416,8 @@ void circumCircleComputation(
 template <typename S>
 FCL_EXPORT
 S maximumDistance(
-    Vector3<S>* ps,
-    Vector3<S>* ps2,
+    const Vector3<S>* const ps,
+    const Vector3<S>* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
@@ -1433,8 +1433,8 @@ S maximumDistance(
 template <typename S>
 FCL_EXPORT
 void getExtentAndCenter(
-    Vector3<S>* ps,
-    Vector3<S>* ps2,
+    const Vector3<S>* const ps,
+    const Vector3<S>* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
@@ -1451,8 +1451,9 @@ void getExtentAndCenter(
 //==============================================================================
 template <typename S>
 FCL_EXPORT
-void getCovariance(Vector3<S>* ps,
-    Vector3<S>* ps2,
+void getCovariance(
+    const Vector3<S>* const ps,
+    const Vector3<S>* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n, Matrix3<S>& M)

--- a/include/fcl/math/geometry.h
+++ b/include/fcl/math/geometry.h
@@ -125,8 +125,8 @@ void relativeTransform(
 template <typename S>
 FCL_EXPORT
 void getRadiusAndOriginAndRectangleSize(
-    Vector3<S>* ps,
-    Vector3<S>* ps2,
+    const Vector3<S>* const ps,
+    const Vector3<S>* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
@@ -140,8 +140,8 @@ void getRadiusAndOriginAndRectangleSize(
 template <typename S>
 FCL_EXPORT
 void getRadiusAndOriginAndRectangleSize(
-    Vector3<S>* ps,
-    Vector3<S>* ps2,
+    const Vector3<S>* const ps,
+    const Vector3<S>* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
@@ -163,8 +163,8 @@ void circumCircleComputation(
 template <typename S>
 FCL_EXPORT
 S maximumDistance(
-    Vector3<S>* ps,
-    Vector3<S>* ps2,
+    const Vector3<S>* const ps,
+    const Vector3<S>* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
@@ -175,8 +175,8 @@ S maximumDistance(
 template <typename S>
 FCL_EXPORT
 void getExtentAndCenter(
-    Vector3<S>* ps,
-    Vector3<S>* ps2,
+    const Vector3<S>* const ps,
+    const Vector3<S>* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
@@ -189,8 +189,8 @@ void getExtentAndCenter(
 template <typename S>
 FCL_EXPORT
 void getExtentAndCenter(
-    Vector3<S>* ps,
-    Vector3<S>* ps2,
+    const Vector3<S>* const ps,
+    const Vector3<S>* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
@@ -203,8 +203,8 @@ void getExtentAndCenter(
 template <typename S>
 FCL_EXPORT
 void getCovariance(
-    Vector3<S>* ps,
-    Vector3<S>* ps2,
+    const Vector3<S>* const ps,
+    const Vector3<S>* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -1708,7 +1708,7 @@ static inline ccd_real_t _ccdDist(const void *obj1, const void *obj2,
                                       &closest_p);
       dist = CCD_SQRT(dist);
     }
-    else if(ccdSimplexSize(simplex) == 3)
+    else if (ccdSimplexSize(simplex) == 3)
     {
       dist = ccdVec3PointTriDist2(ccd_vec3_origin,
                                   &ccdSimplexPoint(simplex, 0)->v,
@@ -1828,7 +1828,9 @@ static int penEPAPosClosest(const ccd_pt_el_t* nearest, ccd_vec3_t* p1,
   }
 }
 
-static inline ccd_real_t ccdGJKSignedDist(const void* obj1, const void* obj2, const ccd_t* ccd, ccd_vec3_t* p1, ccd_vec3_t* p2)
+static inline ccd_real_t ccdGJKSignedDist(const void* obj1, const void* obj2,
+                                          const ccd_t* ccd, ccd_vec3_t* p1,
+                                          ccd_vec3_t* p2)
 {
   ccd_simplex_t simplex;
 
@@ -1889,7 +1891,9 @@ static inline ccd_real_t ccdGJKSignedDist(const void* obj1, const void* obj2, co
 // penetrating, -1 is returned.
 // @note Unlike _ccdDist function, this function does not need a warm-started
 // simplex as the input argument.
-static inline ccd_real_t ccdGJKDist2(const void *obj1, const void *obj2, const ccd_t *ccd, ccd_vec3_t* p1, ccd_vec3_t* p2)
+static inline ccd_real_t ccdGJKDist2(const void *obj1, const void *obj2,
+                                     const ccd_t *ccd, ccd_vec3_t* p1,
+                                     ccd_vec3_t* p2)
 {
   ccd_simplex_t simplex;
   // first find an intersection
@@ -1903,7 +1907,8 @@ static inline ccd_real_t ccdGJKDist2(const void *obj1, const void *obj2, const c
 
 /** Basic shape to ccd shape */
 template <typename S>
-static void shapeToGJK(const ShapeBase<S>& s, const Transform3<S>& tf, ccd_obj_t* o)
+static void shapeToGJK(const ShapeBase<S>& s, const Transform3<S>& tf,
+                       ccd_obj_t* o)
 {
   FCL_UNUSED(s);
 
@@ -1924,7 +1929,8 @@ static void boxToGJK(const Box<S>& s, const Transform3<S>& tf, ccd_box_t* box)
 }
 
 template <typename S>
-static void capToGJK(const Capsule<S>& s, const Transform3<S>& tf, ccd_cap_t* cap)
+static void capToGJK(const Capsule<S>& s, const Transform3<S>& tf,
+                     ccd_cap_t* cap)
 {
   shapeToGJK(s, tf, cap);
   cap->radius = s.radius;
@@ -1932,7 +1938,8 @@ static void capToGJK(const Capsule<S>& s, const Transform3<S>& tf, ccd_cap_t* ca
 }
 
 template <typename S>
-static void cylToGJK(const Cylinder<S>& s, const Transform3<S>& tf, ccd_cyl_t* cyl)
+static void cylToGJK(const Cylinder<S>& s, const Transform3<S>& tf,
+                     ccd_cyl_t* cyl)
 {
   shapeToGJK(s, tf, cyl);
   cyl->radius = s.radius;
@@ -1940,7 +1947,8 @@ static void cylToGJK(const Cylinder<S>& s, const Transform3<S>& tf, ccd_cyl_t* c
 }
 
 template <typename S>
-static void coneToGJK(const Cone<S>& s, const Transform3<S>& tf, ccd_cone_t* cone)
+static void coneToGJK(const Cone<S>& s, const Transform3<S>& tf,
+                      ccd_cone_t* cone)
 {
   shapeToGJK(s, tf, cone);
   cone->radius = s.radius;
@@ -1948,14 +1956,16 @@ static void coneToGJK(const Cone<S>& s, const Transform3<S>& tf, ccd_cone_t* con
 }
 
 template <typename S>
-static void sphereToGJK(const Sphere<S>& s, const Transform3<S>& tf, ccd_sphere_t* sph)
+static void sphereToGJK(const Sphere<S>& s, const Transform3<S>& tf,
+                        ccd_sphere_t* sph)
 {
   shapeToGJK(s, tf, sph);
   sph->radius = s.radius;
 }
 
 template <typename S>
-static void ellipsoidToGJK(const Ellipsoid<S>& s, const Transform3<S>& tf, ccd_ellipsoid_t* ellipsoid)
+static void ellipsoidToGJK(const Ellipsoid<S>& s, const Transform3<S>& tf,
+                           ccd_ellipsoid_t* ellipsoid)
 {
   shapeToGJK(s, tf, ellipsoid);
   ellipsoid->radii[0] = s.radii[0];
@@ -1964,14 +1974,16 @@ static void ellipsoidToGJK(const Ellipsoid<S>& s, const Transform3<S>& tf, ccd_e
 }
 
 template <typename S>
-static void convexToGJK(const Convex<S>& s, const Transform3<S>& tf, ccd_convex_t<S>* conv)
+static void convexToGJK(const Convex<S>& s, const Transform3<S>& tf,
+                        ccd_convex_t<S>* conv)
 {
   shapeToGJK(s, tf, conv);
   conv->convex = &s;
 }
 
 /** Support functions */
-static inline void supportBox(const void* obj, const ccd_vec3_t* dir_, ccd_vec3_t* v)
+static inline void supportBox(const void* obj, const ccd_vec3_t* dir_,
+                              ccd_vec3_t* v)
 {
   const ccd_box_t* o = static_cast<const ccd_box_t*>(obj);
   ccd_vec3_t dir;
@@ -1984,7 +1996,8 @@ static inline void supportBox(const void* obj, const ccd_vec3_t* dir_, ccd_vec3_
   ccdVec3Add(v, &o->pos);
 }
 
-static inline void supportCap(const void* obj, const ccd_vec3_t* dir_, ccd_vec3_t* v)
+static inline void supportCap(const void* obj, const ccd_vec3_t* dir_,
+                              ccd_vec3_t* v)
 {
   const ccd_cap_t* o = static_cast<const ccd_cap_t*>(obj);
   ccd_vec3_t dir, pos1, pos2;
@@ -2001,7 +2014,7 @@ static inline void supportCap(const void* obj, const ccd_vec3_t* dir_, ccd_vec3_
   ccdVec3Add(&pos1, v);
   ccdVec3Add(&pos2, v);
 
-  if(ccdVec3Z (&dir) > 0)
+  if (ccdVec3Z (&dir) > 0)
     ccdVec3Copy(v, &pos1);
   else
     ccdVec3Copy(v, &pos2);
@@ -2011,7 +2024,8 @@ static inline void supportCap(const void* obj, const ccd_vec3_t* dir_, ccd_vec3_
   ccdVec3Add(v, &o->pos);
 }
 
-static inline void supportCyl(const void* obj, const ccd_vec3_t* dir_, ccd_vec3_t* v)
+static inline void supportCyl(const void* obj, const ccd_vec3_t* dir_,
+                              ccd_vec3_t* v)
 {
   const ccd_cyl_t* cyl = static_cast<const ccd_cyl_t*>(obj);
   ccd_vec3_t dir;
@@ -2022,7 +2036,7 @@ static inline void supportCyl(const void* obj, const ccd_vec3_t* dir_, ccd_vec3_
 
   zdist = dir.v[0] * dir.v[0] + dir.v[1] * dir.v[1];
   zdist = sqrt(zdist);
-  if(ccdIsZero(zdist))
+  if (ccdIsZero(zdist))
     ccdVec3Set(v, 0., 0., ccdSign(ccdVec3Z(&dir)) * cyl->height);
   else
   {
@@ -2038,7 +2052,8 @@ static inline void supportCyl(const void* obj, const ccd_vec3_t* dir_, ccd_vec3_
   ccdVec3Add(v, &cyl->pos);
 }
 
-static inline void supportCone(const void* obj, const ccd_vec3_t* dir_, ccd_vec3_t* v)
+static inline void supportCone(const void* obj, const ccd_vec3_t* dir_,
+                               ccd_vec3_t* v)
 {
   const ccd_cone_t* cone = static_cast<const ccd_cone_t*>(obj);
   ccd_vec3_t dir;
@@ -2054,9 +2069,9 @@ static inline void supportCone(const void* obj, const ccd_vec3_t* dir_, ccd_vec3
 
   double sin_a = cone->radius / sqrt(cone->radius * cone->radius + 4 * cone->height * cone->height);
 
-  if(dir.v[2] > len * sin_a)
+  if (dir.v[2] > len * sin_a)
     ccdVec3Set(v, 0., 0., cone->height);
-  else if(zdist > 0)
+  else if (zdist > 0)
   {
     rad = cone->radius / zdist;
     ccdVec3Set(v, rad * ccdVec3X(&dir), rad * ccdVec3Y(&dir), -cone->height);
@@ -2069,7 +2084,8 @@ static inline void supportCone(const void* obj, const ccd_vec3_t* dir_, ccd_vec3
   ccdVec3Add(v, &cone->pos);
 }
 
-static inline void supportSphere(const void* obj, const ccd_vec3_t* dir_, ccd_vec3_t* v)
+static inline void supportSphere(const void* obj, const ccd_vec3_t* dir_,
+                                 ccd_vec3_t* v)
 {
   const ccd_sphere_t* s = static_cast<const ccd_sphere_t*>(obj);
   ccd_vec3_t dir;
@@ -2086,7 +2102,8 @@ static inline void supportSphere(const void* obj, const ccd_vec3_t* dir_, ccd_ve
   ccdVec3Add(v, &s->pos);
 }
 
-static inline void supportEllipsoid(const void* obj, const ccd_vec3_t* dir_, ccd_vec3_t* v)
+static inline void supportEllipsoid(const void* obj, const ccd_vec3_t* dir_,
+                                    ccd_vec3_t* v)
 {
   const ccd_ellipsoid_t* s = static_cast<const ccd_ellipsoid_t*>(obj);
   ccd_vec3_t dir;
@@ -2111,7 +2128,8 @@ static inline void supportEllipsoid(const void* obj, const ccd_vec3_t* dir_, ccd
 }
 
 template <typename S>
-static void supportConvex(const void* obj, const ccd_vec3_t* dir_, ccd_vec3_t* v)
+static void supportConvex(const void* obj, const ccd_vec3_t* dir_,
+                          ccd_vec3_t* v)
 {
   const auto* c = (const ccd_convex_t<S>*)obj;
   ccd_vec3_t dir, p;
@@ -2123,11 +2141,12 @@ static void supportConvex(const void* obj, const ccd_vec3_t* dir_, ccd_vec3_t* v
 
   maxdot = -CCD_REAL_MAX;
 
-  for(const auto& vertex : *(c->convex->getVertices()))
+  for (const auto& vertex : c->convex->getVertices())
   {
-    ccdVec3Set(&p, vertex[0] - center[0], vertex[1] - center[1], vertex[2] - center[2]);
+    ccdVec3Set(&p, vertex[0] - center[0], vertex[1] - center[1],
+        vertex[2] - center[2]);
     dot = ccdVec3Dot(&dir, &p);
-    if(dot > maxdot)
+    if (dot > maxdot)
     {
       ccdVec3Set(v, vertex[0], vertex[1], vertex[2]);
       maxdot = dot;
@@ -2139,7 +2158,8 @@ static void supportConvex(const void* obj, const ccd_vec3_t* dir_, ccd_vec3_t* v
   ccdVec3Add(v, &c->pos);
 }
 
-static void supportTriangle(const void* obj, const ccd_vec3_t* dir_, ccd_vec3_t* v)
+static void supportTriangle(const void* obj, const ccd_vec3_t* dir_,
+                            ccd_vec3_t* v)
 {
   const ccd_triangle_t* tri = static_cast<const ccd_triangle_t*>(obj);
   ccd_vec3_t dir, p;
@@ -2151,11 +2171,12 @@ static void supportTriangle(const void* obj, const ccd_vec3_t* dir_, ccd_vec3_t*
 
   maxdot = -CCD_REAL_MAX;
 
-  for(i = 0; i < 3; ++i)
+  for (i = 0; i < 3; ++i)
   {
-    ccdVec3Set(&p, tri->p[i].v[0] - tri->c.v[0], tri->p[i].v[1] - tri->c.v[1], tri->p[i].v[2] - tri->c.v[2]);
+    ccdVec3Set(&p, tri->p[i].v[0] - tri->c.v[0], tri->p[i].v[1] - tri->c.v[1],
+        tri->p[i].v[2] - tri->c.v[2]);
     dot = ccdVec3Dot(&dir, &p);
-    if(dot > maxdot)
+    if (dot > maxdot)
     {
       ccdVec3Copy(v, &tri->p[i]);
       maxdot = dot;
@@ -2195,7 +2216,8 @@ template <typename S>
 bool GJKCollide(void* obj1, ccd_support_fn supp1, ccd_center_fn cen1,
                 void* obj2, ccd_support_fn supp2, ccd_center_fn cen2,
                 unsigned int max_iterations, S tolerance,
-                Vector3<S>* contact_points, S* penetration_depth, Vector3<S>* normal)
+                Vector3<S>* contact_points, S* penetration_depth,
+                Vector3<S>* normal)
 {
   ccd_t ccd;
   int res;
@@ -2211,15 +2233,16 @@ bool GJKCollide(void* obj1, ccd_support_fn supp1, ccd_center_fn cen1,
   ccd.max_iterations = max_iterations;
   ccd.mpr_tolerance = tolerance;
 
-  if(!contact_points)
+  if (!contact_points)
   {
     return ccdMPRIntersect(obj1, obj2, &ccd);
   }
 
 
-  /// libccd returns dir and pos in world space and dir is pointing from object 1 to object 2
+  /// libccd returns dir and pos in world space and dir is pointing from
+  /// object 1 to object 2
   res = ccdMPRPenetration(obj1, obj2, &ccd, &depth, &dir, &pos);
-  if(res == 0)
+  if (res == 0)
   {
     *contact_points << ccdVec3X(&pos), ccdVec3Y(&pos), ccdVec3Z(&pos);
     *penetration_depth = depth;
@@ -2340,7 +2363,8 @@ GJKCenterFunction GJKInitializer<S, Cylinder<S>>::getCenterFunction()
 }
 
 template <typename S>
-void* GJKInitializer<S, Cylinder<S>>::createGJKObject(const Cylinder<S>& s, const Transform3<S>& tf)
+void* GJKInitializer<S, Cylinder<S>>::createGJKObject(const Cylinder<S>& s,
+                                                      const Transform3<S>& tf)
 {
   ccd_cyl_t* o = new ccd_cyl_t;
   cylToGJK(s, tf, o);
@@ -2367,7 +2391,8 @@ GJKCenterFunction GJKInitializer<S, Sphere<S>>::getCenterFunction()
 }
 
 template <typename S>
-void* GJKInitializer<S, Sphere<S>>::createGJKObject(const Sphere<S>& s, const Transform3<S>& tf)
+void* GJKInitializer<S, Sphere<S>>::createGJKObject(const Sphere<S>& s,
+                                                    const Transform3<S>& tf)
 {
   ccd_sphere_t* o = new ccd_sphere_t;
   sphereToGJK(s, tf, o);
@@ -2394,7 +2419,8 @@ GJKCenterFunction GJKInitializer<S, Ellipsoid<S>>::getCenterFunction()
 }
 
 template <typename S>
-void* GJKInitializer<S, Ellipsoid<S>>::createGJKObject(const Ellipsoid<S>& s, const Transform3<S>& tf)
+void* GJKInitializer<S, Ellipsoid<S>>::createGJKObject(const Ellipsoid<S>& s,
+                                                       const Transform3<S>& tf)
 {
   ccd_ellipsoid_t* o = new ccd_ellipsoid_t;
   ellipsoidToGJK(s, tf, o);
@@ -2421,7 +2447,8 @@ GJKCenterFunction GJKInitializer<S, Box<S>>::getCenterFunction()
 }
 
 template <typename S>
-void* GJKInitializer<S, Box<S>>::createGJKObject(const Box<S>& s, const Transform3<S>& tf)
+void* GJKInitializer<S, Box<S>>::createGJKObject(const Box<S>& s,
+                                                 const Transform3<S>& tf)
 {
   ccd_box_t* o = new ccd_box_t;
   boxToGJK(s, tf, o);
@@ -2448,7 +2475,8 @@ GJKCenterFunction GJKInitializer<S, Capsule<S>>::getCenterFunction()
 }
 
 template <typename S>
-void* GJKInitializer<S, Capsule<S>>::createGJKObject(const Capsule<S>& s, const Transform3<S>& tf)
+void* GJKInitializer<S, Capsule<S>>::createGJKObject(const Capsule<S>& s,
+                                                     const Transform3<S>& tf)
 {
   ccd_cap_t* o = new ccd_cap_t;
   capToGJK(s, tf, o);
@@ -2475,7 +2503,8 @@ GJKCenterFunction GJKInitializer<S, Cone<S>>::getCenterFunction()
 }
 
 template <typename S>
-void* GJKInitializer<S, Cone<S>>::createGJKObject(const Cone<S>& s, const Transform3<S>& tf)
+void* GJKInitializer<S, Cone<S>>::createGJKObject(const Cone<S>& s,
+                                                  const Transform3<S>& tf)
 {
   ccd_cone_t* o = new ccd_cone_t;
   coneToGJK(s, tf, o);
@@ -2502,7 +2531,8 @@ GJKCenterFunction GJKInitializer<S, Convex<S>>::getCenterFunction()
 }
 
 template <typename S>
-void* GJKInitializer<S, Convex<S>>::createGJKObject(const Convex<S>& s, const Transform3<S>& tf)
+void* GJKInitializer<S, Convex<S>>::createGJKObject(const Convex<S>& s,
+                                                    const Transform3<S>& tf)
 {
   auto* o = new ccd_convex_t<S>;
   convexToGJK(s, tf, o);
@@ -2527,10 +2557,12 @@ inline GJKCenterFunction triGetCenterFunction()
 }
 
 template <typename S>
-void* triCreateGJKObject(const Vector3<S>& P1, const Vector3<S>& P2, const Vector3<S>& P3)
+void* triCreateGJKObject(const Vector3<S>& P1, const Vector3<S>& P2,
+                         const Vector3<S>& P3)
 {
   ccd_triangle_t* o = new ccd_triangle_t;
-  Vector3<S> center((P1[0] + P2[0] + P3[0]) / 3, (P1[1] + P2[1] + P3[1]) / 3, (P1[2] + P2[2] + P3[2]) / 3);
+  Vector3<S> center((P1[0] + P2[0] + P3[0]) / 3, (P1[1] + P2[1] + P3[1]) / 3,
+      (P1[2] + P2[2] + P3[2]) / 3);
 
   ccdVec3Set(&o->p[0], P1[0], P1[1], P1[2]);
   ccdVec3Set(&o->p[1], P2[0], P2[1], P2[2]);
@@ -2544,10 +2576,12 @@ void* triCreateGJKObject(const Vector3<S>& P1, const Vector3<S>& P2, const Vecto
 }
 
 template <typename S>
-void* triCreateGJKObject(const Vector3<S>& P1, const Vector3<S>& P2, const Vector3<S>& P3, const Transform3<S>& tf)
+void* triCreateGJKObject(const Vector3<S>& P1, const Vector3<S>& P2,
+                         const Vector3<S>& P3, const Transform3<S>& tf)
 {
   ccd_triangle_t* o = new ccd_triangle_t;
-  Vector3<S> center((P1[0] + P2[0] + P3[0]) / 3, (P1[1] + P2[1] + P3[1]) / 3, (P1[2] + P2[2] + P3[2]) / 3);
+  Vector3<S> center((P1[0] + P2[0] + P3[0]) / 3, (P1[1] + P2[1] + P3[1]) / 3,
+      (P1[2] + P2[2] + P3[2]) / 3);
 
   ccdVec3Set(&o->p[0], P1[0], P1[1], P1[2]);
   ccdVec3Set(&o->p[1], P2[0], P2[1], P2[2]);

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -2144,10 +2144,9 @@ static void supportConvex(const void* obj, const ccd_vec3_t* dir_,
   for (const auto& vertex : c->convex->getVertices())
   {
     ccdVec3Set(&p, vertex[0] - center[0], vertex[1] - center[1],
-        vertex[2] - center[2]);
+               vertex[2] - center[2]);
     dot = ccdVec3Dot(&dir, &p);
-    if (dot > maxdot)
-    {
+    if (dot > maxdot) {
       ccdVec3Set(v, vertex[0], vertex[1], vertex[2]);
       maxdot = dot;
     }

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -2116,23 +2116,20 @@ static void supportConvex(const void* obj, const ccd_vec3_t* dir_, ccd_vec3_t* v
   const auto* c = (const ccd_convex_t<S>*)obj;
   ccd_vec3_t dir, p;
   ccd_real_t maxdot, dot;
-  int i;
-  Vector3<S>* curp;
-  const auto& center = c->convex->interior_point;
+  const auto& center = c->convex->getInteriorPoint();
 
   ccdVec3Copy(&dir, dir_);
   ccdQuatRotVec(&dir, &c->rot_inv);
 
   maxdot = -CCD_REAL_MAX;
-  curp = c->convex->vertices;
 
-  for(i = 0; i < c->convex->num_vertices; ++i, curp += 1)
+  for(const auto& vertex : *(c->convex->getVertices()))
   {
-    ccdVec3Set(&p, (*curp)[0] - center[0], (*curp)[1] - center[1], (*curp)[2] - center[2]);
+    ccdVec3Set(&p, vertex[0] - center[0], vertex[1] - center[1], vertex[2] - center[2]);
     dot = ccdVec3Dot(&dir, &p);
     if(dot > maxdot)
     {
-      ccdVec3Set(v, (*curp)[0], (*curp)[1], (*curp)[2]);
+      ccdVec3Set(v, vertex[0], vertex[1], vertex[2]);
       maxdot = dot;
     }
   }
@@ -2180,7 +2177,7 @@ template <typename S>
 static void centerConvex(const void* obj, ccd_vec3_t* c)
 {
   const auto *o = static_cast<const ccd_convex_t<S>*>(obj);
-  const Vector3<S>& p = o->convex->interior_point;
+  const Vector3<S>& p = o->convex->getInteriorPoint();
   ccdVec3Set(c, p[0], p[1], p[2]);
   ccdQuatRotVec(c, &o->rot);
   ccdVec3Add(c, &o->pos);

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/minkowski_diff-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/minkowski_diff-inl.h
@@ -183,14 +183,13 @@ Vector3<S> getSupport(
     {
       const Convex<S>* convex = static_cast<const Convex<S>*>(shape);
       S maxdot = - std::numeric_limits<S>::max();
-      Vector3<S>* curp = convex->vertices;
       Vector3<S> bestv = Vector3<S>::Zero();
-      for(int i = 0; i < convex->num_vertices; ++i, curp+=1)
+      for(const auto& vertex : *(convex->getVertices()))
       {
-        S dot = dir.dot(*curp);
+        S dot = dir.dot(vertex);
         if(dot > maxdot)
         {
-          bestv = *curp;
+          bestv = vertex;
           maxdot = dot;
         }
       }

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/minkowski_diff-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/minkowski_diff-inl.h
@@ -184,7 +184,7 @@ Vector3<S> getSupport(
       const Convex<S>* convex = static_cast<const Convex<S>*>(shape);
       S maxdot = - std::numeric_limits<S>::max();
       Vector3<S> bestv = Vector3<S>::Zero();
-      for(const auto& vertex : *(convex->getVertices()))
+      for(const auto& vertex : convex->getVertices())
       {
         S dot = dir.dot(vertex);
         if(dot > maxdot)

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/halfspace-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/halfspace-inl.h
@@ -500,7 +500,7 @@ bool convexHalfspaceIntersect(const Convex<S>& s1, const Transform3<S>& tf1,
   Vector3<S> v;
   S depth = std::numeric_limits<S>::max();
 
-  for(const auto& vertex : *(s1.getVertices()))
+  for (const auto& vertex : s1.getVertices())
   {
     Vector3<S> p = tf1 * vertex;
 

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/halfspace-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/halfspace-inl.h
@@ -500,9 +500,9 @@ bool convexHalfspaceIntersect(const Convex<S>& s1, const Transform3<S>& tf1,
   Vector3<S> v;
   S depth = std::numeric_limits<S>::max();
 
-  for(int i = 0; i < s1.num_vertices; ++i)
+  for(const auto& vertex : *(s1.getVertices()))
   {
-    Vector3<S> p = tf1 * s1.vertices[i];
+    Vector3<S> p = tf1 * vertex;
 
     S d = new_s2.signedDistance(p);
     if(d < depth)

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/plane-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/plane-inl.h
@@ -648,9 +648,9 @@ bool convexPlaneIntersect(const Convex<S>& s1, const Transform3<S>& tf1,
   Vector3<S> v_min, v_max;
   S d_min = std::numeric_limits<S>::max(), d_max = -std::numeric_limits<S>::max();
 
-  for(int i = 0; i < s1.num_vertices; ++i)
+  for(const auto& vertex : *(s1.getVertices()))
   {
-    Vector3<S> p = tf1 * s1.vertices[i];
+    Vector3<S> p = tf1 * vertex;
 
     S d = new_s2.signedDistance(p);
 

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/plane-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/plane-inl.h
@@ -648,7 +648,7 @@ bool convexPlaneIntersect(const Convex<S>& s1, const Transform3<S>& tf1,
   Vector3<S> v_min, v_max;
   S d_min = std::numeric_limits<S>::max(), d_max = -std::numeric_limits<S>::max();
 
-  for(const auto& vertex : *(s1.getVertices()))
+  for (const auto& vertex : s1.getVertices())
   {
     Vector3<S> p = tf1 * vertex;
 

--- a/src/math/bv/utility.cpp
+++ b/src/math/bv/utility.cpp
@@ -46,23 +46,23 @@ namespace OBB_fit_functions {
 
 //==============================================================================
 template
-void fit1(Vector3<double>* ps, OBB<double>& bv);
+void fit1(const Vector3d* const ps, OBB<double>& bv);
 
 //==============================================================================
 template
-void fit2(Vector3<double>* ps, OBB<double>& bv);
+void fit2(const Vector3d* const ps, OBB<double>& bv);
 
 //==============================================================================
 template
-void fit3(Vector3<double>* ps, OBB<double>& bv);
+void fit3(const Vector3d* const ps, OBB<double>& bv);
 
 //==============================================================================
 template
-void fit6(Vector3<double>* ps, OBB<double>& bv);
+void fit6(const Vector3d* const ps, OBB<double>& bv);
 
 //==============================================================================
 template
-void fitn(Vector3<double>* ps, int n, OBB<double>& bv);
+void fitn(const Vector3d* const ps, int n, OBB<double>& bv);
 
 //==============================================================================
 } // namespace OBB_fit_functions
@@ -74,23 +74,23 @@ namespace RSS_fit_functions {
 
 //==============================================================================
 template
-void fit1(Vector3<double>* ps, RSS<double>& bv);
+void fit1(const Vector3d* const ps, RSS<double>& bv);
 
 //==============================================================================
 template
-void fit2(Vector3<double>* ps, RSS<double>& bv);
+void fit2(const Vector3d* const ps, RSS<double>& bv);
 
 //==============================================================================
 template
-void fit3(Vector3<double>* ps, RSS<double>& bv);
+void fit3(const Vector3d* const ps, RSS<double>& bv);
 
 //==============================================================================
 template
-void fit6(Vector3<double>* ps, RSS<double>& bv);
+void fit6(const Vector3d* const ps, RSS<double>& bv);
 
 //==============================================================================
 template
-void fitn(Vector3<double>* ps, int n, RSS<double>& bv);
+void fitn(const Vector3d* const ps, int n, RSS<double>& bv);
 
 //==============================================================================
 } // namespace RSS_fit_functions
@@ -102,19 +102,19 @@ namespace kIOS_fit_functions {
 
 //==============================================================================
 template
-void fit1(Vector3<double>* ps, kIOS<double>& bv);
+void fit1(const Vector3d* const ps, kIOS<double>& bv);
 
 //==============================================================================
 template
-void fit2(Vector3<double>* ps, kIOS<double>& bv);
+void fit2(const Vector3d* const ps, kIOS<double>& bv);
 
 //==============================================================================
 template
-void fit3(Vector3<double>* ps, kIOS<double>& bv);
+void fit3(const Vector3d* const ps, kIOS<double>& bv);
 
 //==============================================================================
 template
-void fitn(Vector3<double>* ps, int n, kIOS<double>& bv);
+void fitn(const Vector3d* const ps, int n, kIOS<double>& bv);
 
 //==============================================================================
 } // namespace kIOS_fit_functions
@@ -126,19 +126,19 @@ namespace OBBRSS_fit_functions {
 
 //==============================================================================
 template
-void fit1(Vector3<double>* ps, OBBRSS<double>& bv);
+void fit1(const Vector3d* const ps, OBBRSS<double>& bv);
 
 //==============================================================================
 template
-void fit2(Vector3<double>* ps, OBBRSS<double>& bv);
+void fit2(const Vector3d* const ps, OBBRSS<double>& bv);
 
 //==============================================================================
 template
-void fit3(Vector3<double>* ps, OBBRSS<double>& bv);
+void fit3(const Vector3d* const ps, OBBRSS<double>& bv);
 
 //==============================================================================
 template
-void fitn(Vector3<double>* ps, int n, OBBRSS<double>& bv);
+void fitn(const Vector3d* const ps, int n, OBBRSS<double>& bv);
 
 //==============================================================================
 } // namespace OBBRSS_fit_functions

--- a/src/math/geometry.cpp
+++ b/src/math/geometry.cpp
@@ -77,8 +77,8 @@ void generateCoordinateSystem(Transform3d& tf);
 //==============================================================================
 template
 void getRadiusAndOriginAndRectangleSize(
-    Vector3d* ps,
-    Vector3d* ps2,
+    const Vector3d* const ps,
+    const Vector3d* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
@@ -90,8 +90,8 @@ void getRadiusAndOriginAndRectangleSize(
 //==============================================================================
 template
 void getRadiusAndOriginAndRectangleSize(
-    Vector3d* ps,
-    Vector3d* ps2,
+    const Vector3d* const ps,
+    const Vector3d* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
@@ -111,8 +111,8 @@ void circumCircleComputation(
 //==============================================================================
 template
 double maximumDistance(
-    Vector3d* ps,
-    Vector3d* ps2,
+    const Vector3d* const ps,
+    const Vector3d* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
@@ -121,8 +121,8 @@ double maximumDistance(
 //==============================================================================
 template
 void getExtentAndCenter(
-    Vector3d* ps,
-    Vector3d* ps2,
+    const Vector3d* const ps,
+    const Vector3d* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
@@ -133,8 +133,8 @@ void getExtentAndCenter(
 //==============================================================================
 template
 void getCovariance(
-    Vector3d* ps,
-    Vector3d* ps2,
+    const Vector3d* const ps,
+    const Vector3d* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n, Matrix3d& M);
@@ -146,44 +146,44 @@ namespace detail {
 //==============================================================================
 template
 double maximumDistance_mesh(
-    Vector3<double>* ps,
-    Vector3<double>* ps2,
+    const Vector3d* const ps,
+    const Vector3d* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
-    const Vector3<double>& query);
+    const Vector3d& query);
 
 //==============================================================================
 template
 double maximumDistance_pointcloud(
-    Vector3<double>* ps,
-    Vector3<double>* ps2,
+    const Vector3d* const ps,
+    const Vector3d* const ps2,
     unsigned int* indices,
     int n,
-    const Vector3<double>& query);
+    const Vector3d& query);
 
 //==============================================================================
 template
 void getExtentAndCenter_pointcloud(
-    Vector3<double>* ps,
-    Vector3<double>* ps2,
+    const Vector3d* const ps,
+    const Vector3d* const ps2,
     unsigned int* indices,
     int n,
-    const Matrix3<double>& axis,
-    Vector3<double>& center,
-    Vector3<double>& extent);
+    const Matrix3d& axis,
+    Vector3d& center,
+    Vector3d& extent);
 
 //==============================================================================
 template
 void getExtentAndCenter_mesh(
-    Vector3<double>* ps,
-    Vector3<double>* ps2,
+    const Vector3d* const ps,
+    const Vector3d* const ps2,
     Triangle* ts,
     unsigned int* indices,
     int n,
-    const Matrix3<double>& axis,
-    Vector3<double>& center,
-    Vector3<double>& extent);
+    const Matrix3d& axis,
+    Vector3d& center,
+    Vector3d& extent);
 
 //==============================================================================
 } // namespace detail

--- a/test/geometry/shape/test_convex.cpp
+++ b/test/geometry/shape/test_convex.cpp
@@ -79,11 +79,14 @@ struct ScalarString<float> {
 template <typename S>
 class Polytope {
  public:
-  explicit Polytope(S scale) : scale_(scale)
-  {
-    vertices_.reset(new std::vector<Vector3<S>>());
-    polygons_.reset(new std::vector<int>());
-  }
+  explicit Polytope(S scale)
+    : vertices_(std::make_shared<std::vector<Vector3<S>>>()),
+      polygons_(std::make_shared<std::vector<int>>()), scale_(scale) {}
+
+  Polytope(const Polytope &other)
+    : vertices_(std::make_shared<std::vector<Vector3<S>>>(*(other.vertices_))),
+      polygons_(std::make_shared<std::vector<int>>(*(other.polygons_))),
+      scale_(other.scale_) {}
 
   virtual int face_count() const = 0;
   virtual int vertex_count() const = 0;
@@ -164,7 +167,7 @@ class Polytope {
  private:
   std::shared_ptr<std::vector<Vector3<S>>> vertices_;
   std::shared_ptr<std::vector<int>> polygons_;
-  S scale_{1};
+  S scale_{};
 };
 
 // A simple regular tetrahedron with edges of length `scale` centered on the


### PR DESCRIPTION
Based on comments related to the convex shape to take `std::shared_ptr<aligned_vector<Vector3<S>>>` and `std::shared_ptr<std::vector<int>>` I decided to move forward and make the changes. 

I originally went down the route of changing all `Vector<S>*` to `const aligned_vector<Vector3<S>>&` but this quickly took me down a rabbit hole. I have a different branch where I left off, so if this is desirable I will continue working it and create a pull request. This PR does the minimum to integrate the use of new types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/338)
<!-- Reviewable:end -->
