### PR TITLE
Address EPA failure from issue 493

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
     [#472](https://github.com/flexible-collision-library/fcl/pull/472)
   * Documentation for OcTree no longer mistakenly excluded from doxygen:
     [#472](https://github.com/flexible-collision-library/fcl/pull/472)
+  * Another failure mode in the GJK/EPA signed distance query patched:
+    [#494](https://github.com/flexible-collision-library/fcl/pull/494)
 
 * Build/Test/Misc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 * Math
 
+  * constants::eps() is now constexpr:
+    [#494](https://github.com/flexible-collision-library/fcl/pull/494)
+
 * Geometry
 
   * OcTree logic for determining free/occupied:

--- a/include/fcl/math/constants.h
+++ b/include/fcl/math/constants.h
@@ -148,13 +148,17 @@ static Real gjk_default_tolerance() {
 }
 
 /// Returns ε for the precision of the underlying scalar type.
-static Real eps() {
+static constexpr Real eps() {
   static_assert(std::is_floating_point<Real>::value,
                 "Constants can only be evaluated for scalars with floating "
                 "point implementations");
-  static const Real value = std::numeric_limits<Real>::epsilon();
-  return value;
+  return std::numeric_limits<Real>::epsilon();
 }
+
+// TODO(SeanCurtis-TRI) These are *not* declared constexpr because the clang
+//  compiler available in the current CI configuration for ubuntu and mac does
+//  not have std::pow declared as constexpr. When that changes, these can
+//  likewise be declared as constexpr.
 
 /// Returns ε^(7/8) for the precision of the underlying scalar type.
 static Real eps_78() {

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -313,7 +313,7 @@ _ccd_inline void tripleCross(const ccd_vec3_t *a, const ccd_vec3_t *b,
 static int doSimplex2(ccd_simplex_t *simplex, ccd_vec3_t *dir) {
   // Used to define numerical thresholds near zero; typically scaled to the size
   // of the quantities being tested.
-  const ccd_real_t eps = constants<ccd_real_t>::eps();
+  constexpr ccd_real_t eps = constants<ccd_real_t>::eps();
 
   const Vector3<ccd_real_t> p_OA(simplex->ps[simplex->last].v.v);
   const Vector3<ccd_real_t> p_OB(simplex->ps[0].v.v);
@@ -922,7 +922,7 @@ static bool are_coincident(const ccd_vec3_t& p, const ccd_vec3_t& q) {
   using std::abs;
   using std::max;
 
-  const ccd_real_t eps = constants<ccd_real_t>::eps();
+  constexpr ccd_real_t eps = constants<ccd_real_t>::eps();
   // NOTE: Wrapping "1.0" with ccd_real_t accounts for mac problems where ccd
   // is actually float based.
   for (int i = 0; i < 3; ++i) {
@@ -960,7 +960,7 @@ static bool triangle_area_is_zero(const ccd_vec3_t& a, const ccd_vec3_t& b,
   ccdVec3Normalize(&AB);
   ccdVec3Normalize(&AC);
   ccdVec3Cross(&n, &AB, &AC);
-  const ccd_real_t eps = constants<ccd_real_t>::eps();
+  constexpr ccd_real_t eps = constants<ccd_real_t>::eps();
   // Second co-linearity condition.
   if (ccdVec3Len2(&n) < eps * eps) return true;
   return false;

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/sphere_box-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/sphere_box-inl.h
@@ -135,7 +135,7 @@ FCL_EXPORT bool sphereBoxIntersect(const Sphere<S>& sphere,
     // Furthermore, in finding the *near* face, a better candidate must be more
     // than this epsilon closer to the sphere center (see the test in the
     // else branch).
-    auto eps = 16 * constants<S>::eps();
+    constexpr auto eps = 16 * constants<S>::eps();
     if (N_is_not_C && squared_distance > eps * eps) {
       // The center is on the outside. Normal direction is from C to N (computed
       // above) and penetration depth is r - |p_BN - p_BC|. The contact position

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/sphere_cylinder-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/sphere_cylinder-inl.h
@@ -155,7 +155,7 @@ FCL_EXPORT bool sphereCylinderIntersect(
     // Furthermore, in finding the *near* face, a better candidate must be more
     // than this epsilon closer to the sphere center (see the test in the
     // else branch).
-    const auto eps = 16 * constants<S>::eps();
+    constexpr auto eps = 16 * constants<S>::eps();
     if (S_is_outside && p_SN_squared_dist > eps * eps) {
       // The sphere center is *measurably outside* the cylinder. There are three
       // possibilities: nearest point lies on the cap face, cap edge, or barrel.


### PR DESCRIPTION
Address EPA failure from issue 493

 - Incidentally, make the constants::eps* methods `constexpr`.
 - Introduce two regression tests (the two posted in the issue).
 - Correct a few confusing whitepsace formatting issues.
 - Modify the validateNearestFeatureOfPolytopeBeingEdge() function in two ways
   - Distance from origin to face must now be greater than epsilon (instead of zero). Justificaiton for this change provided.
   - Test to determine if the edge *truly* is the nearest feature has been simplified and documentation updated. This led to the removal of the is_point_on_line_segment() function.

The eps `constexpr` changes and the EPA fixes are in two separate commits. Let me know if you'd like them broken into two PRs.

resolves #493

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/494)
<!-- Reviewable:end -->
