### PR TITLE
Fixed issue with creating instances of type InterpMotion<float>

### DIFF
--- a/include/fcl/math/motion/interp_motion-inl.h
+++ b/include/fcl/math/motion/interp_motion-inl.h
@@ -45,6 +45,9 @@ namespace fcl
 
 //==============================================================================
 extern template
+class FCL_EXPORT InterpMotion<float>;
+
+extern template
 class FCL_EXPORT InterpMotion<double>;
 
 //==============================================================================
@@ -127,7 +130,7 @@ InterpMotion<S>::InterpMotion(
 
 //==============================================================================
 template <typename S>
-bool InterpMotion<S>::integrate(double dt) const
+bool InterpMotion<S>::integrate(S dt) const
 {
   if(dt > 1) dt = 1;
 

--- a/include/fcl/math/motion/interp_motion.h
+++ b/include/fcl/math/motion/interp_motion.h
@@ -76,7 +76,7 @@ public:
 
   /// @brief Integrate the motion from 0 to dt
   /// We compute the current transformation from zero point instead of from last integrate time, for precision.
-  bool integrate(double dt) const;
+  bool integrate(S dt) const;
 
   /// @brief Compute the motion bound for a bounding volume along a given direction n, which is defined in the visitor
   S computeMotionBound(const BVMotionBoundVisitor<S>& mb_visitor) const;


### PR DESCRIPTION
In InterpMotion class,  method integrate() is not properly declared and defined which does not allow instancing of that class with type other than double.
This is proposed fix for this issue.