### PR TITLE
Fix illegal preprocessor expression when Octree enabled

### DIFF
--- a/include/fcl/narrowphase/detail/traversal/octree/collision/mesh_octree_collision_traversal_node.h
+++ b/include/fcl/narrowphase/detail/traversal/octree/collision/mesh_octree_collision_traversal_node.h
@@ -39,7 +39,7 @@
 #define FCL_TRAVERSAL_OCTREE_MESHOCTREECOLLISIONTRAVERSALNODE_H
 
 #include "fcl/config.h"
-#if not(FCL_HAVE_OCTOMAP)
+#ifndef FCL_HAVE_OCTOMAP
 #error "This header requires fcl to be compiled with octomap support"
 #endif
 

--- a/include/fcl/narrowphase/detail/traversal/octree/collision/mesh_octree_collision_traversal_node.h
+++ b/include/fcl/narrowphase/detail/traversal/octree/collision/mesh_octree_collision_traversal_node.h
@@ -39,7 +39,7 @@
 #define FCL_TRAVERSAL_OCTREE_MESHOCTREECOLLISIONTRAVERSALNODE_H
 
 #include "fcl/config.h"
-#ifndef FCL_HAVE_OCTOMAP
+#if !FCL_HAVE_OCTOMAP
 #error "This header requires fcl to be compiled with octomap support"
 #endif
 

--- a/include/fcl/narrowphase/detail/traversal/octree/distance/mesh_octree_distance_traversal_node.h
+++ b/include/fcl/narrowphase/detail/traversal/octree/distance/mesh_octree_distance_traversal_node.h
@@ -39,7 +39,7 @@
 #define FCL_TRAVERSAL_OCTREE_MESHOCTREEDISTANCETRAVERSALNODE_H
 
 #include "fcl/config.h"
-#ifndef FCL_HAVE_OCTOMAP
+#if !FCL_HAVE_OCTOMAP
 #error "This header requires fcl to be compiled with octomap support"
 #endif
 

--- a/include/fcl/narrowphase/detail/traversal/octree/distance/mesh_octree_distance_traversal_node.h
+++ b/include/fcl/narrowphase/detail/traversal/octree/distance/mesh_octree_distance_traversal_node.h
@@ -39,7 +39,7 @@
 #define FCL_TRAVERSAL_OCTREE_MESHOCTREEDISTANCETRAVERSALNODE_H
 
 #include "fcl/config.h"
-#if not(FCL_HAVE_OCTOMAP)
+#ifndef FCL_HAVE_OCTOMAP
 #error "This header requires fcl to be compiled with octomap support"
 #endif
 


### PR DESCRIPTION
When building on Windows with Octree enabled I ran into compilation failures due to non-standard preprocessor expressions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/441)
<!-- Reviewable:end -->
