### PR TITLE
Report configuration state for narrowphase errors

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -2037,7 +2037,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = FCL_DOXYGEN_CXX=1
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/include/fcl/geometry/shape/box.h
+++ b/include/fcl/geometry/shape/box.h
@@ -40,6 +40,8 @@
 
 #include "fcl/geometry/shape/shape_base.h"
 
+#include <iostream>
+
 namespace fcl
 {
 
@@ -78,6 +80,12 @@ public:
   /// @brief get the vertices of some convex shape which can bound this shape in
   /// a specific configuration
   std::vector<Vector3<S>> getBoundVertices(const Transform3<S>& tf) const;
+
+  friend
+  std::ostream& operator<<(std::ostream& out, const Box& box) {
+    out << "Box" << box.side.transpose();
+    return out;
+  }
 };
 
 using Boxf = Box<float>;

--- a/include/fcl/geometry/shape/capsule.h
+++ b/include/fcl/geometry/shape/capsule.h
@@ -38,6 +38,8 @@
 #ifndef FCL_SHAPE_CAPSULE_H
 #define FCL_SHAPE_CAPSULE_H
 
+#include <iostream>
+
 #include "fcl/geometry/shape/shape_base.h"
 
 namespace fcl
@@ -75,6 +77,12 @@ public:
   /// @brief get the vertices of some convex shape which can bound this shape in
   /// a specific configuration
   std::vector<Vector3<S>> getBoundVertices(const Transform3<S>& tf) const;
+
+  friend
+  std::ostream& operator<<(std::ostream& out, const Capsule& capsule) {
+    out << "Capsule(r: " << capsule.radius << ", lz: " << capsule.lz << ")";
+    return out;
+  }
 };
 
 using Capsulef = Capsule<float>;

--- a/include/fcl/geometry/shape/cone.h
+++ b/include/fcl/geometry/shape/cone.h
@@ -38,6 +38,8 @@
 #ifndef FCL_SHAPE_CONE_H
 #define FCL_SHAPE_CONE_H
 
+#include <iostream>
+
 #include "fcl/geometry/shape/shape_base.h"
 
 namespace fcl
@@ -77,6 +79,12 @@ public:
   /// @brief get the vertices of some convex shape which can bound this shape in
   /// a specific configuration
   std::vector<Vector3<S>> getBoundVertices(const Transform3<S>& tf) const;
+
+  friend
+  std::ostream& operator<<(std::ostream& out, const Cone& cone) {
+    out << "Cone(r: " << cone.radius << ", lz: " << cone.lz << ")";
+    return out;
+  }
 };
 
 using Conef = Cone<float>;

--- a/include/fcl/geometry/shape/convex.h
+++ b/include/fcl/geometry/shape/convex.h
@@ -39,6 +39,8 @@
 #ifndef FCL_SHAPE_CONVEX_H
 #define FCL_SHAPE_CONVEX_H
 
+#include <iostream>
+
 #include "fcl/geometry/shape/shape_base.h"
 
 namespace fcl
@@ -157,6 +159,13 @@ public:
   /// @brief Gets the vertices of some convex shape which can bound this shape in
   /// a specific configuration
   std::vector<Vector3<S>> getBoundVertices(const Transform3<S>& tf) const;
+
+  friend
+  std::ostream& operator<<(std::ostream& out, const Convex& convex) {
+    out << "Convex(v count: " << convex.vertices_->size() << ", f count: "
+        << convex.getFaceCount() << ")";
+    return out;
+  }
 
 private:
   const std::shared_ptr<const std::vector<Vector3<S>>> vertices_;

--- a/include/fcl/geometry/shape/cylinder.h
+++ b/include/fcl/geometry/shape/cylinder.h
@@ -38,6 +38,8 @@
 #ifndef FCL_SHAPE_CYLINDER_H
 #define FCL_SHAPE_CYLINDER_H
 
+#include <iostream>
+
 #include "fcl/geometry/shape/shape_base.h"
 
 namespace fcl
@@ -75,6 +77,12 @@ public:
   /// @brief get the vertices of some convex shape which can bound this shape in
   /// a specific configuration
   std::vector<Vector3<S>> getBoundVertices(const Transform3<S>& tf) const;
