### PR TITLE
Fix capsule moment of inertia

### DIFF
--- a/include/fcl/geometry/shape/capsule-inl.h
+++ b/include/fcl/geometry/shape/capsule-inl.h
@@ -82,6 +82,7 @@ S Capsule<S>::computeVolume() const
 }
 
 //==============================================================================
+// Compare https://www.gamedev.net/articles/programming/math-and-physics/capsule-inertia-tensor-r3856/
 template <typename S>
 Matrix3<S> Capsule<S>::computeMomentofInertia() const
 {

--- a/include/fcl/geometry/shape/capsule-inl.h
+++ b/include/fcl/geometry/shape/capsule-inl.h
@@ -85,11 +85,14 @@ S Capsule<S>::computeVolume() const
 template <typename S>
 Matrix3<S> Capsule<S>::computeMomentofInertia() const
 {
-  S v_cyl = radius * radius * lz * constants<S>::pi();
-  S v_sph = radius * radius * radius * constants<S>::pi() * 4 / 3.0;
+  S l2 = lz * lz;
+  S r2 = radius * radius;
 
-  S ix = v_cyl * lz * lz / 12.0 + 0.25 * v_cyl * radius + 0.4 * v_sph * radius * radius + 0.25 * v_sph * lz * lz;
-  S iz = (0.5 * v_cyl + 0.4 * v_sph) * radius * radius;
+  S v_cyl = r2 * lz * constants<S>::pi();
+  S v_sph = r2 * radius * constants<S>::pi() * 4 / 3.0;
+
+  S ix = v_cyl * (l2 / 12. + r2 / 4.) + v_sph * (0.4 * r2 + 0.25 * l2 + 3. * radius * lz / 8.);
+  S iz = (0.5 * v_cyl + 0.4 * v_sph) * r2;
 
   return Vector3<S>(ix, ix, iz).asDiagonal();
 }

--- a/test/geometry/shape/CMakeLists.txt
+++ b/test/geometry/shape/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(tests
         test_convex.cpp
+        test_capsule.cpp
         )
 
 # Build all the tests

--- a/test/geometry/shape/test_capsule.cpp
+++ b/test/geometry/shape/test_capsule.cpp
@@ -56,7 +56,7 @@ std::vector<paird> get_test_sizes() {
       paird(20.,30.),
       paird(3.,2.),
       paird(30.,20.)
-      };
+  };
 }
 
 template <typename S>
@@ -70,7 +70,7 @@ void testVolumeComputation(const Capsule<S>& shape, S tol) {
   S v_sph = 4./3.*pi*r*r*r; // volume of a sphere
   S v_cap = v_cyl + v_sph;  // total volume
 
-  EXPECT_NEAR(shape.computeVolume(), v_cap, tol);
+  EXPECT_TRUE(Eigen::internal::isApprox(shape.computeVolume(), v_cap, tol));
 }
 
 template <typename S>
@@ -113,12 +113,12 @@ GTEST_TEST(Capsule, Volume_Capsule) {
     double rd = pair.first;
     double ld = pair.second;
     Capsuled capsule_d(rd, ld);
-    testVolumeComputation(capsule_d, 1e-10);
+    testVolumeComputation(capsule_d, 1e-15);
 
     double rf = static_cast<float>(pair.first);
     double lf = static_cast<float>(pair.second);
     Capsulef capsule_f(rf, lf);
-    testVolumeComputation(capsule_f, 1e-9f);
+    testVolumeComputation(capsule_f, 1e-8f);
   }
 }
 

--- a/test/geometry/shape/test_capsule.cpp
+++ b/test/geometry/shape/test_capsule.cpp
@@ -32,11 +32,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-/** @author Sean Curtis (sean@tri.global) (2018) */
+/** @author Gabriele Buondonno (gbuondon@laas.fr) (2019) */
 
-// Tests the implementation of a convex polytope geometry.
+// Tests the implementation of a capsule object.
 
-#include "fcl/geometry/shape/convex.h"
+#include "fcl/geometry/shape/capsule.h"
 
 #include <vector>
 
@@ -44,7 +44,6 @@
 #include <gtest/gtest.h>
 
 #include "eigen_matrix_compare.h"
