### PR TITLE
Update change log to merged PR that forgot to do it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## FCL 0
 
+### FCL 0.7.0 (????-??-??)
+
+* Narrowphase
+
+  * Various corrections and clarifications of the GJK algorithm used for general
+    convex distance:
+     [#446](https://github.com/flexible-collision-library/fcl/pull/446)
+
 ### FCL 0.6.0 (2020-02-10)
 
 * Core/Common


### PR DESCRIPTION
This adds the missing changelog edit for PR 446.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/447)
<!-- Reviewable:end -->
