### PR TITLE
[trivial fix] Fix build when ccd_real_t == float

### DIFF
--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -1693,7 +1693,8 @@ static void validateNearestFeatureOfPolytopeBeingEdge(ccd_pt_t* polytope) {
   // for this possibility.
   const ccd_real_t v0_dist =
       std::sqrt(ccdVec3Len2(&nearest_edge->vertex[0]->v.v));
-  const ccd_real_t plane_threshold = kEps * std::max(1.0, v0_dist);
+  const ccd_real_t plane_threshold =
+      kEps * std::max(static_cast<ccd_real_t>(1.0), v0_dist);
 
   for (int i = 0; i < 2; ++i) {
     face_normals[i] =


### PR DESCRIPTION
libccd supports single or double precision builds.
It seems like the developers build it with double precision.
But if you actually require double precision you should check for it in the configuration.

Without the patch the build fails because stl does not support `std::max(double, float)` (problems with the `initializer_list` overload being preferred).
A fact that by itself is rather frustrating as well...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/498)
<!-- Reviewable:end -->
