### PR TITLE
Update changelog and package.xml to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## FCL 0
 
-### FCL 0.7.0 (2021-08-xx)
+### FCL 0.7.0 (2021-09-09)
 
 * Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,35 @@
 ## FCL 0
 
-### FCL 0.7.0 (????-??-??)
+### FCL 0.7.0 (2021-08-xx)
 
 * Breaking changes
 
   * Macros `FCL_SUPPRESS_MAYBE_UNINITIALIZED_BEGIN` and `FCL_SUPPRESS_MAYBE_UNINITIALIZED_END` defined in `fcl/common/warning.h` have been removed:
     [#489](https://github.com/flexible-collision-library/fcl/pull/489)
+  * Require CMake 3.10:
+    [#506](https://github.com/flexible-collision-library/fcl/pull/506)
+  * Check SSE support and enable SSE if support is found:
+    [#506](https://github.com/flexible-collision-library/fcl/pull/506)
+    [#514](https://github.com/flexible-collision-library/fcl/pull/514)
 
 * Core/Common
+
+  * Use package format 3 with conditional dependency on catkin:
+    [#536](https://github.com/flexible-collision-library/fcl/pull/536)
+  * Fix compilation on Windows. Do not use "not" in preprocessor:
+    [#530](https://github.com/flexible-collision-library/fcl/pull/530)
+  * Use std::copy instead of memcpy. Patches imported from Debian:
+    [#517](https://github.com/flexible-collision-library/fcl/pull/517)
+  * Fix finding of ccd with pkg-config:
+    [#499](https://github.com/flexible-collision-library/fcl/pull/499)
+    [#497](https://github.com/flexible-collision-library/fcl/pull/497)
 
 * Math
 
   * constants::eps() is now constexpr:
     [#494](https://github.com/flexible-collision-library/fcl/pull/494)
+  * Fix shape conservative advancement normal computation:
+    [#505](https://github.com/flexible-collision-library/fcl/pull/505)
 
 * Geometry
 
@@ -26,6 +43,8 @@
     collision between ellipsoid and half space *with that ordering*. Now also
     supports half space and ellipsoid.
     [#520](https://github.com/flexible-collision-library/fcl/pull/520)
+  * Do not flush error messages on cerr:
+    [#542](https://github.com/flexible-collision-library/fcl/pull/542)
 
 * Broadphase
 
@@ -39,6 +58,10 @@
     [#472](https://github.com/flexible-collision-library/fcl/pull/472)
   * Another failure mode in the GJK/EPA signed distance query patched:
     [#494](https://github.com/flexible-collision-library/fcl/pull/494)
+  * Fix build when ccd_real_t == float:
+    [#498](https://github.com/flexible-collision-library/fcl/pull/498)
+  * Remove accidental recursive include:
+    [#496](https://github.com/flexible-collision-library/fcl/pull/496)
 
 * Build/Test/Misc
 

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <package format="3">
   <name>fcl</name>
-  <version>0.6.1</version>
+  <version>0.7.0</version>
   <description>FCL: the Flexible Collision Library</description>
   <maintainer email="fcl@tri.global">TRI Geometry Team</maintainer>
   <license>BSD</license>


### PR DESCRIPTION
Following https://github.com/flexible-collision-library/fcl/issues/532 and after checking with @scpeters and @SeanCurtis-TRI I think we are ready to run a new fcl version, 0.7.0.

I've included everything I found in https://github.com/flexible-collision-library/fcl/compare/v0.6.1...master in the Changelog.
Fixes https://github.com/flexible-collision-library/fcl/issues/532

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/547)
<!-- Reviewable:end -->
