### PR TITLE
Default-defined method on extern-templated class not visible

### DIFF
--- a/include/fcl/geometry/shape/convex.h
+++ b/include/fcl/geometry/shape/convex.h
@@ -102,7 +102,7 @@ public:
          int num_faces, const std::shared_ptr<const std::vector<int>>& faces);
 
   /// @brief Copy constructor 
-  Convex(const Convex& other) = default;
+  Convex(const Convex& other);
 
   ~Convex() = default;
 
@@ -164,6 +164,12 @@ private:
   const std::shared_ptr<const std::vector<int>> faces_;
   Vector3<S> interior_point_;
 };
+
+// Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57728 which
+// should be moved back into the class definition once we no longer need to
+// support GCC versions prior to 6.3.
+template <typename S>
+Convex<S>::Convex(const Convex<S>& other) = default;
 
 using Convexf = Convex<float>;
 using Convexd = Convex<double>;


### PR DESCRIPTION
This addresses a bug unique to versions of GCC prior to 6.3. It loses methods that are `= default` defined. Specifically, this enables downstream applications from being able to use the `Convex(const Convex&)` copy constructor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/369)
<!-- Reviewable:end -->
