### PR TITLE
Fixing capsule-capsule distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
     simpler, documented constructor:
      [#325](https://github.com/flexible-collision-library/fcl/pull/325),
      [#338](https://github.com/flexible-collision-library/fcl/pull/338)
+  * Fixed interpretation of capsule in primitive Capsule-Capsule distance computation.
+     [#436](https://github.com/flexible-collision-library/fcl/pull/436)
 
 * Broadphase
 

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/capsule_capsule-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/capsule_capsule-inl.h
@@ -51,10 +51,12 @@ extern template
 double clamp(double n, double min, double max);
 
 //==============================================================================
-extern template
-double closestPtSegmentSegment(
-    Vector3d p1, Vector3d q1, Vector3d p2, Vector3d q2,
-    double &s, double& t, Vector3d &c1, Vector3d &c2);
+extern template double closestPtSegmentSegment(const Vector3d& p_FP1,
+                                               const Vector3d& p_FQ1,
+                                               const Vector3d& p_FP2,
+                                               const Vector3d& p_FQ2, double* s,
+                                               double* t, Vector3d* p_FC1,
+                                               Vector3d* p_FC2);
 
 //==============================================================================
 extern template
@@ -74,110 +76,164 @@ S clamp(S n, S min, S max)
 
 //==============================================================================
 template <typename S>
-S closestPtSegmentSegment(
-    Vector3<S> p1, Vector3<S> q1, Vector3<S> p2, Vector3<S> q2,
-    S &s, S &t, Vector3<S> &c1, Vector3<S> &c2)
-{
-  const S EPSILON = 0.001;
-  Vector3<S> d1 = q1 - p1; // Direction vector of segment S1
-  Vector3<S> d2 = q2 - p2; // Direction vector of segment S2
-  Vector3<S> r = p1 - p2;
-  S a = d1.dot(d1); // Squared length of segment S1, always nonnegative
+S closestPtSegmentSegment(const Vector3<S>& p_FP1, const Vector3<S>& p_FQ1,
+                          const Vector3<S>& p_FP2, const Vector3<S>& p_FQ2,
+                          S* s, S* t, Vector3<S>* p_FC1, Vector3<S>* p_FC2) {
+  // TODO(SeanCurtis-TRI): Document the match underlying this function -- the
+  //  variables: a, b, c, e, and f are otherwise overly inscrutable.
+  const auto kEps = constants<S>::eps_78();
+  const auto kEpsSquared = kEps * kEps;
 
-  S e = d2.dot(d2); // Squared length of segment S2, always nonnegative
-  S f = d2.dot(r);
-  // Check if either or both segments degenerate into points
-  if (a <= EPSILON && e <= EPSILON) {
-    // Both segments degenerate into points
-    s = t = 0.0;
-    c1 = p1;
-    c2 = p2;
-    Vector3<S> diff = c1-c2;
-    S res = diff.dot(diff);
-    return res;
+  Vector3<S> p_P1Q1 = p_FQ1 - p_FP1;  // Segment 1's displacement vector: D1.
+  Vector3<S> p_P2Q2 = p_FQ2 - p_FP2;  // Segment 2's displacement vector: D2.
+  Vector3<S> p_P2P1 = p_FP1 - p_FP2;
+
+  S a = p_P1Q1.dot(p_P1Q1); // Squared length of segment S1, always nonnegative.
+  S e = p_P2Q2.dot(p_P2Q2); // Squared length of segment S2, always nonnegative.
+  S f = p_P2Q2.dot(p_P2P1);
+
+  // Check if either or both segments degenerate into points.
+  if (a <= kEpsSquared && e <= kEpsSquared) {
+    // Both segments degenerate into points.
+    *s = *t = 0.0;
+    *p_FC1 = p_FP1;
+    *p_FC2 = p_FP2;
+    return (*p_FC1 - *p_FC2).squaredNorm();
   }
-  if (a <= EPSILON) {
-    // First segment degenerates into a point
-    s = 0.0;
-    t = f / e; // s = 0 => t = (b*s + f) / e = f / e
-    t = clamp(t, (S)0.0, (S)1.0);
+  if (a <= kEpsSquared) {
+    // First segment degenerates into a point.
+    *s = 0.0;
+    // t = (b * s + f) / e, s = 0 --> t = f / e.
+    *t = clamp(f / e, (S)0.0, (S)1.0);
   } else {
-    S c = d1.dot(r);
-    if (e <= EPSILON) {
-      // Second segment degenerates into a point
-      t = 0.0;
-      s = clamp(-c / a, (S)0.0, (S)1.0); // t = 0 => s = (b*t - c) / a = -c / a
+    const S c = p_P1Q1.dot(p_P2P1);
+    if (e <= kEpsSquared) {
+      // Second segment degenerates into a point.
+      *t = 0.0;
+      // s = (b*t - c) / a, t = 0 --> s = -c / a.
+      *s = clamp(-c / a, (S)0.0, (S)1.0);
     } else {
-      // The general nondegenerate case starts here
-      S b = d1.dot(d2);
-      S denom = a*e-b*b; // Always nonnegative
-      // If segments not parallel, compute closest point on L1 to L2 and
-      // clamp to segment S1. Else pick arbitrary s (here 0)
-      if (denom != 0.0) {
-        std::cerr << "denominator equals zero, using 0 as reference" << std::endl;
-        s = clamp((b*f - c*e) / denom, (S)0.0, (S)1.0);
-      } else s = 0.0;
-      // Compute point on L2 closest to S1(s) using
-      // t = Dot((P1 + D1*s) - P2,D2) / Dot(D2,D2) = (b*s + f) / e
-      t = (b*s + f) / e;
+      // The general non-degenerate case starts here.
+      const S b = p_P1Q1.dot(p_P2Q2);
+      // Mathematically, ae - b² ≥ 0, but we need to protect ourselves from
+      // possible rounding error near zero that _might_ produce -epsilon.
+      using std::max;
+      const S denom = max(S(0), a*e-b*b);
 
-      //
-      //If t in [0,1] done. Else clamp t, recompute s for the new value
-      //of t using s = Dot((P2 + D2*t) - P1,D1) / Dot(D1,D1)= (t*b - c) / a
-      //and clamp s to [0, 1]
-      if(t < 0.0) {
-        t = 0.0;
-        s = clamp(-c / a, (S)0.0, (S)1.0);
-      } else if (t > 1.0) {
-        t = 1.0;
-        s = clamp((b - c) / a, (S)0.0, (S)1.0);
+      // If segments are not parallel, compute closest point on L1 to L2 and
+      // clamp to segment S1. Else pick arbitrary s (here 0).
+      if (denom > kEpsSquared) {
+        *s = clamp((b*f - c*e) / denom, (S)0.0, (S)1.0);
+      } else {
+        *s = 0.0;
+      }
+      // Compute point on L2 closest to S1(s) using
+      // t = Dot((P1 + D1*s) - P2, D2) / Dot(D2,D2) = (b*s + f) / e
+      *t = (b*(*s) + f) / e;
+
+      // If t in [0,1] done. Else clamp t, recompute s for the new value
+      // of t using s = Dot((P2 + D2*t) - P1, D1) / Dot(D1,D1) = (t*b - c) / a
+      // and clamp s to [0, 1].
+      if(*t < 0.0) {
+        *t = 0.0;
+        *s = clamp(-c / a, (S)0.0, (S)1.0);
+      } else if (*t > 1.0) {
+        *t = 1.0;
+        *s = clamp((b - c) / a, (S)0.0, (S)1.0);
       }
     }
   }
-  c1 = p1 + d1 * s;
-  c2 = p2 + d2 * t;
-  Vector3<S> diff = c1-c2;
-  S res = diff.dot(diff);
-  return res;
+  *p_FC1 = p_FP1 + p_P1Q1 * (*s);
+  *p_FC2 = p_FP2 + p_P2Q2 * (*t);
+  return (*p_FC1 - *p_FC2).squaredNorm();
+}
+
+// Given a transform relating frames A and B, returns Bz_A, the z-axis of frame
+// B, expressed in frame A.
+template <typename S>
+Vector3<S> z_axis(const Transform3<S>& X_AB) {
+  return X_AB.matrix().template block<3, 1>(0, 2);
 }
 
 //==============================================================================
 template <typename S>
-bool capsuleCapsuleDistance(const Capsule<S>& s1, const Transform3<S>& tf1,
-          const Capsule<S>& s2, const Transform3<S>& tf2,
-          S* dist, Vector3<S>* p1_res, Vector3<S>* p2_res)
+bool capsuleCapsuleDistance(const Capsule<S>& s1, const Transform3<S>& X_FC1,
+          const Capsule<S>& s2, const Transform3<S>& X_FC2,
+          S* dist, Vector3<S>* p_FW1, Vector3<S>* p_FW2)
 {
+  assert(dist != nullptr);
+  assert(p_FW1 != nullptr);
+  assert(p_FW2 != nullptr);
 
-  Vector3<S> p1(tf1.translation());
-  Vector3<S> p2(tf2.translation());
+  // Origin of the capsules' frames relative to F's origin.
+  const Vector3<S> p_FC1o = X_FC1.translation();
+  const Vector3<S> p_FC2o = X_FC2.translation();
 
-  // line segment composes two points. First point is given by the origin, second point is computed by the origin transformed along z.
-  // extension along z-axis means transformation with identity matrix and translation vector z pos
-  Transform3<S> transformQ1 = tf1 * Translation3<S>(Vector3<S>(0,0,s1.lz));
-  Vector3<S> q1 = transformQ1.translation();
+  // A capsule is defined centered on the origin of its canonical frame C
+  // and with the central line segment aligned with Cz. So, the two end points
+  // of the capsule's center line segment are at `z+ = lz / 2 * Cz` and
+  // `z- = -lz / 2 * Cz`, respectively. Cz_F is simply the third column of the
+  // rotation matrix, R_FC. This "half arm" is the position vector from the
+  // canonical frame's origin to the z+ point: p_CoZ+_F in frame F.
+  auto calc_half_arm = [](const Capsule<S>& c,
+                          const Transform3<S>& X_FC) -> Vector3<S> {
+    const S half_length = c.lz / 2;
+    const Vector3<S> Cz_F = z_axis(X_FC);
+    return half_length * Cz_F;
+  };
 
-  Transform3<S> transformQ2 = tf2 * Translation3<S>(Vector3<S>(0,0,s2.lz));
-  Vector3<S> q2 = transformQ2.translation();
+  const Vector3<S> half_arm_1_F = calc_half_arm(s1, X_FC1);
+  const Vector3<S> p_FC1a = p_FC1o + half_arm_1_F;
+  const Vector3<S> p_FC1b = p_FC1o - half_arm_1_F;
 
-  // s and t correspont to the length of the line segment
+  const Vector3<S> half_arm_2_F = calc_half_arm(s2, X_FC2);
+  const Vector3<S> p_FC2a = p_FC2o + half_arm_2_F;
+  const Vector3<S> p_FC2b = p_FC2o - half_arm_2_F;
+
+  // s and t correspond to the length of each line segment; should be s1.lz and
+  // s2.lz, respectively.
   S s, t;
-  Vector3<S> c1, c2;
+  // The points on the line segments closest to each other.
+  Vector3<S> p_FN1, p_FN2;
+  // TODO(SeanCurtis-TRI): This query isn't well tailored for this problem.
+  //  By construction, we know the unit-length vectors for the two segments (and
+  //  their lengths), but closestPtSegmentSegment() infers the segment direction
+  //  from the end point. Furthermore, it returns the values for s and t,
+  //  neither of which is required by this function. The API should be
+  //  streamlined so there is less waste.
+  const S squared_dist = closestPtSegmentSegment(p_FC1a, p_FC1b, p_FC2a, p_FC2b,
+                                                 &s, &t, &p_FN1, &p_FN2);
 
-  S result = closestPtSegmentSegment(p1, q1, p2, q2, s, t, c1, c2);
-  *dist = sqrt(result)-s1.radius-s2.radius;
-
-  // getting directional unit vector
-  Vector3<S> distVec = c2 -c1;
-  distVec.normalize();
-
-  // extend the point to be border of the capsule.
-  // Done by following the directional unit vector for the length of the capsule radius
-  *p1_res = c1 + distVec*s1.radius;
-
-  distVec = c1-c2;
-  distVec.normalize();
-
-  *p2_res = c2 + distVec*s2.radius;
+  const S segment_dist = sqrt(squared_dist);
+  *dist = segment_dist - s1.radius - s2.radius;
+  Vector3<S> vhat_C1C2_F;
+  const auto eps = constants<S>::eps_78();
+  // We can only use the vector between the center-line nearest points to find
+  // the witness points if they are sufficiently far apart.
+  if (segment_dist > eps) {
+    vhat_C1C2_F = (p_FN2 - p_FN1) / segment_dist;
+  } else {
+    // The points are too close. The center lines intersect. We have two cases:
+    //   1. They intersect at a single point (non-parallel center lines).
+    //      - The center lines span a plane and the witness points should lie
+    //        above and below that plane the corresponding radius amount.
+    //   2. They intersect at multiple points (parallel, overlapping center
+    //      lies).
+    //      - Any direction on the plane perpendicular to the common center line
+    //        will suffice. We arbitrarily pick the Cx direction.
+    const Vector3<S>& C1z_F = z_axis(X_FC1);
+    const Vector3<S>& C2z_F = z_axis(X_FC2);
+    using std::abs;
+    if (abs(C1z_F.dot(C2z_F)) < 1 - eps) {
+      // Vectors are sufficiently perpendicular to use cross product.
+      vhat_C1C2_F = C1z_F.cross(C2z_F).normalized();
+    } else {
+      // Vectors are parallel, simply use Cx_F as the vector.
+      vhat_C1C2_F = X_FC1.matrix().template block<3, 1>(0, 0);
+    }
+  }
+  *p_FW1 = p_FN1 + vhat_C1C2_F * s1.radius;
+  *p_FW2 = p_FN2 - vhat_C1C2_F * s2.radius;
 
   return true;
 }

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/capsule_capsule.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/capsule_capsule.h
@@ -52,23 +52,62 @@ template <typename S>
 FCL_EXPORT
 S clamp(S n, S min, S max);
 
-// Computes closest points C1 and C2 of S1(s)=P1+s*(Q1-P1) and
-// S2(t)=P2+t*(Q2-P2), returning s and t. Function result is squared
-// distance between between S1(s) and S2(t)
-template <typename S>
-FCL_EXPORT
-S closestPtSegmentSegment(
-    Vector3<S> p1, Vector3<S> q1, Vector3<S> p2, Vector3<S> q2,
-    S &s, S &t, Vector3<S> &c1, Vector3<S> &c2);
+/** Computes the pair of closest points `(p_FC1, p_FC2)` between two line
+ segments given by point pairs `(p_FP1, p_FQ1)` and (p_FP2, p_FQ2)`. If the
+ lines are parallel, there may be no _unique_ such point pair, in that case it
+ computes one from the set of nearest pairs. As a by-product, it reports the
+ squared distance between those points and the parameters (`s` and `t`) such
+ that `p_FC1 = p_FP1 + s * (p_FQ1 - p_FP1)` for segment one, and similarly for
+ `p_FC2` and `t`, with `0 ≤ s,t ≤ 1`. All points are measured and expressed in a
+ common frame `F`.
 
-// Computes closest points C1 and C2 of S1(s)=P1+s*(Q1-P1) and
-// S2(t)=P2+t*(Q2-P2), returning s and t. Function result is squared
-// distance between between S1(s) and S2(t)
+ @param p_FP1   Segment 1's first point, P1.
+ @param p_FQ1   Segment 1's second point, Q1.
+ @param p_FP2   Segment 2's first point, P2.
+ @param p_FQ2   Segment 2's second point, Q2.
+ @param s       The parameter relating C1 with P1 and Q1.
+ @param t       The parameter relating C2 with P2 and Q2.
+ @param p_FC1   The point C1 on segment 1, nearest segment 2.
+ @param p_FC2   The point C2 on segment 2, nearest segment 1.
+ @return    The squared distance between points C1 and C2.
+ @tparam S  The scalar type for computation.
+ */
+template <typename S>
+FCL_EXPORT S closestPtSegmentSegment(const Vector3<S>& p_FP1,
+                                     const Vector3<S>& p_FQ1,
+                                     const Vector3<S>& p_FP2,
+                                     const Vector3<S>& p_FQ2, S* s, S* t,
+                                     Vector3<S>* p_FC1, Vector3<S>* p_FC2);
+
+/** Computes the signed distance between two capsules `s1` and `s2` (with
+ given poses `X_FC1` and `X_FC2` of the two capsules in a common frame `F`).
+ Further reports the witness points to that distance (`p_FW1` and `p_FW2`).
+
+ It is guaranteed that `|p_FW1 - p_FW2| = |dist|`.
+
+ There are degenerate cases where there is no _unique_ pair of witness points.
+ If the center lines of the two capsules intersect (either once or multiple
+ times when the are co-linear) then distance will still be reported (a
+ negative value with the maximum magnitude possible between the two capsules)
+ and an arbitrary pair of witness points from the set of valid pairs.
+ @param s1      The first capsule.
+ @param X_FC1   The pose of the first capsule in a common frame `F`.
+ @param s2      The second capsule.
+ @param X_FC2   The pose of the second capsule in a common frame `F`.
+ @param dist    The signed distance between the two capsules (negative indicates
+                intersection).
+ @param p_FW1   The first witness point: a point on the surface of the first
+                capsule measured and expressed in the common frame `F`.
+ @param p_FW2   The second witness point: a point on the surface of the second
+                capsule measured and expressed in the common frame `F`.
+ @return `true`.
+ @tparam S  The scalar type for computation.
+ */
 template <typename S>
 FCL_EXPORT
-bool capsuleCapsuleDistance(const Capsule<S>& s1, const Transform3<S>& tf1,
-          const Capsule<S>& s2, const Transform3<S>& tf2,
-          S* dist, Vector3<S>* p1_res, Vector3<S>* p2_res);
+bool capsuleCapsuleDistance(const Capsule<S>& s1, const Transform3<S>& X_FC1,
+          const Capsule<S>& s2, const Transform3<S>& X_FC2,
+          S* dist, Vector3<S>* p_FW1, Vector3<S>* p_FW2);
 
 } // namespace detail
 } // namespace fcl

--- a/src/narrowphase/detail/primitive_shape_algorithm/capsule_capsule.cpp
+++ b/src/narrowphase/detail/primitive_shape_algorithm/capsule_capsule.cpp
@@ -48,10 +48,12 @@ template
 double clamp(double n, double min, double max);
 
 //==============================================================================
-template
-double closestPtSegmentSegment(
-    Vector3d p1, Vector3d q1, Vector3d p2, Vector3d q2,
-    double &s, double& t, Vector3d &c1, Vector3d &c2);
+template double closestPtSegmentSegment(const Vector3d& p_FP1,
+                                        const Vector3d& p_FQ1,
+                                        const Vector3d& p_FP2,
+                                        const Vector3d& p_FQ2, double* s,
+                                        double* t, Vector3d* p_FC1,
+                                        Vector3d* p_FC2);
 
 //==============================================================================
 template

--- a/test/test_fcl_capsule_capsule.cpp
+++ b/test/test_fcl_capsule_capsule.cpp
@@ -534,6 +534,8 @@ TYPED_TEST(SegmentSegmentNearestPtTest, NominalSegments) {
 template <typename S>
 class CapsuleCapsuleSegmentTest : public ::testing::Test {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   CapsuleCapsuleSegmentTest()
       : ::testing::Test(), c1_(S(1.5), S(2.5)), c2_(S(2), S(3)) {}
 

--- a/test/test_fcl_capsule_capsule.cpp
+++ b/test/test_fcl_capsule_capsule.cpp
@@ -1,8 +1,7 @@
 /*
  *  Software License Agreement (BSD License)
  *
- *  Copyright (c) 2011-2014, Willow Garage, Inc.
- *  Copyright (c) 2014-2016, Open Source Robotics Foundation
+ *  Copyright (c) 2020, Toyota Research Institute, Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -33,153 +32,724 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-/** @author Karsten Knese <Karsten.Knese@googlemail.com> */
+/** @author Sean Curtis <sean@tri.global> */
 
 #include <gtest/gtest.h>
 
 #include "fcl/math/constants.h"
-#include "fcl/narrowphase/collision.h"
-#include "fcl/narrowphase/detail/gjk_solver_indep.h"
-#include "fcl/narrowphase/detail/gjk_solver_libccd.h"
+#include "fcl/narrowphase/detail/primitive_shape_algorithm/capsule_capsule-inl.h"
+#include "eigen_matrix_compare.h"
 
 #include <cmath>
 using namespace fcl;
 
-//==============================================================================
+// Test harness for exercising the closestPtSegmentSegment() function.
 template <typename S>
-void test_distance_capsulecapsule_origin()
-{
-  detail::GJKSolver_indep<S> solver;
-  Capsule<S> s1(5, 10);
-  Capsule<S> s2(5, 10);
+class SegmentSegmentNearestPtTest : public ::testing::Test {
+ protected:
+  // Calls the closestPtSegmentSegment with the two segments defined by
+  // endpoint pairs (p0, q0) and (p1, q1). The values s_, t_, n0_, and n1_ will
+  // be updated as a result of this call.
+  // Returns the squared distance between the two segments.
+  S ComputeNearestPoint(const Vector3<S>& p0, const Vector3<S>& q0,
+                        const Vector3<S>& p1, const Vector3<S>& q1) {
+    return detail::closestPtSegmentSegment(p0, q0, p1, q1, &s_, &t_, &n0_,
+                                           &n1_);
+  }
+  // s_ and t_ will contain the lengths of the two segments after calling
+  // the nearest point function.
+  S s_;
+  S t_;
+  // n0_ and n1_ will contain the points on the segments nearest each other
+  // after calling the nearest point function.
+  Vector3<S> n0_;
+  Vector3<S> n1_;
+};
 
-  Vector3<S> closest_p1, closest_p2;
+using ScalarTypes = ::testing::Types<double, float>;
 
-  Transform3<S> transform = Transform3<S>::Identity();
-  Transform3<S> transform2 = Transform3<S>::Identity();
-  transform2.translation() = Vector3<S>(20.1, 0,0);
+TYPED_TEST_CASE(SegmentSegmentNearestPtTest, ScalarTypes);
 
-  bool res;
-  S dist;
+TYPED_TEST(SegmentSegmentNearestPtTest, BothZeroLength) {
+  using S = TypeParam;
 
-  res = solver.template shapeDistance<Capsule<S>, Capsule<S>>(s1, transform, s2, transform2, &dist, &closest_p1, &closest_p2);
-  std::cerr << "applied transformation of two caps: " << transform.translation() << " & " << transform2.translation() << std::endl;
-  std::cerr << "computed points in caps to caps" << closest_p1 << " & " << closest_p2 << "with dist: " << dist << std::endl;
+  // Keep the points near the unit sphere so that the epsilon value doesn't
+  // need to be scaled.
+  const Vector3<S> p0{0.25, 0.5, 1.0};
+  const Vector3<S> p1{0.6, 1.0, -0.3};
 
-  EXPECT_TRUE(std::abs(dist - 10.1) < 0.001);
-  EXPECT_TRUE(res);
+  // Case: Exactly zero.
+  {
+    const S squared_dist = this->ComputeNearestPoint(p0, p0, p1, p1);
+    EXPECT_EQ(squared_dist, (p1 - p0).squaredNorm());
+    EXPECT_TRUE(CompareMatrices(this->n0_, p0));
+    EXPECT_TRUE(CompareMatrices(this->n1_, p1));
+  }
+
+  // We exploit the knowledge that the segment-segment function uses an
+  // epsilon of eps_78()² on *squared distance*. This test will fail if we
+  // change the epsilon in the algorithm and these brackets should move
+  // accordingly.
+  using std::sqrt;
+  const S kEps = constants<S>::eps_78();
+
+  // Case: Zero to within epsilon.
+  {
+    // Just below the epsilon for squared distance.
+    const S eps = kEps * 0.99;
+    const Vector3<S> q0(p0(0) + eps, p0(1), p0(2));
+    const Vector3<S> q1(p1(0) + eps, p1(1), p1(2));
+    const S squared_dist = this->ComputeNearestPoint(p0, q0, p1, q1);
+    EXPECT_EQ(squared_dist, (p1 - p0).squaredNorm());
+    EXPECT_TRUE(CompareMatrices(this->n0_, p0));
+    EXPECT_TRUE(CompareMatrices(this->n1_, p1));
+  }
+
+  // Case: Just outside epsilon length will no longer return the distance
+  // between points p0 and p1. All that we care is that the distance is no
+  // longer *exactly* the distance between p0 and p1. Thus it shows that we've
+  // crossed the algorithm's threshold.
+  {
+    // Just above the epsilon for squared distance.
+    const S eps = kEps * 1.5;
+    // Make sure the line segments are *not* parallel so we don't exercise any
+    // degenerate cases.
+    const Vector3<S> q0(p0(0) + eps, p0(1), p0(2));
+    const Vector3<S> q1(p1(0), p1(1) + eps, p1(2));
+    const S squared_dist = this->ComputeNearestPoint(p0, q0, p1, q1);
+    EXPECT_NE(squared_dist, (p1 - p0).squaredNorm());
+  }
 }
 
-//==============================================================================
+// Tests the case where the one segment is zero length.
+TYPED_TEST(SegmentSegmentNearestPtTest, OneZeroLength) {
+  using S = TypeParam;
+
+  // Segment 2 passes through the origin.
+  Vector3<S> p1{-1, -2, -3};
+  Vector3<S> q1{1, 2, 3};
+
+  // Case: First zero-length segment is nearest p1.
+  {
+    const Vector3<S> p0 = p1 + p1;
+    const S squared_dist = this->ComputeNearestPoint(p0, p0, p1, q1);
+    EXPECT_EQ(squared_dist, (p1 - p0).squaredNorm());
+    EXPECT_TRUE(CompareMatrices(this->n0_, p0));
+    EXPECT_TRUE(CompareMatrices(this->n1_, p1));
+  }
+
+  // Case: First zero-length segment is nearest q1.
+  {
+    const Vector3<S> p0 = q1 + q1;
+    const S squared_dist = this->ComputeNearestPoint(p0, p0, p1, q1);
+    EXPECT_EQ(squared_dist, (q1 - p0).squaredNorm());
+    EXPECT_TRUE(CompareMatrices(this->n0_, p0));
+    EXPECT_TRUE(CompareMatrices(this->n1_, q1));
+  }
+
+  // Case: First zero-length segment is nearest interior of second segment.
+  {
+    const Vector3<S> dir1 = q1 - p1;
+    // Create a vector perpendicular to the second segment, closest to the
+    // origin.
+    const Vector3<S> p0(dir1(1), -dir1(0), 0);
+    const S squared_dist = this->ComputeNearestPoint(p0, p0, p1, q1);
+    EXPECT_EQ(squared_dist, p0.squaredNorm());
+    EXPECT_TRUE(CompareMatrices(this->n0_, p0));
+    EXPECT_TRUE(
+        CompareMatrices(this->n1_, Vector3<S>::Zero(), constants<S>::eps_78()));
+  }
+
+  // Now we want to reverse the roles (such that the second segment has zero
+  // length) but otherwise perform the same tests. So, we'll alias the old
+  // p1, q1 as p0, q0 and then modify p1, q1 to support the equivalent tests.
+
+  const Vector3<S> p0(p1);
+  const Vector3<S> q0(q1);
+
+  // Case: Second zero-length segment is nearest p0.
+  {
+    const Vector3<S> p1 = p0 + p0;
+    const S squared_dist = this->ComputeNearestPoint(p0, q0, p1, p1);
+    EXPECT_EQ(squared_dist, (p1 - p0).squaredNorm());
+    EXPECT_TRUE(CompareMatrices(this->n0_, p0));
+    EXPECT_TRUE(CompareMatrices(this->n1_, p1));
+  }
+
+  // Case: Second zero-length segment is nearest q0.
+  {
+    const Vector3<S> p1 = q0 + q0;
+    const S squared_dist = this->ComputeNearestPoint(p0, q0, p1, p1);
+    EXPECT_EQ(squared_dist, (q0 - p1).squaredNorm());
+    EXPECT_TRUE(CompareMatrices(this->n0_, q0));
+    EXPECT_TRUE(CompareMatrices(this->n1_, p1));
+  }
+
+  // Case: Second zero-length segment is nearest interior of first segment.
+  {
+    const Vector3<S> dir1 = q0 - p0;
+    // Create a vector perpendicular to the second segment, closest to the
+    // origin.
+    const Vector3<S> p1(dir1(1), -dir1(0), 0);
+    const S squared_dist = this->ComputeNearestPoint(p0, q0, p1, p1);
+    EXPECT_EQ(squared_dist, p1.squaredNorm());
+    EXPECT_TRUE(CompareMatrices(this->n1_, p1));
+    EXPECT_TRUE(
+        CompareMatrices(this->n0_, Vector3<S>::Zero(), constants<S>::eps_78()));
+  }
+}
+
+// Tests the case where the line segments have length and are _parallel_.
+TYPED_TEST(SegmentSegmentNearestPtTest, ParallelSegments) {
+  using S = TypeParam;
+
+  const S eps = constants<S>::eps_78();
+
+  // A line to which all of the segments will be parallel.
+  const Vector3<S> dir = Vector3<S>{1, 2, 3}.normalized();
+  // A direction perpendicular to the line given by `dir`.
+  const Vector3<S> dir_perp = Vector3<S>{dir(1), -dir(0), 0}.normalized();
+  ASSERT_NEAR(dir.dot(dir_perp), 0, eps);
+
+  // In the case where there are multiple possible pairs (because the solution
+  // is not unique). While we could directly express these tests based on known
+  // details of the implementation, we decouple the test from those details by
+  // equivalently testing for:
+  //   1. The distance between the pairs should be the expected distance.
+  //   2. We can determine that the nearest point lies in the correct region
+  //      of one of the two segments.
+  // Then the implementation can use any policy it chooses to pick one point
+  // from the set and the test won't have to change.
+
+  // Case: Multiple nearest pairs: co-linear and overlapping.
+  {
+    // Segment 0 is symmetric and passes through the origin.
+    const Vector3<S> p0(-dir);
+    const Vector3<S> q0(dir);
+    // Segment 1 includes the origin and passes through q1 extending a similar
+    // distance beyond.
+    const Vector3<S> p1(Vector3<S>::Zero());
+    const Vector3<S> q1(2 * dir);
+    const S squared_dist = this->ComputeNearestPoint(p0, q0, p1, q1);
+
+    EXPECT_NEAR(squared_dist, 0, eps);
+
+    // Test pair: distance between them and that n0 lies between the origin and
+    // q0.
+    EXPECT_NEAR((this->n0_ - this->n1_).norm(), 0, eps);
+    const S nearest_dist = this->n0_.norm();
+    EXPECT_NEAR(nearest_dist, dir.dot(this->n0_), eps);
+    EXPECT_LE(nearest_dist, q0.norm());
+  }
+
+  // Case: Multiple nearest pairs: separated parallel lines but with overlapping
+  // projections.
+  {
+    // Same configuration as in the co-linear case, but the second segment is
+    // moved perpendicularly to the first segment.
+    const Vector3<S> p0(-dir);
+    const Vector3<S> q0(dir);
+    const S expected_dist = 0.5;
+    const Vector3<S> offset = dir_perp * expected_dist;
+    const Vector3<S> p1 = Vector3<S>::Zero() + offset;
+    const Vector3<S> q1 = 2 * dir + offset;
+    const S squared_dist = this->ComputeNearestPoint(p0, q0, p1, q1);
+
+    EXPECT_NEAR(squared_dist, expected_dist * expected_dist, eps);
+    // Test pair: distance between them and n0 lies between origin and q0.
+    EXPECT_NEAR((this->n0_ - this->n1_).norm(), expected_dist, eps);
+    const S nearest_dist = this->n0_.norm();
+    EXPECT_NEAR(nearest_dist, dir.dot(this->n0_), eps);
+    EXPECT_LE(nearest_dist, q0.norm());
+  }
+
+  // Case: Single solution: shared end point.
+  {
+    const Vector3<S> p0(-dir);
+    const Vector3<S> q0(dir);  // also serves as p1.
+    const Vector3<S> q1(2 * dir);
+
+    const S squared_dist = this->ComputeNearestPoint(p0, q0, q0, q1);
+
+    EXPECT_NEAR(squared_dist, 0, eps);
+    EXPECT_TRUE(CompareMatrices(this->n0_, q0));
+    EXPECT_TRUE(CompareMatrices(this->n1_, q0));
+  }
+
+  // Case: Single solution: co-linear but non-overlapping such that (p1, q0)
+  // are the nearest points.
+  {
+    const Vector3<S> p0(-dir);
+    const Vector3<S> q0(dir);
+    const Vector3<S> p1(2 * dir);
+    const Vector3<S> q1(3 * dir);
+
+    const S squared_dist = this->ComputeNearestPoint(p0, q0, p1, q1);
+
+    EXPECT_NEAR(squared_dist, dir.norm(), eps);
+    EXPECT_TRUE(CompareMatrices(this->n0_, q0));
+    EXPECT_TRUE(CompareMatrices(this->n1_, p1));
+  }
+
+  // Case: Single solution: not co-linear and non-overlapping such that (p1, q0)
+  // are the nearest points.
+  {
+    const Vector3<S> p0(-dir);
+    const Vector3<S> q0(dir);
+    const Vector3<S> p1(2 * dir + dir_perp);
+    const Vector3<S> q1(3 * dir + dir_perp);
+
+    const S squared_dist = this->ComputeNearestPoint(p0, q0, p1, q1);
+
+    EXPECT_NEAR(squared_dist, (p1 - q0).squaredNorm(), eps);
+    EXPECT_TRUE(CompareMatrices(this->n0_, q0));
+    EXPECT_TRUE(CompareMatrices(this->n1_, p1));
+  }
+
+  // Case: Single solution: co-linear but non-overlapping such that (p0, q1)
+  // are the nearest points.
+  {
+    const Vector3<S> p0(-dir);
+    const Vector3<S> q0(dir);
+    const Vector3<S> p1(-3 * dir);
+    const Vector3<S> q1(-2 * dir);
+
+    const S squared_dist = this->ComputeNearestPoint(p0, q0, p1, q1);
+
+    EXPECT_NEAR(squared_dist, dir.norm(), eps);
+    EXPECT_TRUE(CompareMatrices(this->n0_, p0));
+    EXPECT_TRUE(CompareMatrices(this->n1_, q1));
+  }
+
+  // Case: Single solution: not co-linear and non-overlapping such that (p0, q1)
+  // are the nearest points.
+  {
+    const Vector3<S> p0(-dir);
+    const Vector3<S> q0(dir);
+    const Vector3<S> p1(-3 * dir + dir_perp);
+    const Vector3<S> q1(-2 * dir + dir_perp);
+
+    const S squared_dist = this->ComputeNearestPoint(p0, q0, p1, q1);
+
+    EXPECT_NEAR(squared_dist, (p0 - q1).squaredNorm(), eps);
+    EXPECT_TRUE(CompareMatrices(this->n0_, p0));
+    EXPECT_TRUE(CompareMatrices(this->n1_, q1));
+  }
+}
+
+// Tests the nominal case where the segments have length and are *not* parallel.
+TYPED_TEST(SegmentSegmentNearestPtTest, NominalSegments) {
+  using S = TypeParam;
+
+  const S eps = constants<S>::eps_78();
+
+  // An arbitrary direction for segment A.
+  const Vector3<S> dir_A = Vector3<S>{1, 2, 3}.normalized();
+  // An arbitrary direction for segment B such that it is neither parallel nor
+  // perpendicular to dir_A. We're excluding perpendicular as that represents
+  // the _best_ conditioning for the math and we want to characterize the
+  // accuracy when the numbers _aren't_ that great.
+  const Vector3<S> dir_B = Vector3<S>{-2, 1, -0.5}.normalized();
+  using std::abs;
+  GTEST_ASSERT_GE(abs(dir_A.dot(dir_B)), eps);
+  GTEST_ASSERT_LT(abs(dir_A.dot(dir_B)), 1 - eps);
+
+  // A direction perpendicular to both A and B.
+  const Vector3<S> perp = dir_A.cross(dir_B).normalized();
+
+  // Configure the two segments so that they perfectly intersect at expected_n0.
+  const Vector3<S> expected_n0 = Vector3<S>{-0.5, 1.25, 0.75};
+  const Vector3<S> p0 = expected_n0 + dir_A;
+  const Vector3<S> q0 = expected_n0 - 2 * dir_A;
+  const Vector3<S> p1 = expected_n0 + dir_B;
+  const Vector3<S> q1 = expected_n0 - 2.5 * dir_B;
+  const S expected_s = 1 / 3.0;
+  const S t_expected = 1 / 3.5;
+
+  // Case: literally intersecting (intersection point is *not* at the origin).
+  {
+    const S squared_dist = this->ComputeNearestPoint(p0, q0, p1, q1);
+
+    EXPECT_NEAR(squared_dist, S(0), eps);
+    EXPECT_NEAR(this->s_, expected_s, eps);
+    EXPECT_NEAR(this->t_, t_expected, eps);
+    EXPECT_TRUE(CompareMatrices(this->n0_, expected_n0, eps));
+    EXPECT_TRUE(CompareMatrices(this->n1_, expected_n0, eps));
+  }
+
+  // Case: nearest points on interior of both. We simply separate the
+  // intersecting lines in a direction perpendicular to segment A; n0 will still
+  // be the same. And s and t will be unchanged.
+  {
+    const S expected_dist = 1.25;
+    const Vector3<S> offset = expected_dist * perp;
+    const S squared_dist =
+        this->ComputeNearestPoint(p0, q0, p1 + offset, q1 + offset);
+
+    EXPECT_NEAR(squared_dist, expected_dist * expected_dist, eps);
+    EXPECT_NEAR(this->s_, expected_s, eps);
+    EXPECT_NEAR(this->t_, t_expected, eps);
+    EXPECT_TRUE(CompareMatrices(this->n0_, expected_n0, eps));
+    EXPECT_TRUE(CompareMatrices(this->n1_, this->n0_ + offset, eps));
+  }
+
+  // Projects the point Q onto the line segment AB and reports the projection
+  // point N and the parameter u such that N = A + u(B - A)
+  auto project_onto_segment = [](const Vector3<S>& A, const Vector3<S>& B,
+                                 const Vector3<S>& Q, Vector3<S>* N, S* u) {
+    const Vector3<S> d = B - A;
+    *u = d.dot(Q - A) / d.squaredNorm();
+    *N = A + *u * d;
+  };
+
+  // Case: p0 nearest to interior of B. We'll take the intersecting
+  // configuration and slide segment B off of the p0 end of segment A, but
+  // because they aren't perpendicular, the point on B that is nearest (and the
+  // value of t), will depend on the distance.
+  {
+    const Vector3<S> offset = 1.1 * (p0 - expected_n0);
+    const Vector3<S> p1_shift = p1 + offset;
+    const Vector3<S> q1_shift = q1 + offset;
+    Vector3<S> expected_N1;
+    S t_expected;
+    project_onto_segment(p1_shift, q1_shift, p0, &expected_N1, &t_expected);
+    const S expected_squared_dist = (p0 - expected_N1).squaredNorm();
+
+    // Test p0 against interior of B.
+    S squared_dist =
+        this->ComputeNearestPoint(p0, q0, p1_shift, q1_shift);
+
+    EXPECT_NEAR(squared_dist, expected_squared_dist, eps);
+    EXPECT_NEAR(this->s_, S(0), eps);
+    EXPECT_NEAR(this->t_, t_expected, eps);
+    EXPECT_TRUE(CompareMatrices(this->n0_, p0, eps));
+    EXPECT_TRUE(CompareMatrices(this->n1_, expected_N1, eps));
+
+    // Test p1 against interior of A (by swapping parameter arguments). This
+    // requires testing s against expected t, n0 against expected n1, and n1
+    // against p0.
+    squared_dist = this->ComputeNearestPoint(p1_shift, q1_shift, p0, q0);
+
+    EXPECT_NEAR(squared_dist, expected_squared_dist, eps);
+    EXPECT_NEAR(this->s_, t_expected, eps);
+    EXPECT_NEAR(this->t_, S(0), eps);
+    EXPECT_TRUE(CompareMatrices(this->n0_, expected_N1, eps));
+    EXPECT_TRUE(CompareMatrices(this->n1_, p0, eps));
+  }
+
+  // Case: q0 nearest to center of B. Now slide B the other direction.
+  {
+    const Vector3<S> offset = 1.1 * (q0 - expected_n0);
+    const Vector3<S> p1_shift = p1 + offset;
+    const Vector3<S> q1_shift = q1 + offset;
+    Vector3<S> expected_N1;
+    S t_expected;
+    project_onto_segment(p1_shift, q1_shift, q0, &expected_N1, &t_expected);
+    const S expected_squared_dist = (q0 - expected_N1).squaredNorm();
+
+    // Test q0 against interior of B.
+    S squared_dist =
+        this->ComputeNearestPoint(p0, q0, p1_shift, q1_shift);
+
+    EXPECT_NEAR(squared_dist, expected_squared_dist, eps);
+    EXPECT_NEAR(this->s_, S(1), eps);
+    EXPECT_NEAR(this->t_, t_expected, eps);
+    EXPECT_TRUE(CompareMatrices(this->n0_, q0, eps));
+    EXPECT_TRUE(CompareMatrices(this->n1_, expected_N1, eps));
+
+    // Test q1 against interior of A (by swapping parameter arguments). This
+    // requires testing s against expected t, n0 against expected n1, and n1
+    // against q0.
+    squared_dist = this->ComputeNearestPoint(p1_shift, q1_shift, p0, q0);
+
+    EXPECT_NEAR(squared_dist, expected_squared_dist, eps);
+    EXPECT_NEAR(this->s_, t_expected, eps);
+    EXPECT_NEAR(this->t_, S(1), eps);
+    EXPECT_TRUE(CompareMatrices(this->n0_, expected_N1, eps));
+    EXPECT_TRUE(CompareMatrices(this->n1_, q0, eps));
+  }
+
+  // Case: p0 nearest end point of segment B (first p1, then q1). However, the
+  // point on B cannot be co-linear with A. We won't reverse these roles
+  // because the problem is already perfectly symmetric.
+  {
+    // Offset is guaranteed to have a positive dot product with dir the
+    // direction along segment A towards p0, but _not_ be parallel (which
+    // prevents co-linearity).
+    const Vector3<S> p0_dir = p0 - expected_n0;
+    const Vector3<S> offset = p0_dir.cwiseProduct(Vector3<S>{1.75, 1.5, 1.25});
+    const Vector3<S> p1_shift = p0 + offset;
+    // q1 needs to be positioned such that it's always farther from segment A
+    // than p1. We know the direction from segment A to p1 (offset). If
+    // offset⋅dir_B is positive, then we extend in the dir_B direction,
+    // otherwise the -dir_B direction.
+    const Vector3<S> q1_shift =
+        p1_shift + (offset.dot(dir_B) > 0 ? dir_B : Vector3<S>{-dir_B});
+
+    // p0 is nearest p1.
+    S squared_dist = this->ComputeNearestPoint(p0, q0, p1_shift, q1_shift);
+
+    EXPECT_NEAR(squared_dist, offset.squaredNorm(), eps);
+    EXPECT_NEAR(this->s_, S(0), eps);
+    EXPECT_NEAR(this->t_, S(0), eps);
+    EXPECT_TRUE(CompareMatrices(this->n0_, p0, eps));
+    EXPECT_TRUE(CompareMatrices(this->n1_, p1_shift, eps));
+
+    // p0 is nearest q1 -- simply reverse p1_shift and q1_shift.
+    squared_dist = this->ComputeNearestPoint(p0, q0, q1_shift, p1_shift);
+
+    EXPECT_NEAR(squared_dist, offset.squaredNorm(), eps);
+    EXPECT_NEAR(this->s_, S(0), eps);
+    EXPECT_NEAR(this->t_, S(1), eps);
+    EXPECT_TRUE(CompareMatrices(this->n0_, p0, eps));
+    EXPECT_TRUE(CompareMatrices(this->n1_, p1_shift, eps));
+
+    // q0 is nearest p1 -- reverse p0 and q0.
+    squared_dist = this->ComputeNearestPoint(q0, p0, p1_shift, q1_shift);
+
+    EXPECT_NEAR(squared_dist, offset.squaredNorm(), eps);
+    EXPECT_NEAR(this->s_, S(1), eps);
+    EXPECT_NEAR(this->t_, S(0), eps);
+    EXPECT_TRUE(CompareMatrices(this->n0_, p0, eps));
+    EXPECT_TRUE(CompareMatrices(this->n1_, p1_shift, eps));
+
+    // q0 is nearest q1 -- reverse all points.
+    squared_dist = this->ComputeNearestPoint(q0, p0, q1_shift, p1_shift);
+
+    EXPECT_NEAR(squared_dist, offset.squaredNorm(), eps);
+    EXPECT_NEAR(this->s_, S(1), eps);
+    EXPECT_NEAR(this->t_, S(1), eps);
+    EXPECT_TRUE(CompareMatrices(this->n0_, p0, eps));
+    EXPECT_TRUE(CompareMatrices(this->n1_, p1_shift, eps));
+  }
+}
+
+// Test harness for exercising the capsuleCapsuleDistance() function. Most of
+// the functionality of this function relies on closestPtSegmentSegment() for
+// correctness. That has been rigorously tested above. capsuleCapsuleDistance()
+// simply has the responsibility of creating the correct segments out of
+// arbitrarily posed capsules and then reporting the distance and nearest
+// points correctly (to account for capsule radii).
 template <typename S>
-void test_distance_capsulecapsule_transformXY()
-{
-  detail::GJKSolver_indep<S> solver;
-  Capsule<S> s1(5, 10);
-  Capsule<S> s2(5, 10);
+class CapsuleCapsuleSegmentTest : public ::testing::Test {
+ public:
+  CapsuleCapsuleSegmentTest() : ::testing::Test(), c1_(1.5, 2.5), c2_(2, 3) {}
 
-  Vector3<S> closest_p1, closest_p2;
+ protected:
+  // See the note below for the explanation of these four cases.
+  enum Configuration {
+    kSeparated,
+    kIntersecting,
+    kSingleOverlap,
+    kMultipleOverlap
+  };
+  /* Configure the scene such that neither transform is ever near an identity
+   matrix. But the scenario will essentially be one of:
 
-  Transform3<S> transform = Transform3<S>::Identity();
-  Transform3<S> transform2 = Transform3<S>::Identity();
-  transform2.translation() = Vector3<S>(20, 20,0);
+         ●●●●●●●●●
+       ●  _______  ●                                           ●●●
+       ●           ●                                         ●     ●
+         ●●●●●●●●●         ●●●●●●●●●            ○○○          ● ○○○ ●
+                         ●  _______  ●       ●●●●●●●●●       ●○   ○●
+           ○○○           ●   ○○○     ●     ●  _○ | ○_  ●     ●○ | ○●
+          ○   ○            ●●●●●●●●●       ●   ○ | ○   ●     ●○ | ○●
+          ○ | ○             ○ | ○            ●●●●●●●●●        ○●●●○
+          ○ | ○             ○ | ○              ○ | ○          ○ | ○
+          ○ | ○             ○ | ○              ○   ○          ○   ○
+          ○ | ○             ○ | ○               ○○○            ○○○
+          ○   ○             ○   ○
+           ○○○               ○○○
 
-  bool res;
-  S dist;
+        Separated        Intersecting       Single overlap    Multiple overlap
 
-  res = solver.template shapeDistance<Capsule<S>, Capsule<S>>(s1, transform, s2, transform2, &dist, &closest_p1, &closest_p2);
-  std::cerr << "applied transformation of two caps: " << transform.translation() << " & " << transform2.translation() << std::endl;
-  std::cerr << "computed points in caps to caps" << closest_p1 << " & " << closest_p2 << "with dist: " << dist << std::endl;
+  Separated:        A single, well-defined pair of witness points to the
+                    positive signed distance.
+  Intersecting:     A single, well-defined pair of witness points to the
+                    negative signed distance.
+  Single overlap:   The capsule center lines intersect so there is no unique
+                    witness pair to the negative signed distance.
+  Multiple overlap: The capsule center lines overlap over an interval, so there
+                    is no unique witness pair to the negative signed distance.
 
-  S expected = std::sqrt(S(800)) - 10;
-  EXPECT_TRUE(std::abs(expected-dist) < 0.01);
-  EXPECT_TRUE(res);
+  We prevent the transforms from being "boring" by expressing the configuration
+  above in a test frame T, but then evaluate the test in frame F, such that X_FT
+  is arbitrarily ugly.
+  */
+  void Configure(Configuration config) {
+    switch (config) {
+      case kSeparated:
+        ConfigureSeparated();
+        break;
+      case kIntersecting:
+        ConfigureIntersecting();
+        break;
+      case kSingleOverlap:
+        ConfigureSingleOverlap();
+        break;
+      case kMultipleOverlap:
+        ConfigureMultipleOverlap();
+        break;
+    }
+  }
+
+  ::testing::AssertionResult RunTestConfiguration(Configuration config) {
+    S distance;
+    Vector3<S> p_FW1, p_FW2;
+
+    this->Configure(config);
+
+    detail::capsuleCapsuleDistance(this->c1_, this->X_FC1_, this->c2_,
+                                   this->X_FC2_, &distance, &p_FW1, &p_FW2);
+    const auto eps = constants<S>::eps_78();
+    using std::abs;
+    S error = abs(distance - this->expected_distance_);
+    if (error > eps) {
+      return ::testing::AssertionFailure()
+             << "Error in reported distances"
+             << "\n Actual: " << distance
+             << "\n Expected: " << this->expected_distance_
+             << "\n Error: " << error
+             << "\n Tolerance: " << eps;
+    }
+    auto result1 = CompareMatrices(p_FW1, this->expected_p_FW1_, eps);
+    if (!result1) return result1;
+    return CompareMatrices(p_FW2, this->expected_p_FW2_, eps);
+  }
+
+  void ConfigureSeparated() {
+    this->ConfigureViableT(0.25);
+  }
+
+  void ConfigureIntersecting() {
+    this->ConfigureViableT(-0.25);
+  }
+
+  // Configures separated, instance, and single overlap. What they have in
+  // common is that the the geometries form a "T" (which means that between
+  // the *center lines* there will always be a unique witness point pair.
+  void ConfigureViableT(S distance) {
+    const auto pi = constants<S>::pi();
+
+    // The reported distance cannot be less than -(r1 + r2); that is the deepest
+    // penetration possible.
+    using std::max;
+    expected_distance_ = max(distance, -(c1_.radius + c2_.radius));
+
+    Transform3<S> X_TC1 = Transform3<S>::Identity();
+    Transform3<S> X_TC2(AngleAxis<S>(pi / 2, Vector3<S>::UnitY()));
+    X_TC2.translation() << 0, 0,
+        c1_.lz / 2 + c1_.radius + c2_.radius + distance;
+
+    Vector3<S> p_TW1{0, 0, c1_.lz / 2 + c1_.radius};
+    expected_p_FW1_ = X_FT() * p_TW1;
+    Vector3<S> p_TW2{p_TW1(0), p_TW1(1), p_TW1(2) + distance};
+    expected_p_FW2_ = X_FT() * p_TW2;
+
+    X_FC1_ = X_FT() * X_TC1;
+    X_FC2_ = X_FT() * X_TC2;
+  }
+
+  void ConfigureSingleOverlap() {
+    expected_distance_ = -(c1_.radius + c2_.radius);
+
+    const auto pi = constants<S>::pi();
+    Transform3<S> X_TC1 = Transform3<S>::Identity();
+    Transform3<S> X_TC2(AngleAxis<S>(pi / 2, Vector3<S>::UnitY()));
+    // Position C2 halfway up the upper length of C1.
+    X_TC2.translation() << 0, 0, c1_.lz / 4;
+
+    // The witness points lie on a line parallel with the Ty direction that
+    // passes through the point p_TC2. For each capsule there are *two* points
+    // that lie on that line. This test has been specifically formulated with
+    // knowledge of how the capsuleCapsuleDistance() function is formulated
+    // to select *one* of those two. This allows the final test to simply
+    // compare witness points directly. A change in this special case in the
+    // function under test will cause this configuration to fail.
+    Vector3<S> p_TW1{0, c1_.radius, c1_.lz / 4};
+    expected_p_FW1_ = X_FT() * p_TW1;
+    Vector3<S> p_TW2{0, -c2_.radius, c1_.lz / 4};
+    expected_p_FW2_ = X_FT() * p_TW2;
+
+    X_FC1_ = X_FT() * X_TC1;
+    X_FC2_ = X_FT() * X_TC2;
+  }
+
+  void ConfigureMultipleOverlap() {
+    expected_distance_ = -(c1_.radius + c2_.radius);
+
+    Transform3<S> X_TC1 = Transform3<S>::Identity();
+    Transform3<S> X_TC2 = Transform3<S>::Identity();
+    // Position C2 so that the lower end of its center lines is at the origin
+    // and overlaps with the upper end of C1's center line.
+    X_TC2.translation() << 0, 0, c2_.lz / 2;
+
+    // When the two center lines are aligned and overlap, there is an infinite
+    // set of witness points. We exploit the knowledge of how the function under
+    // test resolves this to create *specific* witness points. We *know* it will
+    // pick points that line up with the Tx axis. The biggest unknown is where
+    // in the range [0, L1/2] along Tz the witness point is placed. Empirically,
+    // it is shown to be at p0 (the top of C1's center line).
+    Vector3<S> p_TW1{c1_.radius, 0, c1_.lz / 2};
+    expected_p_FW1_ = X_FT() * p_TW1;
+    Vector3<S> p_TW2{-c2_.radius, 0, c1_.lz / 2};
+    expected_p_FW2_ = X_FT() * p_TW2;
+
+    X_FC1_ = X_FT() * X_TC1;
+    X_FC2_ = X_FT() * X_TC2;
+  }
+
+  Transform3<S> X_FT() const {
+    // Create some arbitrarily ugly transform; the important bit that there
+    // be no identities (zeros and ones).
+    Transform3<S> X_FT_ = Transform3<S>::Identity();
+    X_FT_.translation() << 10.5, 12.75, -2.5;
+    X_FT_.linear() =
+        AngleAxis<S>(constants<S>::pi() / 7, Vector3<S>{1, 2, 3}.normalized())
+            .matrix();
+    return X_FT_;
+  }
+
+  Capsule<S> c1_;
+  Capsule<S> c2_;
+  Transform3<S> X_FC1_;
+  Transform3<S> X_FC2_;
+
+  // The expected values: signed distance and witness points on capsules 1 and
+  // 2, respectively.
+  S expected_distance_;
+  Vector3<S> expected_p_FW1_;
+  Vector3<S> expected_p_FW2_;
+};
+
+TYPED_TEST_CASE(CapsuleCapsuleSegmentTest, ScalarTypes);
+
+// The nominal case will create two unique capsules with a straight forward
+// relationship. Making sure the transforms are *not* identity will sufficiently
+// exercise the functions logic. We assume that if we can correctly construct
+// one pair of line segments, that we'll construct all line segments properly.
+TYPED_TEST(CapsuleCapsuleSegmentTest, NominalSeparatedCase) {
+  EXPECT_TRUE(this->RunTestConfiguration(
+      CapsuleCapsuleSegmentTest<TypeParam>::kSeparated));
 }
 
-//==============================================================================
-template <typename S>
-void test_distance_capsulecapsule_transformZ()
-{
-  detail::GJKSolver_indep<S> solver;
-  Capsule<S> s1(5, 10);
-  Capsule<S> s2(5, 10);
-
-  Vector3<S> closest_p1, closest_p2;
-
-  Transform3<S> transform = Transform3<S>::Identity();
-  Transform3<S> transform2 = Transform3<S>::Identity();
-  transform2.translation() = Vector3<S>(0,0,20.1);
-
-  bool res;
-  S dist;
-
-  res = solver.template shapeDistance<Capsule<S>, Capsule<S>>(s1, transform, s2, transform2, &dist, &closest_p1, &closest_p2);
-  std::cerr << "applied transformation of two caps: " << transform.translation() << " & " << transform2.translation() << std::endl;
-  std::cerr << "computed points in caps to caps" << closest_p1 << " & " << closest_p2 << "with dist: " << dist << std::endl;
-
-  EXPECT_TRUE(std::abs(dist - 0.1) < 0.001);
-  EXPECT_TRUE(res);
+// Similar to the nominal separated case, but the capsules will be intersecting.
+TYPED_TEST(CapsuleCapsuleSegmentTest, NominalIntersectingCase) {
+  EXPECT_TRUE(this->RunTestConfiguration(
+      CapsuleCapsuleSegmentTest<TypeParam>::kIntersecting));
 }
 
-//==============================================================================
-template <typename S>
-void test_distance_capsulecapsule_transformZ2()
-{
-  const S Pi = constants<S>::pi();
-
-  detail::GJKSolver_indep<S> solver;
-  Capsule<S> s1(5, 10);
-  Capsule<S> s2(5, 10);
-
-  Vector3<S> closest_p1, closest_p2;
-
-  Transform3<S> transform = Transform3<S>::Identity();
-  Transform3<S> transform2 = Transform3<S>::Identity();
-  transform2.translation() = Vector3<S>(0,0,25.1);
-  Matrix3<S> rot2(
-        AngleAxis<S>(0, Vector3<S>::UnitX())
-        * AngleAxis<S>(Pi/2, Vector3<S>::UnitY())
-        * AngleAxis<S>(0, Vector3<S>::UnitZ()));
-  transform2.linear() = rot2;
-
-  bool res;
-  S dist;
-
-  res = solver.template shapeDistance<Capsule<S>, Capsule<S>>(s1, transform, s2, transform2, &dist, &closest_p1, &closest_p2);
-  std::cerr << "applied transformation of two caps: " << transform.translation() << " & " << transform2.translation() << std::endl;
-  std::cerr << "applied transformation of two caps: " << transform.linear() << " & " << transform2.linear() << std::endl;
-  std::cerr << "computed points in caps to caps" << closest_p1 << " & " << closest_p2 << "with dist: " << dist << std::endl;
-
-  EXPECT_TRUE(std::abs(dist - 5.1) < 0.001);
-  EXPECT_TRUE(res);
+// Tests the case where the capsules are positioned such their center lines
+// intersect at a single point.
+TYPED_TEST(CapsuleCapsuleSegmentTest, SingleIntersectionCenterLines) {
+  EXPECT_TRUE(this->RunTestConfiguration(
+      CapsuleCapsuleSegmentTest<TypeParam>::kSingleOverlap));
 }
 
-//==============================================================================
-GTEST_TEST(FCL_CAPSULE_CAPSULE, distance_capsulecapsule_origin)
-{
-//  test_distance_capsulecapsule_origin<float>();
-  test_distance_capsulecapsule_origin<double>();
-}
-
-//==============================================================================
-GTEST_TEST(FCL_CAPSULE_CAPSULE, distance_capsulecapsule_transformXY)
-{
-//  test_distance_capsulecapsule_transformXY<float>();
-  test_distance_capsulecapsule_transformXY<double>();
-}
-
-//==============================================================================
-GTEST_TEST(FCL_CAPSULE_CAPSULE, distance_capsulecapsule_transformZ)
-{
-//  test_distance_capsulecapsule_transformZ<float>();
-  test_distance_capsulecapsule_transformZ<double>();
-}
-
-//==============================================================================
-GTEST_TEST(FCL_CAPSULE_CAPSULE, distance_capsulecapsule_transformZ2)
-{
-//  test_distance_capsulecapsule_transformZ2<float>();
-  test_distance_capsulecapsule_transformZ2<double>();
+// Tests the case where the capsules are positioned such that their center lines
+// overlap.
+TYPED_TEST(CapsuleCapsuleSegmentTest, OverlappingCenterLines) {
+  EXPECT_TRUE(this->RunTestConfiguration(
+      CapsuleCapsuleSegmentTest<TypeParam>::kMultipleOverlap));
 }
 
 //==============================================================================

--- a/test/test_fcl_capsule_capsule.cpp
+++ b/test/test_fcl_capsule_capsule.cpp
@@ -75,8 +75,8 @@ TYPED_TEST(SegmentSegmentNearestPtTest, BothZeroLength) {
 
   // Keep the points near the unit sphere so that the epsilon value doesn't
   // need to be scaled.
-  const Vector3<S> p0{0.25, 0.5, 1.0};
-  const Vector3<S> p1{0.6, 1.0, -0.3};
+  const Vector3<S> p0{S(0.25), S(0.5), S(1.0)};
+  const Vector3<S> p1{S(0.6), S(1.0), S(-0.3)};
 
   // Case: Exactly zero.
   {
@@ -96,7 +96,7 @@ TYPED_TEST(SegmentSegmentNearestPtTest, BothZeroLength) {
   // Case: Zero to within epsilon.
   {
     // Just below the epsilon for squared distance.
-    const S eps = kEps * 0.99;
+    const S eps = kEps * S(0.99);
     const Vector3<S> q0(p0(0) + eps, p0(1), p0(2));
     const Vector3<S> q1(p1(0) + eps, p1(1), p1(2));
     const S squared_dist = this->ComputeNearestPoint(p0, q0, p1, q1);
@@ -111,7 +111,7 @@ TYPED_TEST(SegmentSegmentNearestPtTest, BothZeroLength) {
   // crossed the algorithm's threshold.
   {
     // Just above the epsilon for squared distance.
-    const S eps = kEps * 1.5;
+    const S eps = kEps * S(1.5);
     // Make sure the line segments are *not* parallel so we don't exercise any
     // degenerate cases.
     const Vector3<S> q0(p0(0) + eps, p0(1), p0(2));
@@ -126,8 +126,8 @@ TYPED_TEST(SegmentSegmentNearestPtTest, OneZeroLength) {
   using S = TypeParam;
 
   // Segment 2 passes through the origin.
-  Vector3<S> p1{-1, -2, -3};
-  Vector3<S> q1{1, 2, 3};
+  Vector3<S> p1{S(-1), S(-2), S(-3)};
+  Vector3<S> q1{S(1), S(2), S(3)};
 
   // Case: First zero-length segment is nearest p1.
   {
@@ -190,7 +190,7 @@ TYPED_TEST(SegmentSegmentNearestPtTest, OneZeroLength) {
     const Vector3<S> dir1 = q0 - p0;
     // Create a vector perpendicular to the second segment, closest to the
     // origin.
-    const Vector3<S> p1(dir1(1), -dir1(0), 0);
+    const Vector3<S> p1(dir1(1), -dir1(0), S(0));
     const S squared_dist = this->ComputeNearestPoint(p0, q0, p1, p1);
     EXPECT_EQ(squared_dist, p1.squaredNorm());
     EXPECT_TRUE(CompareMatrices(this->n1_, p1));
@@ -206,9 +206,9 @@ TYPED_TEST(SegmentSegmentNearestPtTest, ParallelSegments) {
   const S eps = constants<S>::eps_78();
 
   // A line to which all of the segments will be parallel.
-  const Vector3<S> dir = Vector3<S>{1, 2, 3}.normalized();
+  const Vector3<S> dir = Vector3<S>{S(1), S(2), S(3)}.normalized();
   // A direction perpendicular to the line given by `dir`.
-  const Vector3<S> dir_perp = Vector3<S>{dir(1), -dir(0), 0}.normalized();
+  const Vector3<S> dir_perp = Vector3<S>{dir(1), -dir(0), S(0)}.normalized();
   ASSERT_NEAR(dir.dot(dir_perp), 0, eps);
 
   // In the case where there are multiple possible pairs (because the solution
@@ -229,14 +229,14 @@ TYPED_TEST(SegmentSegmentNearestPtTest, ParallelSegments) {
     // Segment 1 includes the origin and passes through q1 extending a similar
     // distance beyond.
     const Vector3<S> p1(Vector3<S>::Zero());
-    const Vector3<S> q1(2 * dir);
+    const Vector3<S> q1(S(2) * dir);
     const S squared_dist = this->ComputeNearestPoint(p0, q0, p1, q1);
 
-    EXPECT_NEAR(squared_dist, 0, eps);
+    EXPECT_NEAR(squared_dist, S(0), eps);
 
     // Test pair: distance between them and that n0 lies between the origin and
     // q0.
-    EXPECT_NEAR((this->n0_ - this->n1_).norm(), 0, eps);
+    EXPECT_NEAR((this->n0_ - this->n1_).norm(), S(0), eps);
     const S nearest_dist = this->n0_.norm();
     EXPECT_NEAR(nearest_dist, dir.dot(this->n0_), eps);
     EXPECT_LE(nearest_dist, q0.norm());
@@ -249,10 +249,10 @@ TYPED_TEST(SegmentSegmentNearestPtTest, ParallelSegments) {
     // moved perpendicularly to the first segment.
     const Vector3<S> p0(-dir);
     const Vector3<S> q0(dir);
-    const S expected_dist = 0.5;
+    const S expected_dist{0.5};
     const Vector3<S> offset = dir_perp * expected_dist;
     const Vector3<S> p1 = Vector3<S>::Zero() + offset;
-    const Vector3<S> q1 = 2 * dir + offset;
+    const Vector3<S> q1 = S(2) * dir + offset;
     const S squared_dist = this->ComputeNearestPoint(p0, q0, p1, q1);
 
     EXPECT_NEAR(squared_dist, expected_dist * expected_dist, eps);
@@ -267,11 +267,11 @@ TYPED_TEST(SegmentSegmentNearestPtTest, ParallelSegments) {
   {
     const Vector3<S> p0(-dir);
     const Vector3<S> q0(dir);  // also serves as p1.
-    const Vector3<S> q1(2 * dir);
+    const Vector3<S> q1(S(2) * dir);
 
     const S squared_dist = this->ComputeNearestPoint(p0, q0, q0, q1);
 
-    EXPECT_NEAR(squared_dist, 0, eps);
+    EXPECT_NEAR(squared_dist, S(0), eps);
     EXPECT_TRUE(CompareMatrices(this->n0_, q0));
     EXPECT_TRUE(CompareMatrices(this->n1_, q0));
   }
@@ -281,8 +281,8 @@ TYPED_TEST(SegmentSegmentNearestPtTest, ParallelSegments) {
   {
     const Vector3<S> p0(-dir);
     const Vector3<S> q0(dir);
-    const Vector3<S> p1(2 * dir);
-    const Vector3<S> q1(3 * dir);
+    const Vector3<S> p1(S(2) * dir);
+    const Vector3<S> q1(S(3) * dir);
 
     const S squared_dist = this->ComputeNearestPoint(p0, q0, p1, q1);
 
@@ -296,8 +296,8 @@ TYPED_TEST(SegmentSegmentNearestPtTest, ParallelSegments) {
   {
     const Vector3<S> p0(-dir);
     const Vector3<S> q0(dir);
-    const Vector3<S> p1(2 * dir + dir_perp);
-    const Vector3<S> q1(3 * dir + dir_perp);
+    const Vector3<S> p1(S(2) * dir + dir_perp);
+    const Vector3<S> q1(S(3) * dir + dir_perp);
 
     const S squared_dist = this->ComputeNearestPoint(p0, q0, p1, q1);
 
@@ -311,8 +311,8 @@ TYPED_TEST(SegmentSegmentNearestPtTest, ParallelSegments) {
   {
     const Vector3<S> p0(-dir);
     const Vector3<S> q0(dir);
-    const Vector3<S> p1(-3 * dir);
-    const Vector3<S> q1(-2 * dir);
+    const Vector3<S> p1(S(-3) * dir);
+    const Vector3<S> q1(S(-2) * dir);
 
     const S squared_dist = this->ComputeNearestPoint(p0, q0, p1, q1);
 
@@ -326,8 +326,8 @@ TYPED_TEST(SegmentSegmentNearestPtTest, ParallelSegments) {
   {
     const Vector3<S> p0(-dir);
     const Vector3<S> q0(dir);
-    const Vector3<S> p1(-3 * dir + dir_perp);
-    const Vector3<S> q1(-2 * dir + dir_perp);
+    const Vector3<S> p1(S(-3) * dir + dir_perp);
+    const Vector3<S> q1(S(-2) * dir + dir_perp);
 
     const S squared_dist = this->ComputeNearestPoint(p0, q0, p1, q1);
 
@@ -344,27 +344,27 @@ TYPED_TEST(SegmentSegmentNearestPtTest, NominalSegments) {
   const S eps = constants<S>::eps_78();
 
   // An arbitrary direction for segment A.
-  const Vector3<S> dir_A = Vector3<S>{1, 2, 3}.normalized();
+  const Vector3<S> dir_A = Vector3<S>{S(1), S(2), S(3)}.normalized();
   // An arbitrary direction for segment B such that it is neither parallel nor
   // perpendicular to dir_A. We're excluding perpendicular as that represents
   // the _best_ conditioning for the math and we want to characterize the
   // accuracy when the numbers _aren't_ that great.
-  const Vector3<S> dir_B = Vector3<S>{-2, 1, -0.5}.normalized();
+  const Vector3<S> dir_B = Vector3<S>{S(-2), S(1), S(-0.5)}.normalized();
   using std::abs;
   GTEST_ASSERT_GE(abs(dir_A.dot(dir_B)), eps);
-  GTEST_ASSERT_LT(abs(dir_A.dot(dir_B)), 1 - eps);
+  GTEST_ASSERT_LT(abs(dir_A.dot(dir_B)), S(1) - eps);
 
   // A direction perpendicular to both A and B.
   const Vector3<S> perp = dir_A.cross(dir_B).normalized();
 
   // Configure the two segments so that they perfectly intersect at expected_n0.
-  const Vector3<S> expected_n0 = Vector3<S>{-0.5, 1.25, 0.75};
+  const Vector3<S> expected_n0 = Vector3<S>{S(-0.5), S(1.25), S(0.75)};
   const Vector3<S> p0 = expected_n0 + dir_A;
-  const Vector3<S> q0 = expected_n0 - 2 * dir_A;
+  const Vector3<S> q0 = expected_n0 - S(2) * dir_A;
   const Vector3<S> p1 = expected_n0 + dir_B;
-  const Vector3<S> q1 = expected_n0 - 2.5 * dir_B;
-  const S expected_s = 1 / 3.0;
-  const S t_expected = 1 / 3.5;
+  const Vector3<S> q1 = expected_n0 - S(2.5) * dir_B;
+  const S expected_s = 1 / S(3);
+  const S t_expected = 1 / S(3.5);
 
   // Case: literally intersecting (intersection point is *not* at the origin).
   {
@@ -381,7 +381,7 @@ TYPED_TEST(SegmentSegmentNearestPtTest, NominalSegments) {
   // intersecting lines in a direction perpendicular to segment A; n0 will still
   // be the same. And s and t will be unchanged.
   {
-    const S expected_dist = 1.25;
+    const S expected_dist{1.25};
     const Vector3<S> offset = expected_dist * perp;
     const S squared_dist =
         this->ComputeNearestPoint(p0, q0, p1 + offset, q1 + offset);
@@ -407,7 +407,7 @@ TYPED_TEST(SegmentSegmentNearestPtTest, NominalSegments) {
   // because they aren't perpendicular, the point on B that is nearest (and the
   // value of t), will depend on the distance.
   {
-    const Vector3<S> offset = 1.1 * (p0 - expected_n0);
+    const Vector3<S> offset = S(1.1) * (p0 - expected_n0);
     const Vector3<S> p1_shift = p1 + offset;
     const Vector3<S> q1_shift = q1 + offset;
     Vector3<S> expected_N1;
@@ -439,7 +439,7 @@ TYPED_TEST(SegmentSegmentNearestPtTest, NominalSegments) {
 
   // Case: q0 nearest to center of B. Now slide B the other direction.
   {
-    const Vector3<S> offset = 1.1 * (q0 - expected_n0);
+    const Vector3<S> offset = S(1.1) * (q0 - expected_n0);
     const Vector3<S> p1_shift = p1 + offset;
     const Vector3<S> q1_shift = q1 + offset;
     Vector3<S> expected_N1;
@@ -477,14 +477,15 @@ TYPED_TEST(SegmentSegmentNearestPtTest, NominalSegments) {
     // direction along segment A towards p0, but _not_ be parallel (which
     // prevents co-linearity).
     const Vector3<S> p0_dir = p0 - expected_n0;
-    const Vector3<S> offset = p0_dir.cwiseProduct(Vector3<S>{1.75, 1.5, 1.25});
+    const Vector3<S> offset =
+        p0_dir.cwiseProduct(Vector3<S>{S(1.75), S(1.5), S(1.25)});
     const Vector3<S> p1_shift = p0 + offset;
     // q1 needs to be positioned such that it's always farther from segment A
     // than p1. We know the direction from segment A to p1 (offset). If
     // offset⋅dir_B is positive, then we extend in the dir_B direction,
     // otherwise the -dir_B direction.
     const Vector3<S> q1_shift =
-        p1_shift + (offset.dot(dir_B) > 0 ? dir_B : Vector3<S>{-dir_B});
+        p1_shift + (offset.dot(dir_B) > S(0) ? dir_B : Vector3<S>{-dir_B});
 
     // p0 is nearest p1.
     S squared_dist = this->ComputeNearestPoint(p0, q0, p1_shift, q1_shift);
@@ -533,7 +534,8 @@ TYPED_TEST(SegmentSegmentNearestPtTest, NominalSegments) {
 template <typename S>
 class CapsuleCapsuleSegmentTest : public ::testing::Test {
  public:
-  CapsuleCapsuleSegmentTest() : ::testing::Test(), c1_(1.5, 2.5), c2_(2, 3) {}
+  CapsuleCapsuleSegmentTest()
+      : ::testing::Test(), c1_(S(1.5), S(2.5)), c2_(S(2), S(3)) {}
 
  protected:
   // See the note below for the explanation of these four cases.
@@ -637,10 +639,10 @@ class CapsuleCapsuleSegmentTest : public ::testing::Test {
 
     Transform3<S> X_TC1 = Transform3<S>::Identity();
     Transform3<S> X_TC2(AngleAxis<S>(pi / 2, Vector3<S>::UnitY()));
-    X_TC2.translation() << 0, 0,
+    X_TC2.translation() << S(0), S(0),
         c1_.lz / 2 + c1_.radius + c2_.radius + distance;
 
-    Vector3<S> p_TW1{0, 0, c1_.lz / 2 + c1_.radius};
+    Vector3<S> p_TW1{S(0), S(0), c1_.lz / S(2) + c1_.radius};
     expected_p_FW1_ = X_FT() * p_TW1;
     Vector3<S> p_TW2{p_TW1(0), p_TW1(1), p_TW1(2) + distance};
     expected_p_FW2_ = X_FT() * p_TW2;
@@ -654,9 +656,9 @@ class CapsuleCapsuleSegmentTest : public ::testing::Test {
 
     const auto pi = constants<S>::pi();
     Transform3<S> X_TC1 = Transform3<S>::Identity();
-    Transform3<S> X_TC2(AngleAxis<S>(pi / 2, Vector3<S>::UnitY()));
+    Transform3<S> X_TC2(AngleAxis<S>(pi / S(2), Vector3<S>::UnitY()));
     // Position C2 halfway up the upper length of C1.
-    X_TC2.translation() << 0, 0, c1_.lz / 4;
+    X_TC2.translation() << S(0), S(0), c1_.lz / S(4);
 
     // The witness points lie on a line parallel with the Ty direction that
     // passes through the point p_TC2. For each capsule there are *two* points
@@ -665,9 +667,9 @@ class CapsuleCapsuleSegmentTest : public ::testing::Test {
     // to select *one* of those two. This allows the final test to simply
     // compare witness points directly. A change in this special case in the
     // function under test will cause this configuration to fail.
-    Vector3<S> p_TW1{0, c1_.radius, c1_.lz / 4};
+    Vector3<S> p_TW1{S(0), c1_.radius, c1_.lz / S(4)};
     expected_p_FW1_ = X_FT() * p_TW1;
-    Vector3<S> p_TW2{0, -c2_.radius, c1_.lz / 4};
+    Vector3<S> p_TW2{S(0), -c2_.radius, c1_.lz / S(4)};
     expected_p_FW2_ = X_FT() * p_TW2;
 
     X_FC1_ = X_FT() * X_TC1;
@@ -681,7 +683,7 @@ class CapsuleCapsuleSegmentTest : public ::testing::Test {
     Transform3<S> X_TC2 = Transform3<S>::Identity();
     // Position C2 so that the lower end of its center lines is at the origin
     // and overlaps with the upper end of C1's center line.
-    X_TC2.translation() << 0, 0, c2_.lz / 2;
+    X_TC2.translation() << S(0), S(0), c2_.lz / S(2);
 
     // When the two center lines are aligned and overlap, there is an infinite
     // set of witness points. We exploit the knowledge of how the function under
@@ -689,9 +691,9 @@ class CapsuleCapsuleSegmentTest : public ::testing::Test {
     // pick points that line up with the Tx axis. The biggest unknown is where
     // in the range [0, L1/2] along Tz the witness point is placed. Empirically,
     // it is shown to be at p0 (the top of C1's center line).
-    Vector3<S> p_TW1{c1_.radius, 0, c1_.lz / 2};
+    Vector3<S> p_TW1{c1_.radius, S(0), c1_.lz / S(2)};
     expected_p_FW1_ = X_FT() * p_TW1;
-    Vector3<S> p_TW2{-c2_.radius, 0, c1_.lz / 2};
+    Vector3<S> p_TW2{-c2_.radius, S(0), c1_.lz / S(2)};
     expected_p_FW2_ = X_FT() * p_TW2;
 
     X_FC1_ = X_FT() * X_TC1;
@@ -702,10 +704,10 @@ class CapsuleCapsuleSegmentTest : public ::testing::Test {
     // Create some arbitrarily ugly transform; the important bit that there
     // be no identities (zeros and ones).
     Transform3<S> X_FT_ = Transform3<S>::Identity();
-    X_FT_.translation() << 10.5, 12.75, -2.5;
-    X_FT_.linear() =
-        AngleAxis<S>(constants<S>::pi() / 7, Vector3<S>{1, 2, 3}.normalized())
-            .matrix();
+    X_FT_.translation() << S(10.5), S(12.75), S(-2.5);
+    X_FT_.linear() = AngleAxis<S>(constants<S>::pi() / S(7),
+                                  Vector3<S>{S(1), S(2), S(3)}.normalized())
+                         .matrix();
     return X_FT_;
   }
 


### PR DESCRIPTION
1. Correct definition of capsule definition - i.e. *centered* on the capsule origin.
2. Handle the case where the capsule center lines intersect.
3. Make more robust tests which exercise all (hopefully) the corners of the code.

fixes #225

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/436)
<!-- Reviewable:end -->
