### PR TITLE
Literal defined as ccd_real_t

### DIFF
--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_gjk_doSimplex2.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_gjk_doSimplex2.cpp
@@ -178,7 +178,8 @@ TEST_F(DoSimplex2Test, NeedMoreComputing) {
                          const Vector3Ccd& dir) {
     // If p_OA or p_OB are large vectors, we need to scale EPS up to be able
     // to recognize a valid direction to machine precision.
-    const ccd_real_t eps = std::max({1., p_OA.norm(), p_OB.norm()}) * kEps;
+    const ccd_real_t eps =
+        std::max({ccd_real_t(1), p_OA.norm(), p_OB.norm()}) * kEps;
     const Vector3Ccd phat_AB = (p_OB - p_OA).normalized();
     const Vector3Ccd dir_hat = dir.normalized();
     if (std::abs(dir_hat.dot(phat_AB)) > eps) {


### PR DESCRIPTION
A literal in a type-deduced function call was declared as a `double` literal (e.g., `1.`). When `ccd_real_t` is a `double`, this is fine. But when it is a `float`, the type cannot be successfully deduced.

We correct this by explicitly calling it out as a `ccd_real_t`-typed value.

resolves #372

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/373)
<!-- Reviewable:end -->
