### PR TITLE
CI: Move linux and mac configurations to more current platforms

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -38,9 +38,9 @@ before_build:
             cd ..\..
          ) else (echo Using cached libccd)
   - cmd: if not exist C:\"Program Files"\Eigen\include\eigen3\Eigen\Core (
-            curl -L -o eigen-eigen-dc6cfdf9bcec.tar.gz https://bitbucket.org/eigen/eigen/get/3.2.9.tar.gz &&
-            cmake -E tar zxf eigen-eigen-dc6cfdf9bcec.tar.gz &&
-            cd eigen-eigen-dc6cfdf9bcec &&
+            curl -LO https://gitlab.com/libeigen/eigen/-/archive/3.2.9/eigen-3.2.9.tar.gz &&
+            cmake -E tar zxf eigen-3.2.9.tar.gz &&
+            cd eigen-3.2.9 &&
             mkdir build &&
             cd build &&
             cmake -G "%CMAKE_GENERATOR_NAME%" -DCMAKE_BUILD_TYPE=%Configuration% .. &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: bionic
 cache:
   apt: true
 
@@ -20,11 +20,11 @@ matrix:
       compiler: clang
       env: BUILD_TYPE=Release COVERALLS=OFF
     - os: osx
-      osx_image: xcode9
+      osx_image: xcode11.3
       compiler: clang
       env: BUILD_TYPE=Debug COVERALLS=OFF
     - os: osx
-      osx_image: xcode9
+      osx_image: xcode11.3
       compiler: clang
       env: BUILD_TYPE=Release COVERALLS=OFF
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 ## FCL 0
 
+### FCL 0.7.0 (????-??-??)
+
+* Breaking changes
+
+  * Macros `FCL_SUPPRESS_MAYBE_UNINITIALIZED_BEGIN` and `FCL_SUPPRESS_MAYBE_UNINITIALIZED_END` defined in `fcl/common/warning.h` have been removed:
+    [#489](https://github.com/flexible-collision-library/fcl/pull/489)
+
+* Core/Common
+
+* Math
+
+* Geometry
+
+  * OcTree logic for determining free/occupied:
+    [#467](https://github.com/flexible-collision-library/fcl/pull/467)
+  * Bugs in RSS distance queries fixed:
+    [#467](https://github.com/flexible-collision-library/fcl/pull/467)
+
+* Broadphase
+
+* Narrowphase
+
+  * Primitive convex-half space collision algorithm introduced:
+    [#469](https://github.com/flexible-collision-library/fcl/pull/469)
+  * Contact and distance query results types changed to be compatible with OcTree:
+    [#472](https://github.com/flexible-collision-library/fcl/pull/472)
+  * Documentation for OcTree no longer mistakenly excluded from doxygen:
+    [#472](https://github.com/flexible-collision-library/fcl/pull/472)
+
+* Build/Test/Misc
+
+  * Fixed syntax which prevented building in Visual Studio 2015:
+    [#459](https://github.com/flexible-collision-library/fcl/pull/459)
+  * Fix compilation errors using default options on Emscripten:
+    [#470](https://github.com/flexible-collision-library/fcl/pull/470)
+  * Change supported linux build to Ubuntu 18.04 and Mac OS 10.14.6:
+    [#489](https://github.com/flexible-collision-library/fcl/pull/489)
+
 ### FCL 0.6.1 (2020-02-26)
 
 * Math

--- a/include/fcl/broadphase/detail/hierarchy_tree_array-inl.h
+++ b/include/fcl/broadphase/detail/hierarchy_tree_array-inl.h
@@ -161,10 +161,7 @@ void HierarchyTree<BV>::init_1(NodeType* leaves, int n_leaves_)
   for(size_t i = 0; i < n_leaves; ++i)
     ids[i] = i;
 
-  FCL_SUPPRESS_MAYBE_UNINITIALIZED_BEGIN
-  SortByMorton comp;
-  FCL_SUPPRESS_MAYBE_UNINITIALIZED_END
-  comp.nodes = nodes;
+  const SortByMorton comp{nodes};
   std::sort(ids, ids + n_leaves, comp);
   root_node = mortonRecurse_0(ids, ids + n_leaves, (1 << (coder.bits()-1)), coder.bits()-1);
   delete [] ids;
@@ -208,10 +205,7 @@ void HierarchyTree<BV>::init_2(NodeType* leaves, int n_leaves_)
   for(size_t i = 0; i < n_leaves; ++i)
     ids[i] = i;
 
-  FCL_SUPPRESS_MAYBE_UNINITIALIZED_BEGIN
-  SortByMorton comp;
-  FCL_SUPPRESS_MAYBE_UNINITIALIZED_END
-  comp.nodes = nodes;
+  const SortByMorton comp{nodes};
   std::sort(ids, ids + n_leaves, comp);
   root_node = mortonRecurse_1(ids, ids + n_leaves, (1 << (coder.bits()-1)), coder.bits()-1);
   delete [] ids;
@@ -255,10 +249,7 @@ void HierarchyTree<BV>::init_3(NodeType* leaves, int n_leaves_)
   for(size_t i = 0; i < n_leaves; ++i)
     ids[i] = i;
 
-  FCL_SUPPRESS_MAYBE_UNINITIALIZED_BEGIN
-  SortByMorton comp;
-  FCL_SUPPRESS_MAYBE_UNINITIALIZED_END
-  comp.nodes = nodes;
+  const SortByMorton comp{nodes};
   std::sort(ids, ids + n_leaves, comp);
   root_node = mortonRecurse_2(ids, ids + n_leaves);
   delete [] ids;
@@ -722,9 +713,7 @@ size_t HierarchyTree<BV>::mortonRecurse_0(size_t* lbeg, size_t* lend, const uint
   {
     if(bits > 0)
     {
-      SortByMorton comp;
-      comp.nodes = nodes;
-      comp.split = split;
+      const SortByMorton comp{nodes, split};
       size_t* lcenter = std::lower_bound(lbeg, lend, NULL_NODE, comp);
 
       if(lcenter == lbeg)
@@ -771,9 +760,7 @@ size_t HierarchyTree<BV>::mortonRecurse_1(size_t* lbeg, size_t* lend, const uint
   {
     if(bits > 0)
     {
-      SortByMorton comp;
-      comp.nodes = nodes;
-      comp.split = split;
+      const SortByMorton comp{nodes, split};
       size_t* lcenter = std::lower_bound(lbeg, lend, NULL_NODE, comp);
 
       if(lcenter == lbeg)

--- a/include/fcl/broadphase/detail/hierarchy_tree_array.h
+++ b/include/fcl/broadphase/detail/hierarchy_tree_array.h
@@ -65,6 +65,9 @@ class FCL_EXPORT HierarchyTree
   
   struct SortByMorton
   {
+    SortByMorton(NodeType* nodes_in) : nodes(nodes_in) {}
+    SortByMorton(NodeType* nodes_in, uint32 split_in)
+        : nodes(nodes_in), split(split_in) {}
     bool operator() (size_t a, size_t b) const
     {
       if((a != NULL_NODE) && (b != NULL_NODE))
@@ -77,8 +80,8 @@ class FCL_EXPORT HierarchyTree
       return false;
     }
 
-    NodeType* nodes;
-    uint32 split;
+    NodeType* nodes{};
+    uint32 split{};
   };
 
 public:

--- a/include/fcl/common/warning.h
+++ b/include/fcl/common/warning.h
@@ -68,13 +68,6 @@
   #define FCL_SUPPRESS_UNINITIALIZED_END \
     _Pragma("GCC diagnostic pop")
 
-  #define FCL_SUPPRESS_MAYBE_UNINITIALIZED_BEGIN                           \
-    _Pragma("GCC diagnostic push")                                   \
-    _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
-
-  #define FCL_SUPPRESS_MAYBE_UNINITIALIZED_END \
-    _Pragma("GCC diagnostic pop")
-
 #elif defined (FCL_COMPILER_CLANG)
 
   #define FCL_SUPPRESS_DEPRECATED_BEGIN                               \
@@ -91,10 +84,6 @@
   #define FCL_SUPPRESS_UNINITIALIZED_END \
     _Pragma("clang diagnostic pop")
 
-  #define FCL_SUPPRESS_MAYBE_UNINITIALIZED_BEGIN
-
-  #define FCL_SUPPRESS_MAYBE_UNINITIALIZED_END
-
 #elif defined (FCL_COMPILER_MSVC)
 
   #define FCL_SUPPRESS_DEPRECATED_BEGIN \
@@ -107,10 +96,6 @@
   #define FCL_SUPPRESS_UNINITIALIZED_BEGIN  // TODO
 
   #define FCL_SUPPRESS_UNINITIALIZED_END  // TODO
-
-  #define FCL_SUPPRESS_MAYBE_UNINITIALIZED_BEGIN  // TODO
-
-  #define FCL_SUPPRESS_MAYBE_UNINITIALIZED_END  // TODO
 
 #endif
 


### PR DESCRIPTION
Move CI to more modern platforms

1. Advance linux to bionic
2. Advance mac to the new default xcode 9.4.
3. Clean up:
  - HierarchyTree::SortByMorton had "maybe" uninitialized values. Cleaned up initialization and instantiation (using RAII).


resolves #490

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/489)
<!-- Reviewable:end -->