+
+  friend
+  std::ostream& operator<<(std::ostream& out, const Cylinder& cylinder) {
+    out << "Cylinder(r: " << cylinder.radius << ", lz: " << cylinder.lz << ")";
+    return out;
+  }
 };
 
 using Cylinderf = Cylinder<float>;

--- a/include/fcl/geometry/shape/ellipsoid.h
+++ b/include/fcl/geometry/shape/ellipsoid.h
@@ -38,6 +38,8 @@
 #ifndef FCL_SHAPE_ELLIPSOID_H
 #define FCL_SHAPE_ELLIPSOID_H
 
+#include <iostream>
+
 #include "fcl/geometry/shape/shape_base.h"
 
 namespace fcl
@@ -75,6 +77,12 @@ public:
   /// @brief get the vertices of some convex shape which can bound this shape in
   /// a specific configuration
   std::vector<Vector3<S>> getBoundVertices(const Transform3<S>& tf) const;
+
+  friend
+  std::ostream& operator<<(std::ostream& out, const Ellipsoid& ellipsoid) {
+    out << "Ellipsoid(radii: " << ellipsoid.radii.transpose() << ")";
+    return out;
+  }
 };
 
 using Ellipsoidf = Ellipsoid<float>;

--- a/include/fcl/geometry/shape/halfspace.h
+++ b/include/fcl/geometry/shape/halfspace.h
@@ -38,6 +38,8 @@
 #ifndef FCL_SHAPE_HALFSPACE_H
 #define FCL_SHAPE_HALFSPACE_H
 
+#include <iostream>
+
 #include "fcl/geometry/shape/shape_base.h"
 #include "fcl/math/bv/OBB.h"
 #include "fcl/math/bv/RSS.h"
@@ -81,6 +83,13 @@ public:
   
   /// @brief Planed offset
   S d;
+
+  friend
+  std::ostream& operator<<(std::ostream& out, const Halfspace& halfspace) {
+    out << "Halfspace(n: " << halfspace.n.transpose() << ", d: "
+        << halfspace.d << ")";
+    return out;
+  }
 
 protected:
 

--- a/include/fcl/geometry/shape/plane.h
+++ b/include/fcl/geometry/shape/plane.h
@@ -38,6 +38,8 @@
 #ifndef FCL_SHAPE_PLANE_H
 #define FCL_SHAPE_PLANE_H
 
+#include <iostream>
+
 #include "fcl/geometry/shape/shape_base.h"
 
 namespace fcl
@@ -74,6 +76,12 @@ public:
 
   /// @brief Plane offset 
   S d;
+
+  friend
+  std::ostream& operator<<(std::ostream& out, const Plane& plane) {
+    out << "Plane(n: " << plane.n.transpose() << ", d: " << plane.d << ")";
+    return out;
+  }
 
 protected:
   

--- a/include/fcl/geometry/shape/sphere.h
+++ b/include/fcl/geometry/shape/sphere.h
@@ -40,6 +40,8 @@
 
 #include "fcl/geometry/shape/shape_base.h"
 
+#include <iostream>
+
 namespace fcl
 {
 
@@ -69,6 +71,12 @@ public:
   /// @brief get the vertices of some convex shape which can bound this shape in
   /// a specific configuration
   std::vector<Vector3<S>> getBoundVertices(const Transform3<S>& tf) const;
+
+  friend
+  std::ostream& operator<<(std::ostream& out, const Sphere& sphere) {
+    out << "Sphere(" << sphere.radius << ")";
+    return out;
+  }
 };
 
 using Spheref = Sphere<float>;

--- a/include/fcl/geometry/shape/triangle_p.h
+++ b/include/fcl/geometry/shape/triangle_p.h
@@ -38,6 +38,8 @@
 #ifndef FCL_SHAPE_TRIANGLE_P_H
 #define FCL_SHAPE_TRIANGLE_P_H
 
+#include <iostream>
+
 #include "fcl/geometry/shape/shape_base.h"
 
 namespace fcl
@@ -68,6 +70,13 @@ public:
   /// @brief get the vertices of some convex shape which can bound this shape in
   /// a specific configuration
   std::vector<Vector3<S>> getBoundVertices(const Transform3<S>& tf) const;
+
+  friend
+  std::ostream& operator<<(std::ostream& out, const TriangleP& tri) {
+    out << "TriangleP(a: " << tri.a.transpose()
+        << ", b: " << tri.b.transpose() << ", c: " << tri.c.transpose() << ")";
+    return out;
+  }
 };
 
 using TrianglePf = TriangleP<float>;

