### PR TITLE
Fix rss and improve octree tests

### DIFF
--- a/include/fcl/geometry/bvh/detail/BV_splitter-inl.h
+++ b/include/fcl/geometry/bvh/detail/BV_splitter-inl.h
@@ -531,34 +531,6 @@ struct ComputeSplitVectorImpl<S, kIOS<S>>
 {
   static void run(const kIOS<S>& bv, Vector3<S>& split_vector)
   {
-    /*
-      switch(bv.num_spheres)
-      {
-      case 1:
-      split_vector = Vector3<S>(1, 0, 0);
-      break;
-      case 3:
-      {
-      Vector3<S> v[3];
-      v[0] = bv.spheres[1].o - bv.spheres[0].o;
-      v[0].normalize();
-      generateCoordinateSystem(v[0], v[1], v[2]);
-      split_vector = v[1];
-      }
-      break;
-      case 5:
-      {
-      Vector3<S> v[2];
-      v[0] = bv.spheres[1].o - bv.spheres[0].o;
-      v[1] = bv.spheres[3].o - bv.spheres[0].o;
-      split_vector = v[0].cross(v[1]);
-      split_vector.normalize();
-      }
-      break;
-      default:
-      ;
-      }
-    */
     split_vector = bv.obb.axis.col(0);
   }
 };

--- a/include/fcl/geometry/octree/octree-inl.h
+++ b/include/fcl/geometry/octree/octree-inl.h
@@ -65,8 +65,8 @@ OcTree<S>::OcTree(S resolution)
   default_occupancy = tree->getOccupancyThres();
 
   // default occupancy/free threshold is consistent with default setting from octomap
-  occupancy_threshold = tree->getOccupancyThres();
-  free_threshold = 0;
+  occupancy_threshold_log_odds = tree->getOccupancyThresLog();
+  free_threshold_log_odds = 0.0;
 }
 
 //==============================================================================
@@ -77,8 +77,8 @@ OcTree<S>::OcTree(const std::shared_ptr<const octomap::OcTree>& tree_)
   default_occupancy = tree->getOccupancyThres();
 
   // default occupancy/free threshold is consistent with default setting from octomap
-  occupancy_threshold = tree->getOccupancyThres();
-  free_threshold = 0;
+  occupancy_threshold_log_odds = tree->getOccupancyThresLog();
+  free_threshold_log_odds = 0;
 }
 
 //==============================================================================
@@ -112,7 +112,7 @@ template <typename S>
 bool OcTree<S>::isNodeOccupied(const typename OcTree<S>::OcTreeNode* node) const
 {
   // return tree->isNodeOccupied(node);
-  return node->getOccupancy() >= occupancy_threshold;
+  return node->getLogOdds() >= occupancy_threshold_log_odds;
 }
 
 //==============================================================================
@@ -120,7 +120,7 @@ template <typename S>
 bool OcTree<S>::isNodeFree(const typename OcTree<S>::OcTreeNode* node) const
 {
   // return false; // default no definitely free node
-  return node->getOccupancy() <= free_threshold;
+  return node->getLogOdds() <= free_threshold_log_odds;
 }
 
 //==============================================================================
@@ -134,14 +134,14 @@ bool OcTree<S>::isNodeUncertain(const typename OcTree<S>::OcTreeNode* node) cons
 template <typename S>
 S OcTree<S>::getOccupancyThres() const
 {
-  return occupancy_threshold;
+  return octomap::probability(occupancy_threshold_log_odds);
 }
 
 //==============================================================================
 template <typename S>
 S OcTree<S>::getFreeThres() const
 {
-  return free_threshold;
+  return octomap::probability(free_threshold_log_odds);
 }
 
 //==============================================================================
@@ -162,14 +162,14 @@ void OcTree<S>::setCellDefaultOccupancy(S d)
 template <typename S>
 void OcTree<S>::setOccupancyThres(S d)
 {
-  occupancy_threshold = d;
+  occupancy_threshold_log_odds = octomap::logodds(d);
 }
 
 //==============================================================================
 template <typename S>
 void OcTree<S>::setFreeThres(S d)
 {
-  free_threshold = d;
+  free_threshold_log_odds = octomap::logodds(d);
 }
 
 //==============================================================================

--- a/include/fcl/geometry/octree/octree.h
+++ b/include/fcl/geometry/octree/octree.h
@@ -68,8 +68,8 @@ private:
 
   S default_occupancy;
 
