### PR TITLE
fix missing nearest points in Octree<->Mesh distance result

### DIFF
--- a/include/fcl/narrowphase/detail/traversal/octree/octree_solver-inl.h
+++ b/include/fcl/narrowphase/detail/traversal/octree/octree_solver-inl.h
@@ -506,7 +506,7 @@ bool OcTreeSolver<NarrowPhaseSolver>::OcTreeMeshDistanceRecurse(const OcTree<S>*
       Vector3<S> closest_p1, closest_p2;
       solver->shapeTriangleDistance(box, box_tf, p1, p2, p3, tf2, &dist, &closest_p1, &closest_p2);
 
-      dresult->update(dist, tree1, tree2, root1 - tree1->getRoot(), primitive_id);
+      dresult->update(dist, tree1, tree2, root1 - tree1->getRoot(), primitive_id, closest_p1, closest_p2);
 
       return drequest->isSatisfied(*dresult);
     }

--- a/test/test_fcl_octomap_distance.cpp
+++ b/test/test_fcl_octomap_distance.cpp
@@ -65,6 +65,8 @@ void octomap_distance_test_BVH(std::size_t n, double resolution = 0.1);
 template <typename S>
 void test_octomap_distance()
 {
+  // -- compares result of (manager of primitives <-> octomap)
+  //    against (manager of primitives <-> manager of box primitives from octomap)
 #ifdef NDEBUG
   octomap_distance_test<S>(200, 100, false, false);
   octomap_distance_test<S>(200, 1000, false, false);
@@ -83,6 +85,8 @@ GTEST_TEST(FCL_OCTOMAP, test_octomap_distance)
 template <typename S>
 void test_octomap_distance_mesh()
 {
+  // -- compares result of (manager of meshes <-> octomap)
+  //    against (manager of meshes <-> manager of box meshes from octomap)
 #ifdef NDEBUG
   octomap_distance_test<S>(200, 100, true, true);
   octomap_distance_test<S>(200, 1000, true, true);
@@ -101,6 +105,8 @@ GTEST_TEST(FCL_OCTOMAP, test_octomap_distance_mesh)
 template <typename S>
 void test_octomap_distance_mesh_octomap_box()
 {
+  // -- compares result of (manager of meshes <-> octomap)
+  //    against (manager of meshes <-> manager of box primitives from octomap)
 #ifdef NDEBUG
   octomap_distance_test<S>(200, 100, true, false);
   octomap_distance_test<S>(200, 1000, true, false);
@@ -219,6 +225,13 @@ void octomap_distance_test_BVH(std::size_t n, double resolution)
 
     std::cout << dist1 << " " << dist2 << std::endl;
     EXPECT_TRUE(std::abs(dist1 - dist2) < 0.001);
+
+    std::cout << "cdata, np0:\n" << cdata.result.nearest_points[0] << std::endl;
+    std::cout << "cdata, np1:\n" << cdata.result.nearest_points[1] << std::endl;
+    std::cout << "cdata2, np0:\n" << cdata2.result.nearest_points[0] << std::endl;
+    std::cout << "cdata2, np1:\n" << cdata2.result.nearest_points[1] << std::endl;
+    EXPECT_NEAR((cdata.result.nearest_points[0] - cdata2.result.nearest_points[1]).norm(), 0.0, 1e-6);
+    EXPECT_NEAR((cdata.result.nearest_points[1] - cdata2.result.nearest_points[0]).norm(), 0.0, 1e-6);
   }
 }
 
@@ -293,6 +306,13 @@ void octomap_distance_test(S env_scale, std::size_t env_size, bool use_mesh, boo
     EXPECT_TRUE(cdata2.result.min_distance <= 0);
   else
     EXPECT_TRUE(std::abs(cdata.result.min_distance - cdata2.result.min_distance) < 1e-3);
+
+  std::cout << "cdata, np0:\n" << cdata.result.nearest_points[0] << std::endl;
+  std::cout << "cdata, np1:\n" << cdata.result.nearest_points[1] << std::endl;
+  std::cout << "cdata2, np0:\n" << cdata2.result.nearest_points[0] << std::endl;
+  std::cout << "cdata2, np1:\n" << cdata2.result.nearest_points[1] << std::endl;
+  EXPECT_NEAR((cdata.result.nearest_points[0] - cdata2.result.nearest_points[0]).norm(), 0.0, 1e-6);
+  EXPECT_NEAR((cdata.result.nearest_points[1] - cdata2.result.nearest_points[1]).norm(), 0.0, 1e-6);
 
   delete manager;
   delete manager2;

--- a/test/test_fcl_octomap_distance.cpp
+++ b/test/test_fcl_octomap_distance.cpp
@@ -65,8 +65,6 @@ void octomap_distance_test_BVH(std::size_t n, double resolution = 0.1);
 template <typename S>
 void test_octomap_distance()
 {
-  // -- compares result of (manager of primitives <-> octomap)
-  //    against (manager of primitives <-> manager of box primitives from octomap)
 #ifdef NDEBUG
   octomap_distance_test<S>(200, 100, false, false);
   octomap_distance_test<S>(200, 1000, false, false);
@@ -85,8 +83,6 @@ GTEST_TEST(FCL_OCTOMAP, test_octomap_distance)
 template <typename S>
 void test_octomap_distance_mesh()
 {
-  // -- compares result of (manager of meshes <-> octomap)
-  //    against (manager of meshes <-> manager of box meshes from octomap)
 #ifdef NDEBUG
   octomap_distance_test<S>(200, 100, true, true);
   octomap_distance_test<S>(200, 1000, true, true);
@@ -105,8 +101,6 @@ GTEST_TEST(FCL_OCTOMAP, test_octomap_distance_mesh)
 template <typename S>
 void test_octomap_distance_mesh_octomap_box()
 {
-  // -- compares result of (manager of meshes <-> octomap)
-  //    against (manager of meshes <-> manager of box primitives from octomap)
 #ifdef NDEBUG
   octomap_distance_test<S>(200, 100, true, false);
   octomap_distance_test<S>(200, 1000, true, false);
@@ -225,13 +219,6 @@ void octomap_distance_test_BVH(std::size_t n, double resolution)
 
     std::cout << dist1 << " " << dist2 << std::endl;
     EXPECT_TRUE(std::abs(dist1 - dist2) < 0.001);
-
-    std::cout << "cdata, np0:\n" << cdata.result.nearest_points[0] << std::endl;
-    std::cout << "cdata, np1:\n" << cdata.result.nearest_points[1] << std::endl;
-    std::cout << "cdata2, np0:\n" << cdata2.result.nearest_points[0] << std::endl;
-    std::cout << "cdata2, np1:\n" << cdata2.result.nearest_points[1] << std::endl;
-    EXPECT_NEAR((cdata.result.nearest_points[0] - cdata2.result.nearest_points[1]).norm(), 0.0, 1e-6);
-    EXPECT_NEAR((cdata.result.nearest_points[1] - cdata2.result.nearest_points[0]).norm(), 0.0, 1e-6);
   }
 }
 
@@ -306,13 +293,6 @@ void octomap_distance_test(S env_scale, std::size_t env_size, bool use_mesh, boo
     EXPECT_TRUE(cdata2.result.min_distance <= 0);
   else
     EXPECT_TRUE(std::abs(cdata.result.min_distance - cdata2.result.min_distance) < 1e-3);
-
-  std::cout << "cdata, np0:\n" << cdata.result.nearest_points[0] << std::endl;
-  std::cout << "cdata, np1:\n" << cdata.result.nearest_points[1] << std::endl;
-  std::cout << "cdata2, np0:\n" << cdata2.result.nearest_points[0] << std::endl;
-  std::cout << "cdata2, np1:\n" << cdata2.result.nearest_points[1] << std::endl;
-  EXPECT_NEAR((cdata.result.nearest_points[0] - cdata2.result.nearest_points[0]).norm(), 0.0, 1e-6);
-  EXPECT_NEAR((cdata.result.nearest_points[1] - cdata2.result.nearest_points[1]).norm(), 0.0, 1e-6);
 
   delete manager;
   delete manager2;


### PR DESCRIPTION
I stumbled upon this one while testing distance queries between octrees and other entities. Seems like someone just forgot to add the (already computed) nearest points to the result object in the Octree<->Mesh case. A quick test suggests that the nearest points returned now are correct.

For comparison, the Octree<->[Shape, Octree] distance computation attaches the nearest points to the result, cf. https://github.com/flexible-collision-library/fcl/blob/6aeb7a1d30ae57b6b5413b65e0bf2ce9800687ed/include/fcl/narrowphase/detail/traversal/octree/octree_solver-inl.h#L297 and https://github.com/flexible-collision-library/fcl/blob/6aeb7a1d30ae57b6b5413b65e0bf2ce9800687ed/include/fcl/narrowphase/detail/traversal/octree/octree_solver-inl.h#L787

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/427)
<!-- Reviewable:end -->