--- a/include/fcl/narrowphase/detail/failed_at_this_configuration.h
+++ b/include/fcl/narrowphase/detail/failed_at_this_configuration.h
@@ -1,0 +1,125 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019. Toyota Research Institute
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of CNRS-LAAS and AIST nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @author Sean Curtis (sean@tri.global) */
+
+#ifndef FCL_FAILED_AT_THIS_CONFIGURATION_H
+#define FCL_FAILED_AT_THIS_CONFIGURATION_H
+
+#include <exception>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#include "fcl/export.h"
+
+namespace fcl {
+namespace detail {
+
+/** A custom exception type that can be thrown in low-level code indicating
+ that the program has reached an unexpected configuration and that the caller
+ that ultimately has access to the collision objects and their transforms
+ should report the configuration that led to the exception.
+
+ This is strictly an _internal_ exception; it should *always* be caught and
+ transformed into an exception that propagates to the operating system.
+
+ Recommended usage is to throw by invoking the macro
+ FCL_THROW_UNEXPECTED_CONFIGURATION_EXCEPTION defined below. Code that exercises
+ functionality that throws this type of exception should catch it and transform
+ it to a `std::logic_error` by invoking ThrowDetailedConfiguration().  */
+class FCL_EXPORT FailedAtThisConfiguration final
+    : public std::exception {
+ public:
+  FailedAtThisConfiguration(const std::string& message)
+      : std::exception(), message_(message) {}
+
+  const char* what() const noexcept final { return message_.c_str(); }
+
+ private:
+  std::string message_;
+};
+
+/** Helper function for dispatching an `FailedAtThisConfiguration`.
+ Because this exception is designed to be caught and repackaged, we lose the
+ automatic association with file and line number. This wraps them into the
+ message of the exception so it can be preserved in the re-wrapping.
+
+ @param message  The error message itself.
+ @param func     The name of the invoking function.
+ @param file     The name of the file associated with the exception.
+ @param line     The line number where the exception is thrown.  */
+FCL_EXPORT void ThrowFailedAtThisConfiguration(
+    const std::string& message, const char* func, const char* file, int line);
+
+/** Helper class for propagating a low-level exception upwards but with
+ configuration-specific details appended. The parameters
+ 
+ @param s1        The first shape in the query.
+ @param X_FS1     The pose of the first shape in frame F.
+ @param s2        The second shape in the query.
+ @param X_FS2     The pose of the second shape in frame F.
+ @param solver    The solver.
+ @param e         The original exception.
+ @tparam Shape1   The type of shape for shape 1.
+ @tparam Shape2   The type of shape for shape 2.
+ @tparam Solver   The solver type (with scalar type erase).
+ @tparam Pose     The pose type (a Transform<S> with scalar type erased).
+ */
+template <typename Shape1, typename Shape2, typename Solver, typename Pose>
+void ThrowDetailedConfiguration(const Shape1& s1, const Pose& X_FS1,
+                                const Shape2& s2, const Pose& X_FS2,
+                                const Solver& solver, const std::exception& e) {
+  std::stringstream ss;
+  ss << std::setprecision(20);
+  ss << "Error with configuration"
+     << "\n  Original error message: " << e.what()
+     << "\n  Shape 1: " << s1
+     << "\n  X_FS1\n" << X_FS1.matrix()
+     << "\n  Shape 2: " << s2
+     << "\n  X_FS2\n" << X_FS2.matrix()
+     << "\n  Solver: " << solver;
+  throw std::logic_error(ss.str());
+}
+
+}  // namespace detail
+}  // namespace fcl
+
+#define FCL_THROW_FAILED_AT_THIS_CONFIGURATION(message)            \
+  ::fcl::detail::ThrowFailedAtThisConfiguration(message, __func__, __FILE__, \
+                                                __LINE__)
+
+#endif  // FCL_FAILED_AT_THIS_CONFIGURATION_H

--- a/include/fcl/narrowphase/detail/gjk_solver_indep-inl.h
+++ b/include/fcl/narrowphase/detail/gjk_solver_indep-inl.h
@@ -57,6 +57,7 @@
 #include "fcl/narrowphase/detail/primitive_shape_algorithm/box_box.h"
 #include "fcl/narrowphase/detail/primitive_shape_algorithm/halfspace.h"
 #include "fcl/narrowphase/detail/primitive_shape_algorithm/plane.h"