-  S occupancy_threshold;
-  S free_threshold;
+  S occupancy_threshold_log_odds;
+  S free_threshold_log_odds;
 
 public:
 

--- a/include/fcl/geometry/shape/utility-inl.h
+++ b/include/fcl/geometry/shape/utility-inl.h
@@ -658,9 +658,8 @@ struct FCL_EXPORT ComputeBVImpl<S, OBB<S>, Plane<S>>
 {
   static void run(const Plane<S>& s, const Transform3<S>& tf, OBB<S>& bv)
   {
-    Vector3<S> n = tf.linear() * s.n;
-    bv.axis.col(0) = n;
-    generateCoordinateSystem(bv.axis);
+    const Vector3<S> n = tf.linear() * s.n;
+    bv.axis = generateCoordinateSystem(n);
 
     bv.extent << 0, std::numeric_limits<S>::max(), std::numeric_limits<S>::max();
 
@@ -675,10 +674,8 @@ struct FCL_EXPORT ComputeBVImpl<S, RSS<S>, Plane<S>>
 {
   static void run(const Plane<S>& s, const Transform3<S>& tf, RSS<S>& bv)
   {
-    Vector3<S> n = tf.linear() * s.n;
-
-    bv.axis.col(0) = n;
-    generateCoordinateSystem(bv.axis);
+    const Vector3<S> n = tf.linear() * s.n;
+    bv.axis = generateCoordinateSystem(n);
 
     bv.l[0] = std::numeric_limits<S>::max();
     bv.l[1] = std::numeric_limits<S>::max();

--- a/include/fcl/math/bv/RSS-inl.h
+++ b/include/fcl/math/bv/RSS-inl.h
@@ -415,7 +415,17 @@ S RSS<S>::size() const
 template <typename S>
 const Vector3<S> RSS<S>::center() const
 {
-  return To;
+  Vector3<S> p_ToCenter_T;
+  p_ToCenter_T << l[0] * 0.5, l[1] * 0.5, 0.0;
+  return p_FoTo_F() + R_FT() * p_ToCenter_T;
+}
+
+template <typename S>
+void RSS<S>::setToFromCenter(const Vector3<S>& p_FoCenter_F)
+{
+  Vector3<S> p_ToCenter_T;
+  p_ToCenter_T << l[0] * 0.5, l[1] * 0.5, 0.0;
+  p_FoTo_F() = p_FoCenter_F - R_FT() * p_ToCenter_T;
 }
 
 //==============================================================================

--- a/include/fcl/math/bv/RSS.h
+++ b/include/fcl/math/bv/RSS.h
@@ -44,7 +44,16 @@
 namespace fcl
 {
 
-/// @brief A class for rectangle sphere-swept bounding volume
+/// @brief A class for rectangle swept sphere bounding volume.
+///
+/// RSS defines a rectangle swept sphere. The rectangle is defined in the frame
+/// T. It has one corner positioned at the origin of frame T. It lies on T's
+/// z = 0 plane. Its longest dimension extends in the +x direction, and its
+/// shorter dimension in the +y direction.
+///
+/// The RSS is then posed in another frame F. R_FT (the #axis field) is the
+/// relative orientation between frame T and F and p_FoTo_F (the #To field) is
+/// the position of T's origin in frame F.
 template <typename S_>
 class FCL_EXPORT RSS
 {
@@ -52,20 +61,24 @@ public:
 
   using S = S_;
 
-  /// @brief Orientation of RSS. The axes of the rotation matrix are the
-  /// principle directions of the box. We assume that the first column
-  /// corresponds to the axis with the longest box edge, second column
-  /// corresponds to the shorter one and the third coulumn corresponds to the
-  /// shortest one.
+  /// @brief Frame T's orientation in frame F.
+  ///
+  /// The axes of the rotation matrix are the principle directions of the
+  /// rectangle. The first column corresponds to a unit vector along the
+  /// longest edge and the second column the shortest edge. The third column is
+  /// the rectangle's unit normal vector.
   Matrix3<S> axis;
 
-  /// @brief Origin of the rectangle in RSS
+  /// @brief Origin of frame T in frame F.
+  ///
+  /// Note this is the translation in frame F to the origin of frame T.
+  /// The rectangle's minimum corner in frame T is at the origin of frame T.
   Vector3<S> To;
 
-  /// @brief Side lengths of rectangle
+  /// @brief Side lengths of rectangle in frame T.
   S l[2];
 
-  /// @brief Radius of sphere summed with rectangle to form RSS
+  /// @brief Radius of sphere summed with rectangle to form RSS.
   S r;
 
   /// Constructor
@@ -106,8 +119,13 @@ public:
   /// @brief Size of the RSS (used in BV_Splitter to order two RSSs)
   S size() const;
 
-  /// @brief The RSS center
+  /// @brief The RSS center C, measured and expressed in frame F: p_FoC_F.
   const Vector3<S> center() const;
+
+  /// @brief Set #To of the RSS from the center coordinates in frame F.
+  ///
+  /// Note: only works correctly if #axis and #l[] are set.
+  void setToFromCenter(const Vector3<S>& p_FoCenter_F);
 
   /// @brief the distance between two RSS; P and Q, if not nullptr, return the nearest points
   S distance(const RSS<S>& other,
@@ -116,6 +134,18 @@ public:
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
+private:
+  // Internal monogram notation alias of axis.
+  Matrix3<S>& R_FT() { return axis; }
+
+  // Internal monogram notation const alias of axis.
+  const Matrix3<S>& R_FT() const { return axis; }
+
+  // Internal monogram notation alias of To.
+  Vector3<S>& p_FoTo_F() { return To; }
+
+  // Internal monogram notation alias of To.
+  const Vector3<S>& p_FoTo_F() const { return To; }
 };
 
 using RSSf = RSS<float>;

--- a/include/fcl/math/bv/utility-inl.h
+++ b/include/fcl/math/bv/utility-inl.h
@@ -77,12 +77,10 @@ void fit2(const Vector3<S>* const ps, OBB<S>& bv)
 {
   const Vector3<S>& p1 = ps[0];
   const Vector3<S>& p2 = ps[1];
-  Vector3<S> p1p2 = p1 - p2;
-  S len_p1p2 = p1p2.norm();
-  p1p2.normalize();
+  const Vector3<S> p1p2 = p1 - p2;
+  const S len_p1p2 = p1p2.norm();
 
-  bv.axis.col(0) = p1p2;
-  generateCoordinateSystem(bv.axis);
+  bv.axis = generateCoordinateSystem(p1p2);
 
   bv.extent << len_p1p2 * 0.5, 0, 0;
   bv.To.noalias() = 0.5 * (p1 + p2);
@@ -193,12 +191,10 @@ void fit2(const Vector3<S>* const ps, RSS<S>& bv)
 {
   const Vector3<S>& p1 = ps[0];
   const Vector3<S>& p2 = ps[1];
-  Vector3<S> p1p2 = p1 - p2;
-  S len_p1p2 = p1p2.norm();
-  p1p2.normalize();
+  const Vector3<S> p1p2 = p1 - p2;
+  const S len_p1p2 = p1p2.norm();
 
-  bv.axis.col(0) = p1p2;
-  generateCoordinateSystem(bv.axis);
+  bv.axis = generateCoordinateSystem(p1p2);
   bv.l[0] = len_p1p2;
   bv.l[1] = 0;
 
@@ -318,12 +314,10 @@ void fit2(const Vector3<S>* const ps, kIOS<S>& bv)
 
   const Vector3<S>& p1 = ps[0];
   const Vector3<S>& p2 = ps[1];
-  Vector3<S> p1p2 = p1 - p2;
-  S len_p1p2 = p1p2.norm();
-  p1p2.normalize();
+  const Vector3<S> p1p2 = p1 - p2;
+  const S len_p1p2 = p1p2.norm();
 
-  bv.obb.axis.col(0) = p1p2;
-  generateCoordinateSystem(bv.obb.axis);
+  bv.obb.axis = generateCoordinateSystem(p1p2);
 
   S r0 = len_p1p2 * 0.5;
   bv.obb.extent << r0, 0, 0;

--- a/include/fcl/math/bv/utility-inl.h
+++ b/include/fcl/math/bv/utility-inl.h
@@ -791,7 +791,7 @@ public:
   static void run(const RSS<S>& bv1, const Transform3<S>& tf1, OBB<S>& bv2)
   {
     bv2.extent << bv1.l[0] * 0.5 + bv1.r, bv1.l[1] * 0.5 + bv1.r, bv1.r;
-    bv2.To.noalias() = tf1 * bv1.To;
+    bv2.To.noalias() = tf1 * bv1.center();
     bv2.axis.noalias() = tf1.linear() * bv1.axis;
   }
 };
@@ -832,12 +832,23 @@ class FCL_EXPORT ConvertBVImpl<S, OBB<S>, RSS<S>>
 public:
   static void run(const OBB<S>& bv1, const Transform3<S>& tf1, RSS<S>& bv2)
   {
-    bv2.To.noalias() = tf1 * bv1.To;
+    // OBB's rotation matrix in axis is required to be lined up with the
+    // x-axis along the longest edge, the y-axis on the next longest edge
+    // and the z-axis on the shortest edge. RSS requires the longest edge
+    // of the rectangle to be the x-axis and the next longest the y-axis.
+    // This maps perfectly from OBB to RSS so simply transform the rotation
+    // axis of the OBB into the RSS.
     bv2.axis.noalias() = tf1.linear() * bv1.axis;
 
+    // Set longest rectangle side for RSS to longest dimension of OBB.
+    bv2.l[0] = 2 * (bv1.extent[0]);
+    // Set shortest rectangle side for RSS to next-longest dimension of OBB.
+    bv2.l[1] = 2 * (bv1.extent[1]);
+    // Set radius for RSS to the smallest dimension of OBB.
     bv2.r = bv1.extent[2];
-    bv2.l[0] = 2 * (bv1.extent[0] - bv2.r);
-    bv2.l[1] = 2 * (bv1.extent[1] - bv2.r);
+
+    // OBB's To is at its center while RSS's To is at a corner.
+    bv2.setToFromCenter(tf1 * bv1.center());
   }
 };
 
@@ -875,8 +886,6 @@ class FCL_EXPORT ConvertBVImpl<S, AABB<S>, RSS<S>>
 public:
   static void run(const AABB<S>& bv1, const Transform3<S>& tf1, RSS<S>& bv2)
   {
-    bv2.To.noalias() = tf1 * bv1.center();
-
     /// Sort the AABB edges so that AABB extents are ordered.
     S d[3] = {bv1.width(), bv1.height(), bv1.depth() };
     std::size_t id[3] = {0, 1, 2};
@@ -903,8 +912,8 @@ public:
 
     Vector3<S> extent = (bv1.max_ - bv1.min_) * 0.5;
     bv2.r = extent[id[2]];
-    bv2.l[0] = (extent[id[0]] - bv2.r) * 2;
-    bv2.l[1] = (extent[id[1]] - bv2.r) * 2;
+    bv2.l[0] = (extent[id[0]]) * 2;
+    bv2.l[1] = (extent[id[1]]) * 2;
 
     const Matrix3<S>& R = tf1.linear();
     bool left_hand = (id[0] == (id[1] + 1) % 3);
@@ -914,6 +923,7 @@ public:
       bv2.axis.col(0) = R.col(id[0]);
     bv2.axis.col(1) = R.col(id[1]);
     bv2.axis.col(2) = R.col(id[2]);
+    bv2.setToFromCenter(tf1 * bv1.center());
   }
 };
 

--- a/include/fcl/math/geometry.h
+++ b/include/fcl/math/geometry.h
@@ -58,13 +58,6 @@ typename Derived::RealScalar triple(const Eigen::MatrixBase<Derived>& x,
                                     const Eigen::MatrixBase<Derived>& y,
                                     const Eigen::MatrixBase<Derived>& z);
 
-template <typename Derived>
-FCL_EXPORT
-void generateCoordinateSystem(
-    const Eigen::MatrixBase<Derived>& w,
-    Eigen::MatrixBase<Derived>& u,
-    Eigen::MatrixBase<Derived>& v);
-
 template <typename S, int M, int N>
 FCL_EXPORT
 VectorN<S, M+N> combine(
@@ -98,13 +91,19 @@ void axisFromEigen(const Matrix3<S>& eigenV,
                    const Vector3<S>& eigenS,
                    Transform3<S>& tf);
 
+/// @brief compute orthogonal coordinate system basis with given x-axis.
+///
+/// @param  x_axis Direction of x-axis. Must have non-zero length.
+///                For best results, length should be much greater than
+///                constants<S>::eps_12().
+/// @return The coordinate system in a Matrix3<S>.
+///         Column 0 will be the normalized x-axis.
+///         Columns 1 and 2 will be created orthogonal to the x-axis, and
+///         orthogonal to each other. Otherwise, the orientation of the y-axis
+///         and z-axis to the x-axis is arbitrary.
 template <typename S>
 FCL_EXPORT
-void generateCoordinateSystem(Matrix3<S>& axis);
-
-template <typename S>
-FCL_EXPORT
-void generateCoordinateSystem(Transform3<S>& tf);
+Matrix3<S> generateCoordinateSystem(const Vector3<S>& x_axis);
 
 template <typename DerivedA, typename DerivedB, typename DerivedC, typename DerivedD>
 FCL_EXPORT

--- a/src/math/geometry.cpp
+++ b/src/math/geometry.cpp
@@ -68,11 +68,7 @@ void axisFromEigen(const Matrix3d& eigenV,
 
 //==============================================================================
 template
-void generateCoordinateSystem(Matrix3d& axis);
-
-//==============================================================================
-template
-void generateCoordinateSystem(Transform3d& tf);
+Matrix3d generateCoordinateSystem(const Vector3d& x_axis);
 
 //==============================================================================
 template

--- a/test/test_fcl_math.cpp
+++ b/test/test_fcl_math.cpp
@@ -39,6 +39,9 @@
 #include "fcl/broadphase/detail/morton.h"
 #include "fcl/config.h"
 #include "fcl/math/bv/AABB.h"
+#include "fcl/math/bv/RSS.h"
+#include "fcl/math/bv/utility.h"
+#include "fcl/math/constants.h"
 
 using namespace fcl;
 
@@ -128,6 +131,205 @@ GTEST_TEST(FCL_MATH, morton)
 //  test_morton<float>();
   test_morton<double>();
 }
+
+// Test fitting an RSS to various number of points
+template <typename S>
+void test_rss_fit()
+{
+  const S epsilon = constants<S>::eps_78();
+  RSS<S> rss;
+  Vector3<S> pn[8];
+  pn[0] << 0, 0, 0;
+  pn[1] << 1, 0, 0;
+  // Check fitting 1 point
+  fit(pn, 1, rss);
+  EXPECT_EQ(rss.center(), pn[0]);
+  EXPECT_EQ(rss.width(), 0.0);
+  EXPECT_EQ(rss.height(), 0.0);
+  EXPECT_EQ(rss.depth(), 0.0);
+  EXPECT_TRUE(rss.axis.isApprox(Matrix3<S>::Identity()));
+  // Check fitting 2 points for each axis
+  fit(pn, 2, rss);
+  EXPECT_TRUE(rss.center().isApprox(Vector3<S>(0.5, 0, 0)));
+  EXPECT_EQ(rss.width(), 1.0);
+  EXPECT_EQ(rss.height(), 0.0);
+  EXPECT_EQ(rss.depth(), 0.0);
+  EXPECT_TRUE(rss.axis.col(0).isApprox(Vector3<S>(1, 0, 0)) ||
+              rss.axis.col(0).isApprox(Vector3<S>(-1, 0, 0)));
+  pn[1] << 0, 1, 0;
+  fit(pn, 2, rss);
+  EXPECT_TRUE(rss.center().isApprox(Vector3<S>(0, 0.5, 0)));
+  EXPECT_EQ(rss.width(), 1.0);
+  EXPECT_EQ(rss.height(), 0.0);
+  EXPECT_EQ(rss.depth(), 0.0);
+  EXPECT_TRUE(rss.axis.col(0).isApprox(Vector3<S>(0, 1, 0)) ||
+              rss.axis.col(0).isApprox(Vector3<S>(0, -1, 0)));
+  pn[1] << 0, 0, 1;
+  fit(pn, 2, rss);
+  EXPECT_TRUE(rss.center().isApprox(Vector3<S>(0, 0, 0.5)));
+  EXPECT_EQ(rss.width(), 1.0);
+  EXPECT_EQ(rss.height(), 0.0);
+  EXPECT_EQ(rss.depth(), 0.0);
+  EXPECT_TRUE(rss.axis.col(0).isApprox(Vector3<S>(0, 0, 1)) ||
+              rss.axis.col(0).isApprox(Vector3<S>(0, 0, -1)));
+  // Check fitting 2 in opposite order
+  pn[0] << 0, 0, 1;
+  pn[1] << 0, 0, 0;
+  fit(pn, 2, rss);
+  EXPECT_TRUE(rss.center().isApprox(Vector3<S>(0, 0, 0.5)));
+  EXPECT_EQ(rss.width(), 1.0);
+  EXPECT_EQ(rss.height(), 0.0);
+  EXPECT_EQ(rss.depth(), 0.0);
+  EXPECT_TRUE(rss.axis.col(0).isApprox(Vector3<S>(0, 0, 1)) ||
+              rss.axis.col(0).isApprox(Vector3<S>(0, 0, -1)));
+  // Check fitting 2 not along an axis
+  pn[0] << -1, 1, 0;
+  pn[1] << 0, 0, 0;
+  fit(pn, 2, rss);
+  EXPECT_TRUE(rss.center().isApprox(Vector3<S>(-0.5, 0.5, 0)));
+  EXPECT_NEAR(rss.width(), sqrt(2.0), epsilon);
+  EXPECT_EQ(rss.height(), 0.0);
+  EXPECT_EQ(rss.depth(), 0.0);
+  EXPECT_TRUE(
+      rss.axis.col(0).isApprox(Vector3<S>(-sqrt(2.0)/2.0, sqrt(2.0)/2.0, 0)) ||
+      rss.axis.col(0).isApprox(Vector3<S>(sqrt(2.0)/2.0, -sqrt(2.0)/2.0, 0)));
+  // Check fitting 3
+  pn[0] << 0, 0, 0;
+  pn[1] << 1, 0, 0;
+  pn[2] << 0, 1, 0;
+  fit(pn, 3, rss);
+  Vector3<S> c3(0.25, 0.25, 0);
+  EXPECT_TRUE(c3.isApprox(rss.center()));
+  EXPECT_NEAR(rss.width(), sqrt(2.0), epsilon);
+  EXPECT_NEAR(rss.height(), sqrt(2.0) / 2.0, epsilon);
+  EXPECT_EQ(rss.depth(), 0.0);
+  // Check fitting 8
+  pn[3] << 0, 0, 1;
+  pn[4] << 1, 0, 0;
+  pn[5] << 1, 0, 1;
+  pn[6] << 1, 1, 0;
+  pn[7] << 1, 1, 1;
+  fit(pn, 8, rss);
+  EXPECT_GE(rss.depth(), 0.5);
+}
+
+// Test convert RSS to other bounding volumes
+template <typename S>
+void test_rss_conversion()
+{
+  const S epsilon = constants<S>::eps_78();
+  RSS<S> rss;
+  Vector3<S> pn[8];
+  AABB<S> aabb;
+  OBB<S> obb;
+
+  pn[0] << 0, 0, 0;
+  pn[1] << 1, 0, 0;
+  pn[2] << 0, 1, 0;
+  pn[3] << 0, 0, 1;
+  pn[4] << 1, 0, 0;
+  pn[5] << 1, 0, 1;
+  pn[6] << 1, 1, 0;
+  pn[7] << 1, 1, 1;
+  fit(pn, 8, rss);
+
+  convertBV(rss, Transform3<S>::Identity(), aabb);
+  EXPECT_GE(aabb.width(), rss.width());
+  EXPECT_GE(aabb.height(), rss.height());
+  EXPECT_GE(aabb.depth(), rss.depth());
+  EXPECT_TRUE(aabb.center().isApprox(rss.center()));
+  convertBV(aabb, Transform3<S>::Identity(), rss);
+  // The resulting RSS must be bigger than the AABB for it to contain it
+  EXPECT_GE(rss.width() - rss.depth() + epsilon, aabb.width());
+  EXPECT_GE(rss.height() - rss.depth() + epsilon, aabb.height());
+  EXPECT_GE(rss.depth(), aabb.depth());
+  EXPECT_TRUE(aabb.center().isApprox(rss.center()));
+  convertBV(rss, Transform3<S>::Identity(), obb);
+  EXPECT_GE(obb.width(), rss.width());
+  EXPECT_GE(obb.height(), rss.height());
+  EXPECT_GE(obb.depth(), rss.depth());
+  EXPECT_TRUE(obb.center().isApprox(rss.center()));
+}
+
+// Test RSS to RSS distance function
+template <typename S>
+void test_rss_distance()
+{
+  const S epsilon = constants<S>::eps_78();
+  Vector3<S> p0[3];
+  Vector3<S> p1[3];
+  RSS<S> rss;
+  RSS<S> rss2;
+  // Test RSS to RSS distance for correctness
+  p0[0] << 1, 1, 1;
+  p0[1] << 1, 1, -1;
+  p0[2] << 0, 1, -1;
+  p1[0] << 1, -1, 1;
+  p1[1] << 1, -1, -1;
+  p1[2] << 0, -1, -1;
+  fit(p0, 3, rss);
+  fit(p1, 3, rss2);
+  EXPECT_NEAR(rss.distance(rss2), 2.0, epsilon);
+  rss.To << 0, 0, 0.5;
+  rss.axis = Matrix3<S>::Identity();
+  rss.l[0] = 1;
+  rss.l[1] = 1;
+  rss.r = 0.5;
+  rss2.To << -1, -1, 2.5;
+  rss2.axis = Matrix3<S>::Identity();
+  rss2.l[0] = 1;
+  rss2.l[1] = 1;
+  rss2.r = 0.5;
+  EXPECT_NEAR(rss.distance(rss2), 1.0, epsilon);
+  rss2.axis << -1, 0, 0,
+                0, -1, 0,
+                0, 0, -1;
+  EXPECT_NEAR(rss.distance(rss2), sqrt(6) - 1.0, epsilon);
+  rss2.To << 0, 0, 2.5;
+  EXPECT_NEAR(rss.distance(rss2), 1.0, epsilon);
+}
+
+// Test setting RSS position
+template <typename S>
+void test_rss_position()
+{
+  // Verify setting To via the center works correctly.
+  RSS<S> rss;
+  rss.l[0] = 1;
+  rss.l[1] = 1;
+  rss.r = 0.5;
+  rss.axis = Matrix3<S>::Identity();
+  rss.setToFromCenter(Vector3<S>(0.5, 0.5, 0.5));
+  EXPECT_TRUE(rss.To.isApprox(Vector3<S>(0.0, 0.0, 0.5)));
+  rss.axis *= -1.0;
+  rss.setToFromCenter(Vector3<S>(-0.5, -0.5, 2.5));
+  EXPECT_TRUE(rss.To.isApprox(Vector3<S>(0.0, 0.0, 2.5)));
+}
+
+GTEST_TEST(FCL_MATH, rss_fit)
+{
+  test_rss_fit<double>();
+}
+
+GTEST_TEST(FCL_MATH, rss_conversion)
+{
+  test_rss_conversion<double>();
+}
+
+GTEST_TEST(FCL_MATH, rss_distance)
+{
+  test_rss_distance<double>();
+}
+
+GTEST_TEST(FCL_MATH, rss_position)
+{
+  test_rss_position<double>();
+}
+
+// TODO test overlap
+// TODO test contain
+// TODO test operator+
+// TODO test size
 
 //==============================================================================
 int main(int argc, char* argv[])

--- a/test/test_fcl_octomap_collision.cpp
+++ b/test/test_fcl_octomap_collision.cpp
@@ -183,8 +183,26 @@ void octomap_collision_test_BVH(std::size_t n, bool exhaustive, double resolutio
   m1->addSubModel(p1, t1);
   m1->endModel();
 
-  OcTree<S>* tree = new OcTree<S>(std::shared_ptr<const octomap::OcTree>(test::generateOcTree(resolution)));
+  auto octree = std::shared_ptr<const octomap::OcTree>(
+      test::generateOcTree(resolution));
+  OcTree<S>* tree = new OcTree<S>(octree);
   std::shared_ptr<CollisionGeometry<S>> tree_ptr(tree);
+
+  // Check and make sure that the generated tree contains both free and
+  // occupied space. There was a time when it was impossible to represent free
+  // space, this part of the collision tests that both free and occupied space
+  // are correctly represented.
+  size_t free_nodes = 0;
+  size_t occupied_nodes = 0;
+  for (auto it = octree->begin(), end = octree->end(); it != end; ++it)
+  {
+    if (tree->isNodeFree(&*it))
+      ++free_nodes;
+    if (tree->isNodeOccupied(&*it))
+      ++occupied_nodes;
+  }
+  EXPECT_GT(free_nodes, 0UL);
+  EXPECT_GT(occupied_nodes, 0UL);
 
   aligned_vector<Transform3<S>> transforms;
   S extents[] = {-10, -10, 10, 10, 10, 10};


### PR DESCRIPTION
There were several bugs in RSS handling that impacted octree distance checks.
There was also a bug in fcl::octree impacting when nodes were considered free/occupied.
Fix the bugs, and improve both RSS and octree distance check testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/467)
<!-- Reviewable:end -->
