### PR TITLE
Fix finding of ccd with pkg-config (#497)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,17 +174,29 @@ find_package(ccd QUIET)
 # find_library()
 if(NOT ccd_FOUND)
   if(PKG_CONFIG_FOUND)
-    pkg_check_modules(PC_CCD ccd)
-    pkg_check_modules(PC_LIBCCD libccd)
+    pkg_search_module(PC_CCD ccd libccd)
   endif()
 
+  # The include directory returned by pkg_config is very unreliable:
+  #  1. PC_CCD_INCLUDE_DIRS cannot locate ccd.h definitively, it could be:
+  #     a) PC_CCD_INCLUDE_DIRS/ccd/ccd.h
+  #     b) PC_CCD_INCLUDE_DIRS/ccd.h
+  #  2. It may be empty due to pkg-config's de-duplication, if the path is
+  #     provided by:
+  #     a) $PKG_CONFIG_SYSTEM_INCLUDE_PATH
+  #     b) $C_INCLUDE_PATH
+  #     c) $CPLUS_INCLUDE_PATH
   find_path(CCD_INCLUDE_DIR ccd/ccd.h
-    HINTS "${PC_CCD_INCLUDE_DIRS}" "${PC_LIBCCD_INCLUDE_DIRS}")
+    HINTS "${PC_CCD_INCLUDE_DIRS}"
+          "${PC_CCD_INCLUDE_DIRS}/.."
+          ENV PKG_CONFIG_SYSTEM_INCLUDE_PATH
+          ENV C_INCLUDE_PATH
+          ENV CPLUS_INCLUDE_PATH)
 
   # Using find_library() even if pkg-config is available ensures that the full
   # path to the ccd library is available in CCD_LIBRARIES
   find_library(CCD_LIBRARY ccd
-    HINTS "${PC_CCD_LIBRARY_DIRS}" "${PC_LIBCCD_LIBRARY_DIRS}")
+    HINTS "${PC_CCD_LIBRARY_DIRS}")
 
   # libccd links to LibM on UNIX.
   if(CYGWIN OR NOT WIN32)


### PR DESCRIPTION
The fallback path eventually calls `pkg-config -cflags ccd` to locate
the include directory of libccd. However this method is very unreliable.

1. The returned `<prefix>_INCLUDE_DIRS` may be empty, due to the
   de-duplication feature provided by `pkg-config`.
2. The returned `<prefix>_INCLUDE_DIRS` may point to a directory that
   includes `ccd.h` directly, but it may also point to a directory where
   `ccd/ccd.h` resides. FCL's code is expecting the second result.

This patch handles both cases.

Also note we cannot leave CCD_INCLUDE_DIRS to be empty. Otherwise cmake
(at least >= 3.17) will complain:
```
  Target "fcl" INTERFACE_INCLUDE_DIRECTORIES property contains path:
    ".../fcl/src/CCD_INCLUDE_DIRS-NOTFOUND"
  which is prefixed in the source directory.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/499)
<!-- Reviewable:end -->
