### PR TITLE
Resolve a new GJK/EPA real world error

### DIFF
--- a/test/test_fcl_signed_distance.cpp
+++ b/test/test_fcl_signed_distance.cpp
@@ -335,7 +335,8 @@ void test_distance_box_box_helper(const Vector3<S>& box1_size,
   // An expected distance has been provided; let's test that the value is as
   // expected.
   if (expected_distance) {
-    EXPECT_NEAR(result.min_distance, *expected_distance, 1e-10);
+    EXPECT_NEAR(result.min_distance, *expected_distance,
+                constants<S>::eps_12());
   }
 }
 


### PR DESCRIPTION
This PR has two commits -- the failing test in the first commit and the "fix" in the second commit. They will be squashed upon merging.

The solution to this particular failure was cleaning up one aspect of the conversion from simplex to polytope. Specifically, the conversion of a 3-simplex into a tetrahedron.

  - Comparisons were being done between *squared* distance and epsilon. These were changed to be squared distance and squared epsilon (this was sufficient to allow the regression test to pass).
  - Simultaneously, a TODO was resolved, removing redundant work when degenerate simplices are provided.

resolves #445

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/446)
<!-- Reviewable:end -->
