### PR TITLE
Various CMake fixes and cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ else()
   cmake_minimum_required(VERSION 2.8.12)
 endif()
 
-project(fcl C CXX)
+project(fcl CXX)
 
 # Compiler ID for Apple Clang is now AppleClang.
 if(POLICY CMP0025)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,26 +1,50 @@
+# -*- mode: cmake -*-
+# vi: set ft=cmake :
+
+# Copyright (c) 2012, Willow Garage, Inc.
+# Copyright (c) 2016, Toyota Research Institute, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
 if(APPLE)
-  cmake_minimum_required(VERSION 3.0.00)
+  cmake_minimum_required(VERSION 3.0.0)
 elseif(MSVC)
   cmake_minimum_required(VERSION 3.1.3)
 else()
   cmake_minimum_required(VERSION 2.8.12)
 endif()
 
-# Set the CMAKE_CXX_COMPILER_ID variable to AppleClang instead of Clang.
-# AppleClang and Clang have different version number. This was introduced in
-# CMake 3.0.
+project(fcl C CXX)
+
+# Compiler ID for Apple Clang is now AppleClang.
 if(POLICY CMP0025)
   cmake_policy(SET CMP0025 NEW)
 endif()
-
-# Use MACOSX_RPATH by default on OS X. This was added in CMake 2.8.12 and
-# became default in CMake 3.0. Explicitly setting this policy is necessary to
-# suppress a warning in CMake 3.0 and above.
-if(POLICY CMP0042)
-  cmake_policy(SET CMP0042 NEW)
-endif()
-
-project(fcl CXX C)
 
 include(CTest)
 
@@ -49,11 +73,11 @@ endif (MSVC OR MSVC90 OR MSVC10)
 
 set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
+include(GenerateExportHeader)
+include(GNUInstallDirs)
 include(FCLMacros)
 include(CompilerSettings)
 include(FCLVersion)
-include(GNUInstallDirs)
-include(GenerateExportHeader)
 
 if(MSVC OR IS_ICPC)
   option(FCL_STATIC_LIBRARY "Whether the FCL library should be static rather than shared" ON)

--- a/CMakeModules/CompilerSettings.cmake
+++ b/CMakeModules/CompilerSettings.cmake
@@ -1,3 +1,36 @@
+# -*- mode: cmake -*-
+# vi: set ft=cmake :
+
+# Copyright (c) 2013, Willow Garage, Inc.
+# Copyright (c) 2017, Toyota Research Institute, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
 # GCC
 if(CMAKE_COMPILER_IS_GNUCXX)
     add_definitions(-std=c++11 -W -Wall -Wextra -Wpedantic)
@@ -85,11 +118,11 @@ mark_as_advanced(FCL_NO_DEFAULT_RPATH)
 
 # Set rpath http://www.paraview.org/Wiki/CMake_RPATH_handling
 if(FCL_NO_DEFAULT_RPATH)
-    message(STATUS "Set RPATH explicitly to '${CMAKE_INSTALL_LIBDIR_FULL}'")
-    set(CMAKE_SKIP_BUILD_RPATH FALSE)
-    set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR_FULL}")
-    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+    message(STATUS "Set RPATH explicitly to '${CMAKE_INSTALL_FULL_LIBDIR}'")
+    set(CMAKE_SKIP_BUILD_RPATH OFF)
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH OFF)
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
+    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
 endif()
 
 # no prefix needed for python modules

--- a/CMakeModules/CompilerSettings.cmake
+++ b/CMakeModules/CompilerSettings.cmake
@@ -124,6 +124,3 @@ if(FCL_NO_DEFAULT_RPATH)
     set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
     set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
 endif()
-
-# no prefix needed for python modules
-set(CMAKE_SHARED_MODULE_PREFIX "")


### PR DESCRIPTION
Do not set redundant macOS-related policy; `CMP0042` is enabled by virtue of requiring CMake 3.0 on macOS. Do not require a C compiler; there is no C code. Fix typo in `CMAKE_INSTALL_FULL_LIBDIR` variable name; there is no such variable `CMAKE_INSTALL_LIBDIR_FULL`. Remove redundant set of `CMAKE_SHARED_MODULE_PREFIX`; there are no modules being built.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/360)
<!-- Reviewable:end -->