-#include "fcl/geometry/shape/capsule.h"
 
 namespace fcl {
 namespace {
@@ -88,14 +87,15 @@ void testMomentOfInertiaComputation(const Capsule<S>& shape, S tol) {
   S Iz_sph = S(2./5.) * v_sph * r * r; // inertia of a sphere around z
   S Iz = Iz_cyl + Iz_sph;              // total inertia around z
 
-  S Ix_cyl = v_cyl * (S(3.) * r * r + l * l) / S(12.); // inertia of a cylinder around x
+  // inertia of a cylinder around x
+  S Ix_cyl = v_cyl * (S(3.) * r * r + l * l) / S(12.);
 
-  S v_hemi = v_sph / S(2.);                             // volume of a hemisphere
-  S com_hemi = S(3.) * r / S(8.);                       // CoM of a hemisphere from base
-  S Ix0_hemi = Iz_sph / S(2.);                          // inertia of a hemisphere around x
+  S v_hemi = v_sph / S(2.);                  // volume of a hemisphere
+  S com_hemi = S(3.) * r / S(8.);            // CoM of a hemisphere from base
+  S Ix0_hemi = Iz_sph / S(2.);               // inertia of a hemisphere around x
   S Ixc_hemi = Ix0_hemi - v_hemi * com_hemi * com_hemi; // inertia around CoM
-  S dz = l / S(2.) + com_hemi;                          // CoM translation along z-axis
-  S Ix_hemi = Ixc_hemi + v_hemi * dz * dz;              // translated inertia around x
+  S dz = l / S(2.) + com_hemi;               // CoM translation along z-axis
+  S Ix_hemi = Ixc_hemi + v_hemi * dz * dz;   // translated inertia around x
 
   S Ix = Ix_cyl + S(2.) * Ix_hemi;  // total inertia around x
   S Iy = Ix;                        // total inertia around y
@@ -105,7 +105,6 @@ void testMomentOfInertiaComputation(const Capsule<S>& shape, S tol) {
            S(0.),    Iy, S(0.),
            S(0.), S(0.),    Iz;
 
-  //EXPECT_TRUE(CompareMatrices(shape.computeMomentofInertia(), I_cap, tol));
   EXPECT_TRUE(shape.computeMomentofInertia().isApprox(I_cap, tol));
 }
 
@@ -114,7 +113,7 @@ GTEST_TEST(Capsule, Volume_Capsule) {
     double rd = pair.first;
     double ld = pair.second;
     Capsuled capsule_d(rd, ld);
-    testVolumeComputation(capsule_d, 1e-9);
+    testVolumeComputation(capsule_d, 1e-10);
 
     double rf = static_cast<float>(pair.first);
     double lf = static_cast<float>(pair.second);
@@ -144,7 +143,7 @@ GTEST_TEST(Capsule, MomentOfInertia_Capsule) {
     double rd = pair.first;
     double ld = pair.second;
     Capsuled capsule_d(rd, ld);
-    testMomentOfInertiaComputation(capsule_d, 1e-6);
+    testMomentOfInertiaComputation(capsule_d, 1e-14);
 
     double rf = static_cast<float>(pair.first);
     double lf = static_cast<float>(pair.second);

--- a/test/geometry/shape/test_capsule.cpp
+++ b/test/geometry/shape/test_capsule.cpp
@@ -1,0 +1,164 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2018. Toyota Research Institute
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of CNRS-LAAS and AIST nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @author Sean Curtis (sean@tri.global) (2018) */
+
+// Tests the implementation of a convex polytope geometry.
+
+#include "fcl/geometry/shape/convex.h"
+
+#include <vector>
+
+#include <Eigen/StdVector>
+#include <gtest/gtest.h>
+
+#include "eigen_matrix_compare.h"
+#include "fcl/geometry/shape/capsule.h"
+
+namespace fcl {
+namespace {
+
+typedef std::pair<double, double> paird;
+
+std::vector<paird> get_test_sizes() {
+  return std::vector<paird>{
+      paird(2.,3.),
+      paird(20.,30.),
+      paird(3.,2.),
+      paird(30.,20.)
+      };
+}
+
+template <typename S>
+void testVolumeComputation(const Capsule<S>& shape, S tol) {
+  S r = shape.radius;
+  S l = shape.lz;
+
+  S pi = constants<S>::pi();
+
+  S v_cyl = pi*r*r*l;       // volume of a cylinder
+  S v_sph = 4./3.*pi*r*r*r; // volume of a sphere
+  S v_cap = v_cyl + v_sph;  // total volume
+
+  EXPECT_NEAR(shape.computeVolume(), v_cap, tol);
+}
+
+template <typename S>
+void testMomentOfInertiaComputation(const Capsule<S>& shape, S tol) {
+  S r = shape.radius;
+  S l = shape.lz;
+
+  S pi = constants<S>::pi();
+
+  S v_cyl = pi*r*r*l;          // volume of a cylinder
+  S v_sph = S(4./3.)*pi*r*r*r; // volume of a sphere
+
+  S Iz_cyl = S(0.5) * v_cyl * r * r;   // inertia of a cylinder around z
+  S Iz_sph = S(2./5.) * v_sph * r * r; // inertia of a sphere around z
+  S Iz = Iz_cyl + Iz_sph;              // total inertia around z
+
+  S Ix_cyl = v_cyl * (S(3.) * r * r + l * l) / S(12.); // inertia of a cylinder around x
+
+  S v_hemi = v_sph / S(2.);                             // volume of a hemisphere
+  S com_hemi = S(3.) * r / S(8.);                       // CoM of a hemisphere from base
+  S Ix0_hemi = Iz_sph / S(2.);                          // inertia of a hemisphere around x
+  S Ixc_hemi = Ix0_hemi - v_hemi * com_hemi * com_hemi; // inertia around CoM
+  S dz = l / S(2.) + com_hemi;                          // CoM translation along z-axis
+  S Ix_hemi = Ixc_hemi + v_hemi * dz * dz;              // translated inertia around x
+
+  S Ix = Ix_cyl + S(2.) * Ix_hemi;  // total inertia around x
+  S Iy = Ix;                        // total inertia around y
+
+  Eigen::Matrix<S,3,3> I_cap;
+  I_cap <<    Ix, S(0.), S(0.),
+           S(0.),    Iy, S(0.),
+           S(0.), S(0.),    Iz;
+
+  //EXPECT_TRUE(CompareMatrices(shape.computeMomentofInertia(), I_cap, tol));
+  EXPECT_TRUE(shape.computeMomentofInertia().isApprox(I_cap, tol));
+}
+
+GTEST_TEST(Capsule, Volume_Capsule) {
+  for (paird pair : get_test_sizes()) {
+    double rd = pair.first;
+    double ld = pair.second;
+    Capsuled capsule_d(rd, ld);
+    testVolumeComputation(capsule_d, 1e-9);
+
+    double rf = static_cast<float>(pair.first);
+    double lf = static_cast<float>(pair.second);
+    Capsulef capsule_f(rf, lf);
+    testVolumeComputation(capsule_f, 1e-9f);
+  }
+}
+
+GTEST_TEST(Capsule, CenterOfMass_Capsule) {
+  Eigen::Vector3d comd = Vector3d::Zero();
+  Eigen::Vector3f comf = Vector3f::Zero();
+  for (paird pair : get_test_sizes()) {
+    double rd = pair.first;
+    double ld = pair.second;
+    Capsuled capsule_d(rd, ld);
+    EXPECT_TRUE(CompareMatrices(capsule_d.computeCOM(), comd, 0.));
+
+    double rf = static_cast<float>(pair.first);
+    double lf = static_cast<float>(pair.second);
+    Capsulef capsule_f(rf, lf);
+    EXPECT_TRUE(CompareMatrices(capsule_f.computeCOM(), comf, 0.f));
+  }
+}
+
+GTEST_TEST(Capsule, MomentOfInertia_Capsule) {
+  for (paird pair : get_test_sizes()) {
+    double rd = pair.first;
+    double ld = pair.second;
+    Capsuled capsule_d(rd, ld);
+    testMomentOfInertiaComputation(capsule_d, 1e-6);
+
+    double rf = static_cast<float>(pair.first);
+    double lf = static_cast<float>(pair.second);
+    Capsulef capsule_f(rf, lf);
+    testMomentOfInertiaComputation(capsule_f, 1e-6f);
+  }
+}
+
+}  // namespace
+}  // namespace fcl
+
+//==============================================================================
+int main(int argc, char *argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
The formula for `ix` in the capsule was wrong, I fixed it.
Additionally, I grabbed the occasion to group some common terms in the other expressions too

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/420)
<!-- Reviewable:end -->
