### PR TITLE
Use Eigen3 vectorized operations in obbDisjoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,12 +42,12 @@ script:
   - cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DFCL_TREAT_WARNINGS_AS_ERRORS=ON -DFCL_COVERALLS=$COVERALLS ..
 
   # Build
-  - make -j4
+  - travis_wait 30 make -j $(nproc)
   - if [ $COVERALLS = ON ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then make coveralls; fi
 
   # Run unit tests
-  - ctest -j4 --output-on-failure
+  - travis_wait 30 ctest -j $(nproc) --output-on-failure
 
   # Make sure we can install and uninstall with no issues
-  - sudo make -j4 install
-  - sudo make -j4 uninstall
+  - sudo make -j $(nproc) install
+  - sudo make -j $(nproc) uninstall

--- a/src/math/bv/OBB.cpp
+++ b/src/math/bv/OBB.cpp
@@ -71,4 +71,54 @@ bool obbDisjoint(
     const Vector3<double>& a,
     const Vector3<double>& b);
 
+//==============================================================================
+template <>
+bool obbDisjoint(const Matrix3<float>& B, const Vector3<float>& T,
+                 const Vector3<float>& a, const Vector3<float>& b)
+{
+  const float reps = 1e-6;
+
+  Matrix3<float> Bf = B.cwiseAbs();
+  Bf.array() += reps;
+
+  // Test the three major axes of the OBB a.
+  if (((T.cwiseAbs() - (a + Bf * b)).array() > 0).any()) {
+    return true;
+  }
+
+  // Test the three major axes of the OBB b.
+  if ((((B.transpose() * T).cwiseAbs() - (b + Bf.transpose() * a)).array() > 0).any()) {
+    return true;
+  }
+
+  // Test the 9 different cross-axes.
+  Matrix3<float> symmetric_matrix;
+  symmetric_matrix <<    0, b[2], b[1],
+                      b[2],    0, b[0],
+                      b[1], b[0],    0;
+
+  // A0 x B0
+  // A0 x B1
+  // A0 x B2
+  if ((((T[2] * B.row(1) - T[1] * B.row(2)).cwiseAbs() - (Bf.row(2) * a[1] + Bf.row(1) * a[2] + Bf.row(0) * symmetric_matrix)).array() > 0).any()) {
+    return true;
+  }
+
+  // A1 x B0
+  // A1 x B1
+  // A1 x B2
+  if ((((T[0] * B.row(2) - T[2] * B.row(0)).cwiseAbs() - (Bf.row(2) * a[0] + Bf.row(0) * a[2] + Bf.row(1) * symmetric_matrix)).array() > 0).any()) {
+    return true;
+  }
+
+  // A2 x B0
+  // A2 x B1
+  // A2 x B2
+  if ((((T[1] * B.row(0) - T[0] * B.row(1)).cwiseAbs() - (Bf.row(1) * a[0] + Bf.row(0) * a[1] + Bf.row(2) * symmetric_matrix)).array() > 0).any()) {
+    return true;
+  }
+
+  return false;
+}
+
 } // namespace fcl

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,7 @@ set(tests
     test_fcl_generate_bvh_model_deferred_finalize.cpp
     test_fcl_geometric_shapes.cpp
     test_fcl_math.cpp
+    test_fcl_obb_overlap.cpp
     test_fcl_profiler.cpp
     test_fcl_shape_mesh_consistency.cpp
     test_fcl_signed_distance.cpp

--- a/test/test_fcl_obb_overlap.cpp
+++ b/test/test_fcl_obb_overlap.cpp
@@ -1,0 +1,114 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2011-2014, Willow Garage, Inc.
+ *  Copyright (c) 2014-2016, Open Source Robotics Foundation
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Open Source Robotics Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+
+#include "fcl/common/types.h"
+#include "fcl/math/bv/OBB.h"
+
+using namespace fcl;
+
+template <typename S>
+void testObbDisjoint()
+{
+  fcl::Matrix3<S> B;
+  fcl::Vector3<S> T;
+  fcl::Vector3<S> a;
+  fcl::Vector3<S> b;
+
+  // NOTE: The following hard-coded values were extracted from real application.
+  // The results from the original implementation is recorded and considered to be the ground truth.
+
+  {
+    B << 0.455308, 0.770672, 0.445824, -0.701088, 0.618991, -0.354014, -0.548789, -0.151377, 0.822141;
+    T << -0.41102, 0.449435, 1.02396;
+    a << 0.045, 0.615, 0.615;
+    b << 0.39866, 0.124083, 0.117934;
+    EXPECT_TRUE(fcl::obbDisjoint(B, T, a, b));
+  }
+
+  {
+    B << 0.559316, 0.363178, 0.745163, -0.437684, 0.892787, -0.106603, -0.703987, -0.266521, 0.658307;
+    T << -0.350612, 0.857327, 0.9279;
+    a << 0.045, 0.615, 0.615;
+    b << 0.39866, 0.124083, 0.117934;
+    EXPECT_TRUE(fcl::obbDisjoint(B, T, a, b));
+  }
+
+  {
+    B << 0.871089, -0.160559, -0.464138, -0.281678, -0.937498, -0.204341, -0.40232, 0.308737, -0.86187;
+    T << 0.356551, 0.848477, 0.95376;
+    a << 0.045, 0.615, 0.615;
+    b << 0.39866, 0.124083, 0.117934;
+    EXPECT_TRUE(fcl::obbDisjoint(B, T, a, b));
+  }
+
+  {
+    B << 0.460642, 0.720323, 0.518597, 0.887536, -0.367624, -0.277726, -0.00940369, 0.588206, -0.808656;
+    T << -0.385138, 0.74875, 0.807548;
+    a << 0.045, 0.615, 0.615;
+    b << 0.245512, 0.221752, 0.173233;
+    EXPECT_TRUE(fcl::obbDisjoint(B, T, a, b));
+  }
+
+  {
+    B << 0.195341, 0.942717, -0.270419, 0.756619, -0.320295, -0.570034, -0.623995, -0.0932533, -0.775844;
+    T << -0.346916, 0.318086, 0.772772;
+    a << 0.045, 0.615, 0.615;
+    b << 0.245512, 0.221752, 0.173233;
+    EXPECT_TRUE(fcl::obbDisjoint(B, T, a, b));
+  }
+
+  {
+    B << 0.70142, 0.635512, 0.322699, 0.523294, -0.151779, -0.838527, -0.483915, 0.757026, -0.43902;
+    T << -0.281496, -0.221942, 0.474881;
+    a << 0.045, 0.615, 0.615;
+    b << 0.245512, 0.221752, 0.173233;
+    EXPECT_FALSE(fcl::obbDisjoint(B, T, a, b));
+  }
+}
+
+GTEST_TEST(FCL_OBBOVERLAP, testObbDisjoint)
+{
+  testObbDisjoint<float>();
+  testObbDisjoint<double>();
+}
+
+//==============================================================================
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Hi,

This is Shuai from dorabot. We heavily use OBB BVs in our collision detection procedure and we've found that the OBB intersection checking is one of the performance bottlenecks. So we have tried different ways to optimize this part. One of my observation is that the current implementation of `fcl::obbDisjoint` uses scalar operations for the 15 serial separating-axis tests, which can be vectorized and run faster in CPUs with SIMD support.
This PR is one of our vectorized approaches. We group the 15 separating-axis tests into 5 groups of tests, and use vectorization to better exploit the potential of `Eigen3` acceleration. From our experiments (as I will explain later), we can achieve approximately 10% performance improvement for the `fcl::obbDisjoint<float>`.

## Experiments of Performance Comparison

I have collected 133464 `fcl::obbDisjoint` testcases from our application real cases. I also notice that there might be cases where the original scalar implementation is better than the vectorized one: for example, if the first tested axis is already the separating-axis, the original scalar implementation would immediately `return` while the vectorized implementation would still have to complete checking three tested axes. In order to better see the impact, I group the testcases by the number of tested axes. For each testcase, I also run the test for more than thousands of times to measure the stable latency.

Tested environment:
* CPU: Intel(R) Core(TM) i7-8700K @ 3.70GHz x12
* OS: Linux debian 4.9.0-8-amd64

Here I show you the performance comparison for both `float` and `double` specialization of `fcl::obbDisjoint<>` (The SSE and AVX ones are from another patch, which use SSE and AVX intrinsics for vectorization. I will create another PR for that XD):

![fcl_obbDisjoint_float](https://user-images.githubusercontent.com/1416342/61603237-6f603980-ac02-11e9-9274-abf1fbae5251.png)

![fcl_obbDisjoint_double](https://user-images.githubusercontent.com/1416342/61603258-869f2700-ac02-11e9-9064-5830d80dfd38.png)

From the results above, we can find that:
* The latency of the original scalar implementation increases faster as the number of tested axes increase.
* If the number of tested axes is small (like 1 or 2), the original scalar implementation would still be better due to the "early-return" behavior. However, its advantage in this best case is inobvious compared to its disadvantage when the number of tested axes increase.
* The Eigen vectorization patch fails to achieve better performance for `fcl::obbDisjoint<double>`. And that's why I decide to use it only in the `float` specialization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/413)
<!-- Reviewable:end -->
