### PR TITLE
Use package format 3 with conditional dependency on catkin.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,4 @@
-<package format="2">
+<package format="3">
   <name>fcl</name>
   <version>0.6.1</version>
   <description>FCL: the Flexible Collision Library</description>
@@ -9,7 +9,7 @@
   <depend>eigen</depend>
   <depend>octomap</depend>
   <!-- Following recommendations of REP 136 -->
-  <exec_depend>catkin</exec_depend>
+  <exec_depend condition="ROS_VERSION == 1">catkin</exec_depend>
   <export>
     <build_type>cmake</build_type>
   </export>


### PR DESCRIPTION
I'd like to release fcl into ROS 2, starting with ROS 2 Rolling.

catkin isn't used or available in ROS 2. The recommended dependency on catkin for non-ROS packages released on the build farm is covered by the universally injected dependency on the ros_workspace package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/536)
<!-- Reviewable:end -->