+#include "fcl/narrowphase/detail/failed_at_this_configuration.h"
 
 namespace fcl
 {
@@ -669,8 +670,14 @@ bool GJKSolver_indep<S>::shapeSignedDistance(
     Vector3<S>* p2) const
 {
   // TODO: should implement the signed distance version
-  return ShapeDistanceIndepImpl<S, Shape1, Shape2>::run(
+  bool result = false;
+  try {
+    result = ShapeDistanceIndepImpl<S, Shape1, Shape2>::run(
         *this, s1, tf1, s2, tf2, dist, p1, p2);
+  } catch (const FailedAtThisConfiguration& e) {
+    ThrowDetailedConfiguration(s1, tf1, s2, tf2, *this, e);
+  }
+  return result;
 }
 
 // Shape distance algorithms not using built-in GJK algorithm

--- a/include/fcl/narrowphase/detail/gjk_solver_indep.h
+++ b/include/fcl/narrowphase/detail/gjk_solver_indep.h
@@ -38,6 +38,8 @@
 #ifndef FCL_NARROWPHASE_GJKSOLVERINDEP_H
 #define FCL_NARROWPHASE_GJKSOLVERINDEP_H
 
+#include <iostream>
+
 #include "fcl/common/types.h"
 #include "fcl/narrowphase/contact_point.h"
 
@@ -179,6 +181,20 @@ struct FCL_EXPORT GJKSolver_indep
 
   /// @brief smart guess
   mutable Vector3<S> cached_guess;
+
+  friend
+  std::ostream& operator<<(std::ostream& out, const GJKSolver_indep& solver) {
+    out << "GjkSolver_indep"
+        << "\n    gjk tolerance:       " << solver.gjk_tolerance
+        << "\n    gjk max iterations:  " << solver.gjk_max_iterations
+        << "\n    epa tolerance:       " << solver.epa_tolerance
+        << "\n    epa max face num:    " << solver.epa_max_face_num
+        << "\n    epa max vertex num:  " << solver.epa_max_vertex_num
+        << "\n    epa max iterations:  " << solver.epa_max_iterations
+        << "\n    enable cahced guess: " << solver.enable_cached_guess;
+    if (solver.enable_cached_guess) out << solver.cached_guess.transpose();
+    return out;
+  }
 };
 
 using GJKSolver_indepf = GJKSolver_indep<float>;

--- a/include/fcl/narrowphase/detail/gjk_solver_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/gjk_solver_libccd-inl.h
@@ -54,6 +54,7 @@
 #include "fcl/narrowphase/detail/primitive_shape_algorithm/box_box.h"
 #include "fcl/narrowphase/detail/primitive_shape_algorithm/halfspace.h"
 #include "fcl/narrowphase/detail/primitive_shape_algorithm/plane.h"
+#include "fcl/narrowphase/detail/failed_at_this_configuration.h"
 
 namespace fcl
 {
@@ -556,7 +557,7 @@ struct ShapeSignedDistanceLibccdImpl
     void* o1 = detail::GJKInitializer<S, Shape1>::createGJKObject(s1, tf1);
     void* o2 = detail::GJKInitializer<S, Shape2>::createGJKObject(s2, tf2);
 
-    bool res =  detail::GJKSignedDistance(
+    bool res = detail::GJKSignedDistance(
           o1,
           detail::GJKInitializer<S, Shape1>::getSupportFunction(),
           o2,
@@ -585,8 +586,14 @@ bool GJKSolver_libccd<S>::shapeSignedDistance(
     Vector3<S>* p1,
     Vector3<S>* p2) const
 {
-  return ShapeSignedDistanceLibccdImpl<S, Shape1, Shape2>::run(
+  bool result = false;
+  try {
+    result = ShapeSignedDistanceLibccdImpl<S, Shape1, Shape2>::run(
         *this, s1, tf1, s2, tf2, dist, p1, p2);
+  } catch (const FailedAtThisConfiguration& e) {
+    ThrowDetailedConfiguration(s1, tf1, s2, tf2, *this, e);
+  }
+  return result;
 }
 
 

--- a/include/fcl/narrowphase/detail/gjk_solver_libccd.h
+++ b/include/fcl/narrowphase/detail/gjk_solver_libccd.h
@@ -38,6 +38,8 @@
 #ifndef FCL_NARROWPHASE_GJKSOLVERLIBCCD_H
 #define FCL_NARROWPHASE_GJKSOLVERLIBCCD_H
 
+#include <iostream>
+
 #include "fcl/common/types.h"
 #include "fcl/narrowphase/contact_point.h"
 
@@ -167,6 +169,17 @@ struct FCL_EXPORT GJKSolver_libccd
 
   /// @brief the threshold used in GJK algorithm to stop distance iteration
   S distance_tolerance;
+
+  friend
+  std::ostream& operator<<(std::ostream& out, const GJKSolver_libccd& solver) {
+    out << "GjkSolver_libccd"
+        << "\n    collision_tolerance:      " << solver.collision_tolerance
+        << "\n    max collision iterations: " << solver.max_collision_iterations
+        << "\n    distance tolerance:       " << solver.distance_tolerance
+        << "\n    max distance iterations:  " << solver.max_distance_iterations;
+    // NOTE: Cached guesses are not supported.
+    return out;
+  }
 
 };
 

--- a/src/narrowphase/detail/failed_at_this_configuration.cpp
+++ b/src/narrowphase/detail/failed_at_this_configuration.cpp
@@ -1,0 +1,17 @@
+#include "fcl/narrowphase/detail/failed_at_this_configuration.h"
+
+#include <sstream>
+
+namespace fcl {
+namespace detail {
+
+void ThrowFailedAtThisConfiguration(const std::string& message,
+                                    const char* func,
+                                    const char* file, int line) {
+  std::stringstream ss;
+  ss << file << ":(" << line << "): " << func << "(): " << message;
+  throw FailedAtThisConfiguration(ss.str());
+}
+
+}  // namespace detail
+}  // namespace fcl

--- a/test/expect_throws_message.h
+++ b/test/expect_throws_message.h
@@ -1,0 +1,143 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018. Toyota Research Institute
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Open Source Robotics Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// This code was taken from Drake.
+// https://github.com/RobotLocomotion/drake/blob/master/common/test_utilities/expect_throws_message.h
+
+#ifndef FCL_EXPECT_THROWS_MESSAGE_H
+#define FCL_EXPECT_THROWS_MESSAGE_H
+
+#include <regex>
+#include <string>
+
+#ifdef FCL_DOXYGEN_CXX
+
+/** Unit test helper macro for "expecting" an exception to be thrown but also
+testing the error message against a provided regular expression. This is
+like GTest's `EXPECT_THROW` but is fussier about the particular error message.
+Usage example: @code
+  FCL_EXPECT_THROWS_MESSAGE(
+      StatementUnderTest(), // You expect this statement to throw ...
+      std::logic_error,     // ... this exception with ...
+      ".*some important.*phrases.*that must appear.*");  // ... this message.
+@endcode
+The regular expression must match the entire error message. If there is
+boilerplate you don't care to match at the beginning and end, surround with
+`.*` to ignore.
+
+Following GTest's conventions, failure to perform as expected here is a
+non-fatal test error. An `ASSERT` variant is provided to make it fatal. There
+are also `*_IF_ARMED` variants. These require an exception in Debug builds. In
+Release builds, the expression will pass if it _doesn't_ throw or if it throws
+an exception that would pass the same test as in Debug builds. There is no
+mechanism for testing _exclusive_ throwing behavior (i.e., only throws in
+Debug).
+@see FCL_ASSERT_THROWS_MESSAGE
+@see FCL_EXPECT_THROWS_MESSAGE_IF_ARMED, FCL_ASSERT_THROWS_MESSAGE_IF_ARMED */
+#define FCL_EXPECT_THROWS_MESSAGE(expression, exception, regexp)
+
+/** Fatal error version of `FCL_EXPECT_THROWS_MESSAGE`.
+@see FCL_EXPECT_THROWS_MESSAGE */
+#define FCL_ASSERT_THROWS_MESSAGE(expression, exception, regexp)
+
+/** Same as `FCL_EXPECT_THROWS_MESSAGE` in Debug builds, but doesn't require
+a throw in Release builds. However, if the Release build does throw it must
+throw the right message. More precisely, the thrown message is required
+whenever `FCL_ENABLE_ASSERTS` is defined, which Debug builds do by default.
+@see FCL_EXPECT_THROWS_MESSAGE */
+#define FCL_EXPECT_THROWS_MESSAGE_IF_ARMED(expression, exception, regexp)
+
+/** Same as `FCL_ASSERT_THROWS_MESSAGE` in Debug builds, but doesn't require
+a throw in Release builds. However, if the Release build does throw it must
+throw the right message. More precisely, the thrown message is required
+whenever `FCL_ENABLE_ASSERTS` is defined, which Debug builds do by default.
+@see FCL_ASSERT_THROWS_MESSAGE */
+#define FCL_ASSERT_THROWS_MESSAGE_IF_ARMED(expression, exception, regexp)
+
+#else  // FCL_DOXYGEN_CXX
+
+#define FCL_EXPECT_THROWS_MESSAGE_HELPER(expression, exception, regexp, \
+                                         must_throw, fatal_failure) \
+try { \
+  expression; \
+  if (must_throw) { \
+    if (fatal_failure) { \
+      GTEST_FATAL_FAILURE_("\t" #expression " failed to throw " #exception); \
+    } else { \
+      GTEST_NONFATAL_FAILURE_("\t" #expression " failed to throw " #exception);\
+    } \
+  } \
+} catch (const exception& err) { \
+  auto matcher = [](const char* s, const std::string& re) { \
+    return std::regex_match(s, std::regex(re)); }; \
+  if (fatal_failure) { \
+    ASSERT_PRED2(matcher, err.what(), regexp); \
+  } else { \
+    EXPECT_PRED2(matcher, err.what(), regexp); \
+  } \
+}
+
+#define FCL_EXPECT_THROWS_MESSAGE(expression, exception, regexp) \
+  FCL_EXPECT_THROWS_MESSAGE_HELPER(expression, exception, regexp, \
+                                     true /*must_throw*/, false /*non-fatal*/)
+
+#define FCL_ASSERT_THROWS_MESSAGE(expression, exception, regexp) \
+  FCL_EXPECT_THROWS_MESSAGE_HELPER(expression, exception, regexp, \
+                                   true /*must_throw*/, true /*fatal*/)
+
+#ifdef NDEBUG
+// Throwing the expected message is optional in this case.
+
+#define FCL_EXPECT_THROWS_MESSAGE_IF_DEBUG(expression, exception, regexp) \
+  FCL_EXPECT_THROWS_MESSAGE_HELPER(expression, exception, regexp, \
+                                   false /*optional*/, false /*non-fatal*/)
+
+#define FCL_ASSERT_THROWS_MESSAGE_IF_DEBUG(expression, exception, regexp) \
+  FCL_EXPECT_THROWS_MESSAGE_HELPER(expression, exception, regexp, \
+                                   false /*optional*/, true /*fatal*/)
+
+#else  // NDEBUG
+// Throwing the expected message is required in this case.
+
+#define FCL_EXPECT_THROWS_MESSAGE_IF_DEBUG(expression, exception, regexp) \
+  FCL_EXPECT_THROWS_MESSAGE(expression, exception, regexp)
+
+#define FCL_ASSERT_THROWS_MESSAGE_IF_DEBUG(expression, exception, regexp) \
+  FCL_ASSERT_THROWS_MESSAGE(expression, exception, regexp)
+
+#endif  // NDEBUG
+
+#endif  // FCL_DOXYGEN_CXX
+
+#endif  // FCL_EXPECT_THROWS_MESSAGE_H


### PR DESCRIPTION
This allows low-level, narrowphase algorithms to indicate to higher-level callers that something went so wrong that it would be helpful to capture the configuration that led to the error.

resolves #364

Add exception
  1. Add exception type.
  2. Instrument some know problem call sites with the new exception.
  3. Expand unit tests to cover the exceptions.
     i. Add FCL_EXPECT_THROWS_MESSAGE* functionality for tests.

Add exception catching
  1. Add exception processing at an appropriate call site.
     1. Requires printing out shapes and solver data; so streaming operator
        support has been added to all corresponding parties.
     2. Added *only* to signed distance functions of both solvers.

Notes:
  - This doesn't include any unit test for the exception being thrown in context because it has historically been difficult to author such scenarios (which is why we are creating this in the first place). I'm open to testing suggestions.
  - `CollisionGeometry` can span multiple types and this doesn't necessarily cover them all. However, unit tests pass and this can be extended to encompass more geometry types as shown necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/381)
<!-- Reviewable:end -->
