### PR TITLE
ComputeVisiblePatch tracks all visited faces

### DIFF
--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
@@ -558,7 +558,7 @@ void CheckComputeVisiblePatchCommon(
     const Polytope& polytope,
     const std::unordered_set<ccd_pt_edge_t*>& border_edges,
     const std::unordered_set<ccd_pt_face_t*>& visible_faces,
-    const std::unordered_set<ccd_pt_edge_t*> internal_edges,
+    const std::unordered_set<ccd_pt_edge_t*>& internal_edges,
     const std::unordered_set<int>& border_edge_indices_expected,
     const std::unordered_set<int>& visible_face_indices_expected,
     const std::unordered_set<int> internal_edges_indices_expected) {
@@ -590,17 +590,23 @@ void CheckComputeVisiblePatchRecursive(
     const std::unordered_set<int>& internal_edges_indices_expected) {
   std::unordered_set<ccd_pt_edge_t*> border_edges;
   std::unordered_set<ccd_pt_face_t*> visible_faces;
+  std::unordered_set<ccd_pt_face_t*> hidden_faces;
   visible_faces.insert(&face);
   std::unordered_set<ccd_pt_edge_t*> internal_edges;
   for (const int edge_index : edge_indices) {
     libccd_extension::ComputeVisiblePatchRecursive(
         polytope.polytope(), face, edge_index, new_vertex, &border_edges,
-        &visible_faces, &internal_edges);
+        &visible_faces, &hidden_faces, &internal_edges);
   }
   CheckComputeVisiblePatchCommon(polytope, border_edges, visible_faces,
                                  internal_edges, border_edge_indices_expected,
                                  visible_face_indices_expected,
                                  internal_edges_indices_expected);
+
+  // Confirm that visible and hidden faces are disjoint sets.
+  for (const auto hidden_face : hidden_faces) {
+    EXPECT_EQ(visible_faces.count(hidden_face), 0u);
+  }
 }
 
 void CheckComputeVisiblePatch(


### PR DESCRIPTION
The previous version of the code only tracked those faces that were explicitly known to be visible. This led to two problems:

 1. A "hidden" face could be visited multiple times and the calculation to determine its visibility could be needlessly repeated.
 2. The different visits could actually produce *different* results leading to inherently contradictory classifications of edges.

In this case, we track every face we've visited and lock its classification into the first classification computed.

Furthermore, we extend the sanity check to look for duplicate classifications and tweak documentation.

**This bug was responsible for the intermittent failures in mac CI. They should now go away.**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/435)
<!-- Reviewable:end -->
