### PR TITLE
[trivial fix] remove accidental recursive include

### DIFF
--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd.h
@@ -59,7 +59,6 @@
 #include "fcl/narrowphase/detail/convexity_based_algorithm/polytope.h"
 #include "fcl/narrowphase/detail/convexity_based_algorithm/alloc.h"
 #include "fcl/narrowphase/detail/convexity_based_algorithm/list.h"
-#include "fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd.h"
 
 namespace fcl
 {


### PR DESCRIPTION
The file should not include itself.
Might seem like a cosmetic cleanup, but some code sanitizers like `include-what-you-use` fail due to this line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/496)
<!-- Reviewable:end -->
