### PR TITLE
Provide catkin package.xml per ROS REP 136

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,6 +287,9 @@ install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 
 install(FILES "${pkg_conf_file_out}" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/ COMPONENT pkgconfig)
 
+# Install catkin package.xml
+install(FILES package.xml DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME})
+
 # Add uninstall target
 configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules/cmake_uninstall.cmake.in"

--- a/CMakeModules/FCLVersion.cmake
+++ b/CMakeModules/FCLVersion.cmake
@@ -1,7 +1,11 @@
 # set the version in a way CMake can use
-set(FCL_MAJOR_VERSION 0)
-set(FCL_MINOR_VERSION 6)
-set(FCL_PATCH_VERSION 0)
+file(READ package.xml PACKAGE_XML)
+string(REGEX MATCH "<version>[0-9]+\\.[0-9]+\\.[0-9]+</version>" DIRTY_VERSION_STRING ${PACKAGE_XML})
+
+string(REGEX REPLACE "^<version>([0-9]+)\\.[0-9]+\\.[0-9]+</version>" "\\1" FCL_MAJOR_VERSION "${DIRTY_VERSION_STRING}")
+string(REGEX REPLACE "^<version>[0-9]+\\.([0-9])+\\.[0-9]+</version>" "\\1" FCL_MINOR_VERSION "${DIRTY_VERSION_STRING}")
+string(REGEX REPLACE "^<version>[0-9]+\\.[0-9]+\\.([0-9]+)</version>" "\\1" FCL_PATCH_VERSION "${DIRTY_VERSION_STRING}")
+
 set(FCL_VERSION "${FCL_MAJOR_VERSION}.${FCL_MINOR_VERSION}.${FCL_PATCH_VERSION}")
 
 # increment this when we have ABI changes

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,16 @@
+<package format="2">
+  <name>fcl</name>
+  <version>0.6.0</version>
+  <description>FCL: the Flexible Collision Library</description>
+  <maintainer email="fcl@tri.global">TRI Geometry Team</maintainer>
+  <license>BSD</license>
+  <buildtool_depend>cmake</buildtool_depend>
+  <depend>libccd-dev</depend>
+  <depend>eigen</depend>
+  <depend>octomap</depend>
+  <!-- Following recommendations of REP 136 -->
+  <exec_depend>catkin</exec_depend>
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
This provides the least intrusive, but most automated and correct
method for releasing non-catkin packages through the ROS
infrastructure.

These changes allow me to use catkin tools to build fcl, and to
have other catkin packages depend on fcl directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/409)
<!-- Reviewable:end -->
