### PR TITLE
Replace non-portable M_PI with constants::pi()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### FCL 0.7.0 (????-??-??)
 
+* Math
+
+  * Replace M_PI instance with constants::pi():
+     [#450](https://github.com/flexible-collision-library/fcl/pull/450)
+
 * Narrowphase
 
   * Various corrections and clarifications of the GJK algorithm used for general

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
@@ -257,7 +257,8 @@ GTEST_TEST(FCL_GJK_EPA, faceNormalPointingOutwardOriginNearFace1) {
   vertices[1] << 0, 1, face0_origin_distance;
   vertices[2] << -0.5, -0.5, face0_origin_distance;
   vertices[3] << 0, 0, -1;
-  Eigen::AngleAxis<ccd_real_t> rotation(0.05 * M_PI,
+  const double kPi = constants<double>::pi();
+  Eigen::AngleAxis<ccd_real_t> rotation(0.05 * kPi,
                                         Vector3<ccd_real_t>::UnitX());
   for (int i = 0; i < 4; ++i) {
     vertices[i] = rotation * vertices[i];


### PR DESCRIPTION
Apparently an M_PI snuck in after #264. This reversed it back out.

resolves #448

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/450)
<!-- Reviewable:end -->
