### PR TITLE
Make computeAABB virtual in CollisionObject

### DIFF
--- a/include/fcl/narrowphase/collision_object.h
+++ b/include/fcl/narrowphase/collision_object.h
@@ -72,7 +72,7 @@ public:
   const AABB<S>& getAABB() const;
 
   /// @brief compute the AABB in world space
-  void computeAABB();
+  virtual void computeAABB();
 
   /// @brief get user data in object
   void* getUserData() const;


### PR DESCRIPTION
By making this virtual it allows for the developer to create a modified CollisionObject wrapper which adds a margin to the collision objects AABB.