### PR TITLE
fix collision between mesh mesh BVH nodes

### DIFF
--- a/include/fcl/narrowphase/detail/traversal/distance/mesh_conservative_advancement_traversal_node-inl.h
+++ b/include/fcl/narrowphase/detail/traversal/distance/mesh_conservative_advancement_traversal_node-inl.h
@@ -38,41 +38,51 @@
 #ifndef FCL_TRAVERSAL_MESHCONSERVATIVEADVANCEMENTTRAVERSALNODE_INL_H
 #define FCL_TRAVERSAL_MESHCONSERVATIVEADVANCEMENTTRAVERSALNODE_INL_H
 
-#include "fcl/math/bv/RSS.h"
-#include "fcl/math/motion/triangle_motion_bound_visitor.h"
 #include "fcl/narrowphase/detail/traversal/distance/mesh_conservative_advancement_traversal_node.h"
 
-namespace fcl {
+#include "fcl/math/bv/RSS.h"
+#include "fcl/math/motion/triangle_motion_bound_visitor.h"
 
-namespace detail {
+namespace fcl
+{
+
+namespace detail
+{
 
 //==============================================================================
-extern template class FCL_EXPORT
-    MeshConservativeAdvancementTraversalNodeRSS<double>;
+extern template
+class FCL_EXPORT MeshConservativeAdvancementTraversalNodeRSS<double>;
 
 //==============================================================================
-extern template bool initialize(
+extern template
+bool initialize(
     MeshConservativeAdvancementTraversalNodeRSS<double>& node,
-    const BVHModel<RSS<double>>& model1, const Transform3<double>& tf1,
-    const BVHModel<RSS<double>>& model2, const Transform3<double>& tf2,
+    const BVHModel<RSS<double>>& model1,
+    const Transform3<double>& tf1,
+    const BVHModel<RSS<double>>& model2,
+    const Transform3<double>& tf2,
     double w);
 
 //==============================================================================
-extern template class FCL_EXPORT
-    MeshConservativeAdvancementTraversalNodeOBBRSS<double>;
+extern template
+class FCL_EXPORT MeshConservativeAdvancementTraversalNodeOBBRSS<double>;
 
 //==============================================================================
-extern template bool initialize(
+extern template
+bool initialize(
     MeshConservativeAdvancementTraversalNodeOBBRSS<double>& node,
-    const BVHModel<OBBRSS<double>>& model1, const Transform3<double>& tf1,
-    const BVHModel<OBBRSS<double>>& model2, const Transform3<double>& tf2,
+    const BVHModel<OBBRSS<double>>& model1,
+    const Transform3<double>& tf1,
+    const BVHModel<OBBRSS<double>>& model2,
+    const Transform3<double>& tf2,
     double w);
 
 //==============================================================================
 template <typename BV>
-MeshConservativeAdvancementTraversalNode<
-    BV>::MeshConservativeAdvancementTraversalNode(typename BV::S w_)
-    : MeshDistanceTraversalNode<BV>() {
+MeshConservativeAdvancementTraversalNode<BV>::
+MeshConservativeAdvancementTraversalNode(typename BV::S w_)
+  : MeshDistanceTraversalNode<BV>()
+{
   delta_t = 1;
   toc = 0;
   t_err = (S)0.00001;
@@ -85,9 +95,10 @@ MeshConservativeAdvancementTraversalNode<
 
 //==============================================================================
 template <typename BV>
-typename BV::S MeshConservativeAdvancementTraversalNode<BV>::BVTesting(
-    int b1, int b2) const {
-  if (this->enable_statistics) this->num_bv_tests++;
+typename BV::S
+MeshConservativeAdvancementTraversalNode<BV>::BVTesting(int b1, int b2) const
+{
+  if(this->enable_statistics) this->num_bv_tests++;
   Vector3<S> P1, P2;
   S d = this->model1->getBV(b1).distance(this->model2->getBV(b2), &P1, &P2);
 
@@ -98,9 +109,9 @@ typename BV::S MeshConservativeAdvancementTraversalNode<BV>::BVTesting(
 
 //==============================================================================
 template <typename BV>
-void MeshConservativeAdvancementTraversalNode<BV>::leafTesting(int b1,
-                                                               int b2) const {
-  if (this->enable_statistics) this->num_leaf_tests++;
+void MeshConservativeAdvancementTraversalNode<BV>::leafTesting(int b1, int b2) const
+{
+  if(this->enable_statistics) this->num_leaf_tests++;
 
   const BVNode<BV>& node1 = this->model1->getBV(b1);
   const BVNode<BV>& node2 = this->model2->getBV(b2);
@@ -122,9 +133,11 @@ void MeshConservativeAdvancementTraversalNode<BV>::leafTesting(int b1,
   // nearest point pair
   Vector3<S> P1, P2;
 
-  S d = TriangleDistance<S>::triDistance(p1, p2, p3, q1, q2, q3, P1, P2);
+  S d = TriangleDistance<S>::triDistance(p1, p2, p3, q1, q2, q3,
+                                           P1, P2);
 
-  if (d < this->min_distance) {
+  if(d < this->min_distance)
+  {
     this->min_distance = d;
 
     closest_p1 = P1;
@@ -136,77 +149,77 @@ void MeshConservativeAdvancementTraversalNode<BV>::leafTesting(int b1,
 
   Vector3<S> n = P2 - P1;
   n.normalize();
-  // here n is already in global frame as we assume the body is in original
-  // configuration (I, 0) for general BVH
-  TriangleMotionBoundVisitor<S> mb_visitor1(p1, p2, p3, n),
-      mb_visitor2(q1, q2, q3, n);
+  // here n is already in global frame as we assume the body is in original configuration (I, 0) for general BVH
+  TriangleMotionBoundVisitor<S> mb_visitor1(p1, p2, p3, n), mb_visitor2(q1, q2, q3, n);
   S bound1 = motion1->computeMotionBound(mb_visitor1);
   S bound2 = motion2->computeMotionBound(mb_visitor2);
 
   S bound = std::abs(bound1) + std::abs(bound2);
 
   S cur_delta_t;
-  if (bound <= d)
-    cur_delta_t = 1;
-  else
-    cur_delta_t = d / bound;
+  if(bound <= d) cur_delta_t = 1;
+  else cur_delta_t = d / bound;
 
-  if (cur_delta_t < delta_t) delta_t = cur_delta_t;
+  if(cur_delta_t < delta_t)
+    delta_t = cur_delta_t;
 }
 
 //==============================================================================
 template <typename S, typename BV>
-struct CanStopImpl {
-  static bool run(const MeshConservativeAdvancementTraversalNode<BV>& node,
-                  S c) {
-    if ((c >= node.w * (node.min_distance - node.abs_err)) &&
-        (c * (1 + node.rel_err) >= node.w * node.min_distance)) {
+struct CanStopImpl
+{
+  static bool run(
+      const MeshConservativeAdvancementTraversalNode<BV>& node, S c)
+  {
+    if((c >= node.w * (node.min_distance - node.abs_err))
+       && (c * (1 + node.rel_err) >= node.w * node.min_distance))
+    {
       const ConservativeAdvancementStackData<S>& data = node.stack.back();
       S d = data.d;
       Vector3<S> n;
       int c1, c2;
 
-      if (d > c) {
-        const ConservativeAdvancementStackData<S>& data2 =
-            node.stack[node.stack.size() - 2];
+      if(d > c)
+      {
+        const ConservativeAdvancementStackData<S>& data2 = node.stack[node.stack.size() - 2];
         d = data2.d;
-        n = data2.P2 - data2.P1;
-        n.normalize();
+        n = data2.P2 - data2.P1; n.normalize();
         c1 = data2.c1;
         c2 = data2.c2;
         node.stack[node.stack.size() - 2] = node.stack[node.stack.size() - 1];
-      } else {
-        n = data.P2 - data.P1;
-        n.normalize();
+      }
+      else
+      {
+        n = data.P2 - data.P1; n.normalize();
         c1 = data.c1;
         c2 = data.c2;
       }
 
       assert(c == d);
 
-      TBVMotionBoundVisitor<BV> mb_visitor1(node.model1->getBV(c1).bv, n),
-          mb_visitor2(node.model2->getBV(c2).bv, n);
+      TBVMotionBoundVisitor<BV> mb_visitor1(node.model1->getBV(c1).bv, n), mb_visitor2(node.model2->getBV(c2).bv, n);
       S bound1 = node.motion1->computeMotionBound(mb_visitor1);
       S bound2 = node.motion2->computeMotionBound(mb_visitor2);
 
       S bound = bound1 + bound2;
 
       S cur_delta_t;
-      if (bound <= c)
-        cur_delta_t = 1;
-      else
-        cur_delta_t = c / bound;
+      if(bound <= c) cur_delta_t = 1;
+      else cur_delta_t = c / bound;
 
-      if (cur_delta_t < node.delta_t) node.delta_t = cur_delta_t;
+      if(cur_delta_t < node.delta_t)
+        node.delta_t = cur_delta_t;
 
       node.stack.pop_back();
 
       return true;
-    } else {
+    }
+    else
+    {
       const ConservativeAdvancementStackData<S>& data = node.stack.back();
       S d = data.d;
 
-      if (d > c)
+      if(d > c)
         node.stack[node.stack.size() - 2] = node.stack[node.stack.size() - 1];
 
       node.stack.pop_back();
@@ -219,60 +232,105 @@ struct CanStopImpl {
 //==============================================================================
 template <typename BV>
 bool MeshConservativeAdvancementTraversalNode<BV>::canStop(
-    typename BV::S c) const {
+    typename BV::S c) const
+{
   return CanStopImpl<typename BV::S, BV>::run(*this, c);
 }
 
 //==============================================================================
 template <typename S>
-struct CanStopImpl<S, OBB<S>> {
-  static bool run(const MeshConservativeAdvancementTraversalNode<OBB<S>>& node,
-                  S c) {
-    return detail::meshConservativeAdvancementTraversalNodeCanStop(
-        c, node.min_distance, node.abs_err, node.rel_err, node.w, node.model1,
-        node.model2, node.motion1, node.motion2, node.stack, node.delta_t);
-  }
-};
-
-//==============================================================================
-template <typename S>
-struct CanStopImpl<S, RSS<S>> {
-  static bool run(const MeshConservativeAdvancementTraversalNode<RSS<S>>& node,
-                  S c) {
-    return detail::meshConservativeAdvancementTraversalNodeCanStop(
-        c, node.min_distance, node.abs_err, node.rel_err, node.w, node.model1,
-        node.model2, node.motion1, node.motion2, node.stack, node.delta_t);
-  }
-};
-
-//==============================================================================
-template <typename S>
-struct CanStopImpl<S, OBBRSS<S>> {
+struct CanStopImpl<S, OBB<S>>
+{
   static bool run(
-      const MeshConservativeAdvancementTraversalNode<OBBRSS<S>>& node, S c) {
+      const MeshConservativeAdvancementTraversalNode<OBB<S>>& node,
+      S c)
+  {
     return detail::meshConservativeAdvancementTraversalNodeCanStop(
-        c, node.min_distance, node.abs_err, node.rel_err, node.w, node.model1,
-        node.model2, node.motion1, node.motion2, node.stack, node.delta_t);
+          c,
+          node.min_distance,
+          node.abs_err,
+          node.rel_err,
+          node.w,
+          node.model1,
+          node.model2,
+          node.motion1,
+          node.motion2,
+          node.stack,
+          node.delta_t);
+  }
+};
+
+//==============================================================================
+template <typename S>
+struct CanStopImpl<S, RSS<S>>
+{
+  static bool run(
+      const MeshConservativeAdvancementTraversalNode<RSS<S>>& node,
+      S c)
+  {
+    return detail::meshConservativeAdvancementTraversalNodeCanStop(
+          c,
+          node.min_distance,
+          node.abs_err,
+          node.rel_err,
+          node.w,
+          node.model1,
+          node.model2,
+          node.motion1,
+          node.motion2,
+          node.stack,
+          node.delta_t);
+  }
+};
+
+//==============================================================================
+template <typename S>
+struct CanStopImpl<S, OBBRSS<S>>
+{
+  static bool run(
+      const MeshConservativeAdvancementTraversalNode<OBBRSS<S>>& node,
+      S c)
+  {
+    return detail::meshConservativeAdvancementTraversalNodeCanStop(
+          c,
+          node.min_distance,
+          node.abs_err,
+          node.rel_err,
+          node.w,
+          node.model1,
+          node.model2,
+          node.motion1,
+          node.motion2,
+          node.stack,
+          node.delta_t);
   }
 };
 
 //==============================================================================
 template <typename BV>
-bool initialize(MeshConservativeAdvancementTraversalNode<BV>& node,
-                BVHModel<BV>& model1, const Transform3<typename BV::S>& tf1,
-                BVHModel<BV>& model2, const Transform3<typename BV::S>& tf2,
-                typename BV::S w, bool use_refit, bool refit_bottomup) {
+bool initialize(
+    MeshConservativeAdvancementTraversalNode<BV>& node,
+    BVHModel<BV>& model1,
+    const Transform3<typename BV::S>& tf1,
+    BVHModel<BV>& model2,
+    const Transform3<typename BV::S>& tf2,
+    typename BV::S w,
+    bool use_refit,
+    bool refit_bottomup)
+{
   using S = typename BV::S;
 
   std::vector<Vector3<S>> vertices_transformed1(model1.num_vertices);
-  for (int i = 0; i < model1.num_vertices; ++i) {
+  for(int i = 0; i < model1.num_vertices; ++i)
+  {
     Vector3<S>& p = model1.vertices[i];
     Vector3<S> new_v = tf1 * p;
     vertices_transformed1[i] = new_v;
   }
 
   std::vector<Vector3<S>> vertices_transformed2(model2.num_vertices);
-  for (int i = 0; i < model2.num_vertices; ++i) {
+  for(int i = 0; i < model2.num_vertices; ++i)
+  {
     Vector3<S>& p = model2.vertices[i];
     Vector3<S> new_v = tf2 * p;
     vertices_transformed2[i] = new_v;
@@ -302,82 +360,140 @@ bool initialize(MeshConservativeAdvancementTraversalNode<BV>& node,
 
 //==============================================================================
 template <typename S>
-MeshConservativeAdvancementTraversalNodeRSS<
-    S>::MeshConservativeAdvancementTraversalNodeRSS(S w_)
-    : MeshConservativeAdvancementTraversalNode<RSS<S>>(w_) {
+MeshConservativeAdvancementTraversalNodeRSS<S>::
+MeshConservativeAdvancementTraversalNodeRSS(S w_)
+  : MeshConservativeAdvancementTraversalNode<RSS<S>>(w_)
+{
   R.setIdentity();
 }
 
 //==============================================================================
 template <typename S>
-void MeshConservativeAdvancementTraversalNodeRSS<S>::leafTesting(int b1,
-                                                                 int b2) const {
+void MeshConservativeAdvancementTraversalNodeRSS<S>::
+leafTesting(int b1, int b2) const
+{
   detail::meshConservativeAdvancementOrientedNodeLeafTesting(
-      b1, b2, this->model1, this->model2, this->tri_indices1,
-      this->tri_indices2, this->vertices1, this->vertices2, R, T, this->motion1,
-      this->motion2, this->enable_statistics, this->min_distance,
-      this->closest_p1, this->closest_p2, this->last_tri_id1,
-      this->last_tri_id2, this->delta_t, this->num_leaf_tests);
+        b1,
+        b2,
+        this->model1,
+        this->model2,
+        this->tri_indices1,
+        this->tri_indices2,
+        this->vertices1,
+        this->vertices2,
+        R,
+        T,
+        this->motion1,
+        this->motion2,
+        this->enable_statistics,
+        this->min_distance,
+        this->closest_p1,
+        this->closest_p2,
+        this->last_tri_id1,
+        this->last_tri_id2,
+        this->delta_t,
+        this->num_leaf_tests);
 }
 
 //==============================================================================
 template <typename S>
-bool MeshConservativeAdvancementTraversalNodeRSS<S>::canStop(S c) const {
+bool MeshConservativeAdvancementTraversalNodeRSS<S>::canStop(S c) const
+{
   return detail::meshConservativeAdvancementOrientedNodeCanStop(
-      c, this->min_distance, this->abs_err, this->rel_err, this->w,
-      this->model1, this->model2, this->motion1, this->motion2, this->stack,
-      this->delta_t);
+        c,
+        this->min_distance,
+        this->abs_err,
+        this->rel_err,
+        this->w,
+        this->model1,
+        this->model2,
+        this->motion1,
+        this->motion2,
+        this->stack,
+        this->delta_t);
 }
 
 //==============================================================================
 template <typename S>
-MeshConservativeAdvancementTraversalNodeOBBRSS<
-    S>::MeshConservativeAdvancementTraversalNodeOBBRSS(S w_)
-    : MeshConservativeAdvancementTraversalNode<OBBRSS<S>>(w_) {
+MeshConservativeAdvancementTraversalNodeOBBRSS<S>::
+MeshConservativeAdvancementTraversalNodeOBBRSS(S w_)
+  : MeshConservativeAdvancementTraversalNode<OBBRSS<S>>(w_)
+{
   R.setIdentity();
 }
 
 //==============================================================================
 template <typename S>
-void MeshConservativeAdvancementTraversalNodeOBBRSS<S>::leafTesting(
-    int b1, int b2) const {
+void MeshConservativeAdvancementTraversalNodeOBBRSS<S>::
+leafTesting(int b1, int b2) const
+{
   detail::meshConservativeAdvancementOrientedNodeLeafTesting(
-      b1, b2, this->model1, this->model2, this->tri_indices1,
-      this->tri_indices2, this->vertices1, this->vertices2, this->R, this->T,
-      this->motion1, this->motion2, this->enable_statistics, this->min_distance,
-      this->closest_p1, this->closest_p2, this->last_tri_id1,
-      this->last_tri_id2, this->delta_t, this->num_leaf_tests);
+        b1,
+        b2,
+        this->model1,
+        this->model2,
+        this->tri_indices1,
+        this->tri_indices2,
+        this->vertices1,
+        this->vertices2,
+        this->R,
+        this->T,
+        this->motion1,
+        this->motion2,
+        this->enable_statistics,
+        this->min_distance,
+        this->closest_p1,
+        this->closest_p2,
+        this->last_tri_id1,
+        this->last_tri_id2,
+        this->delta_t,
+        this->num_leaf_tests);
 }
 
 //==============================================================================
 template <typename S>
-bool MeshConservativeAdvancementTraversalNodeOBBRSS<S>::canStop(S c) const {
+bool MeshConservativeAdvancementTraversalNodeOBBRSS<S>::canStop(S c) const
+{
   return detail::meshConservativeAdvancementOrientedNodeCanStop(
-      c, this->min_distance, this->abs_err, this->rel_err, this->w,
-      this->model1, this->model2, this->motion1, this->motion2, this->stack,
-      this->delta_t);
+        c,
+        this->min_distance,
+        this->abs_err,
+        this->rel_err,
+        this->w,
+        this->model1,
+        this->model2,
+        this->motion1,
+        this->motion2,
+        this->stack,
+        this->delta_t);
 }
 
-/// @brief for OBB and RSS, there is local coordinate of BV, so normal need to
-/// be transformed
+/// @brief for OBB and RSS, there is local coordinate of BV, so normal need to be transformed
 
 //==============================================================================
 template <typename S, typename BV>
-struct GetBVAxisImpl {
-  const Vector3<S> operator()(const BV& bv, int i) { return bv.axis.col(i); }
+struct GetBVAxisImpl
+{
+  const Vector3<S> operator()(const BV& bv, int i)
+  {
+    return bv.axis.col(i);
+  }
 };
 
 //==============================================================================
 template <typename BV>
-const Vector3<typename BV::S> getBVAxis(const BV& bv, int i) {
+const Vector3<typename BV::S> getBVAxis(const BV& bv, int i)
+{
   GetBVAxisImpl<typename BV::S, BV> getBVAxisImpl;
   return getBVAxisImpl(bv, i);
 }
 
 //==============================================================================
 template <typename S>
-struct GetBVAxisImpl<S, OBBRSS<S>> {
-  const Vector3<S> operator()(const OBBRSS<S>& bv, int i) {
+struct GetBVAxisImpl<S, OBBRSS<S>>
+{
+  const Vector3<S> operator()(const OBBRSS<S>& bv, int i)
+  {
     return bv.obb.axis.col(i);
   }
 };
@@ -385,66 +501,74 @@ struct GetBVAxisImpl<S, OBBRSS<S>> {
 //==============================================================================
 template <typename BV>
 bool meshConservativeAdvancementTraversalNodeCanStop(
-    typename BV::S c, typename BV::S min_distance, typename BV::S abs_err,
-    typename BV::S rel_err, typename BV::S w, const BVHModel<BV>* model1,
-    const BVHModel<BV>* model2, const MotionBase<typename BV::S>* motion1,
+    typename BV::S c,
+    typename BV::S min_distance,
+    typename BV::S abs_err,
+    typename BV::S rel_err,
+    typename BV::S w,
+    const BVHModel<BV>* model1,
+    const BVHModel<BV>* model2,
+    const MotionBase<typename BV::S>* motion1,
     const MotionBase<typename BV::S>* motion2,
     std::vector<ConservativeAdvancementStackData<typename BV::S>>& stack,
-    typename BV::S& delta_t) {
+    typename BV::S& delta_t)
+{
   using S = typename BV::S;
 
-  if ((c >= w * (min_distance - abs_err)) &&
-      (c * (1 + rel_err) >= w * min_distance)) {
+  if((c >= w * (min_distance - abs_err)) && (c * (1 + rel_err) >= w * min_distance))
+  {
     const ConservativeAdvancementStackData<S>& data = stack.back();
     S d = data.d;
     Vector3<S> n;
     int c1, c2;
 
-    if (d > c) {
-      const ConservativeAdvancementStackData<S>& data2 =
-          stack[stack.size() - 2];
+    if(d > c)
+    {
+      const ConservativeAdvancementStackData<S>& data2 = stack[stack.size() - 2];
       d = data2.d;
-      n = data2.P2 - data2.P1;
-      n.normalize();
+      n = data2.P2 - data2.P1; n.normalize();
       c1 = data2.c1;
       c2 = data2.c2;
       stack[stack.size() - 2] = stack[stack.size() - 1];
-    } else {
-      n = data.P2 - data.P1;
-      n.normalize();
+    }
+    else
+    {
+      n = data.P2 - data.P1; n.normalize();
       c1 = data.c1;
       c2 = data.c2;
     }
 
     assert(c == d);
 
-    Vector3<S> n_transformed = getBVAxis(model1->getBV(c1).bv, 0) * n[0] +
-                               getBVAxis(model1->getBV(c1).bv, 1) * n[1] +
-                               getBVAxis(model1->getBV(c1).bv, 2) * n[2];
+    Vector3<S> n_transformed =
+        getBVAxis(model1->getBV(c1).bv, 0) * n[0] +
+        getBVAxis(model1->getBV(c1).bv, 1) * n[1] +
+        getBVAxis(model1->getBV(c1).bv, 2) * n[2];
 
-    TBVMotionBoundVisitor<BV> mb_visitor1(model1->getBV(c1).bv, n_transformed),
-        mb_visitor2(model2->getBV(c2).bv, n_transformed);
+    TBVMotionBoundVisitor<BV> mb_visitor1(model1->getBV(c1).bv, n_transformed), mb_visitor2(model2->getBV(c2).bv, n_transformed);
     S bound1 = motion1->computeMotionBound(mb_visitor1);
     S bound2 = motion2->computeMotionBound(mb_visitor2);
 
     S bound = bound1 + bound2;
 
     S cur_delta_t;
-    if (bound <= c)
-      cur_delta_t = 1;
-    else
-      cur_delta_t = c / bound;
+    if(bound <= c) cur_delta_t = 1;
+    else cur_delta_t = c / bound;
 
-    if (cur_delta_t < delta_t) delta_t = cur_delta_t;
+    if(cur_delta_t < delta_t)
+      delta_t = cur_delta_t;
 
     stack.pop_back();
 
     return true;
-  } else {
+  }
+  else
+  {
     const ConservativeAdvancementStackData<S>& data = stack.back();
     S d = data.d;
 
-    if (d > c) stack[stack.size() - 2] = stack[stack.size() - 1];
+    if(d > c)
+      stack[stack.size() - 2] = stack[stack.size() - 1];
 
     stack.pop_back();
 
@@ -455,33 +579,39 @@ bool meshConservativeAdvancementTraversalNodeCanStop(
 //==============================================================================
 template <typename BV>
 bool meshConservativeAdvancementOrientedNodeCanStop(
-    typename BV::S c, typename BV::S min_distance, typename BV::S abs_err,
-    typename BV::S rel_err, typename BV::S w, const BVHModel<BV>* model1,
-    const BVHModel<BV>* model2, const MotionBase<typename BV::S>* motion1,
+    typename BV::S c,
+    typename BV::S min_distance,
+    typename BV::S abs_err,
+    typename BV::S rel_err,
+    typename BV::S w,
+    const BVHModel<BV>* model1,
+    const BVHModel<BV>* model2,
+    const MotionBase<typename BV::S>* motion1,
     const MotionBase<typename BV::S>* motion2,
     std::vector<ConservativeAdvancementStackData<typename BV::S>>& stack,
-    typename BV::S& delta_t) {
+    typename BV::S& delta_t)
+{
   using S = typename BV::S;
 
-  if ((c >= w * (min_distance - abs_err)) &&
-      (c * (1 + rel_err) >= w * min_distance)) {
+  if((c >= w * (min_distance - abs_err)) && (c * (1 + rel_err) >= w * min_distance))
+  {
     const ConservativeAdvancementStackData<S>& data = stack.back();
     S d = data.d;
     Vector3<S> n;
     int c1, c2;
 
-    if (d > c) {
-      const ConservativeAdvancementStackData<S>& data2 =
-          stack[stack.size() - 2];
+    if(d > c)
+    {
+      const ConservativeAdvancementStackData<S>& data2 = stack[stack.size() - 2];
       d = data2.d;
-      n = data2.P2 - data2.P1;
-      n.normalize();
+      n = data2.P2 - data2.P1; n.normalize();
       c1 = data2.c1;
       c2 = data2.c2;
       stack[stack.size() - 2] = stack[stack.size() - 1];
-    } else {
-      n = data.P2 - data.P1;
-      n.normalize();
+    }
+    else
+    {
+      n = data.P2 - data.P1; n.normalize();
       c1 = data.c1;
       c2 = data.c2;
     }
@@ -489,37 +619,39 @@ bool meshConservativeAdvancementOrientedNodeCanStop(
     assert(c == d);
 
     // n is in local frame of c1, so we need to turn n into the global frame
-    Vector3<S> n_transformed = getBVAxis(model1->getBV(c1).bv, 0) * n[0] +
-                               getBVAxis(model1->getBV(c1).bv, 1) * n[1] +
-                               getBVAxis(model1->getBV(c1).bv, 2) * n[2];
+    Vector3<S> n_transformed =
+      getBVAxis(model1->getBV(c1).bv, 0) * n[0] +
+      getBVAxis(model1->getBV(c1).bv, 1) * n[1] +
+      getBVAxis(model1->getBV(c1).bv, 2) * n[2];
     Quaternion<S> R0;
     motion1->getCurrentRotation(R0);
     n_transformed = R0 * n_transformed;
     n_transformed.normalize();
 
-    TBVMotionBoundVisitor<BV> mb_visitor1(model1->getBV(c1).bv, n_transformed),
-        mb_visitor2(model2->getBV(c2).bv, -n_transformed);
+    TBVMotionBoundVisitor<BV> mb_visitor1(model1->getBV(c1).bv, n_transformed), mb_visitor2(model2->getBV(c2).bv, -n_transformed);
     S bound1 = motion1->computeMotionBound(mb_visitor1);
     S bound2 = motion2->computeMotionBound(mb_visitor2);
 
     S bound = bound1 + bound2;
 
     S cur_delta_t;
-    if (bound <= c)
-      cur_delta_t = 1;
-    else
-      cur_delta_t = c / bound;
+    if(bound <= c) cur_delta_t = 1;
+    else cur_delta_t = c / bound;
 
-    if (cur_delta_t < delta_t) delta_t = cur_delta_t;
+    if(cur_delta_t < delta_t)
+      delta_t = cur_delta_t;
 
     stack.pop_back();
 
     return true;
-  } else {
+  }
+  else
+  {
     const ConservativeAdvancementStackData<S>& data = stack.back();
     S d = data.d;
 
-    if (d > c) stack[stack.size() - 2] = stack[stack.size() - 1];
+    if(d > c)
+      stack[stack.size() - 2] = stack[stack.size() - 1];
 
     stack.pop_back();
 
@@ -530,18 +662,30 @@ bool meshConservativeAdvancementOrientedNodeCanStop(
 //==============================================================================
 template <typename BV>
 void meshConservativeAdvancementOrientedNodeLeafTesting(
-    int b1, int b2, const BVHModel<BV>* model1, const BVHModel<BV>* model2,
-    const Triangle* tri_indices1, const Triangle* tri_indices2,
+    int b1,
+    int b2,
+    const BVHModel<BV>* model1,
+    const BVHModel<BV>* model2,
+    const Triangle* tri_indices1,
+    const Triangle* tri_indices2,
     const Vector3<typename BV::S>* vertices1,
-    const Vector3<typename BV::S>* vertices2, const Matrix3<typename BV::S>& R,
-    const Vector3<typename BV::S>& T, const MotionBase<typename BV::S>* motion1,
-    const MotionBase<typename BV::S>* motion2, bool enable_statistics,
-    typename BV::S& min_distance, Vector3<typename BV::S>& p1,
-    Vector3<typename BV::S>& p2, int& last_tri_id1, int& last_tri_id2,
-    typename BV::S& delta_t, int& num_leaf_tests) {
+    const Vector3<typename BV::S>* vertices2,
+    const Matrix3<typename BV::S>& R,
+    const Vector3<typename BV::S>& T,
+    const MotionBase<typename BV::S>* motion1,
+    const MotionBase<typename BV::S>* motion2,
+    bool enable_statistics,
+    typename BV::S& min_distance,
+    Vector3<typename BV::S>& p1,
+    Vector3<typename BV::S>& p2,
+    int& last_tri_id1,
+    int& last_tri_id2,
+    typename BV::S& delta_t,
+    int& num_leaf_tests)
+{
   using S = typename BV::S;
 
-  if (enable_statistics) num_leaf_tests++;
+  if(enable_statistics) num_leaf_tests++;
 
   const BVNode<BV>& node1 = model1->getBV(b1);
   const BVNode<BV>& node2 = model2->getBV(b2);
@@ -563,10 +707,12 @@ void meshConservativeAdvancementOrientedNodeLeafTesting(
   // nearest point pair
   Vector3<S> P1, P2;
 
-  S d = TriangleDistance<S>::triDistance(t11, t12, t13, t21, t22, t23, R, T, P1,
-                                         P2);
+  S d = TriangleDistance<S>::triDistance(t11, t12, t13, t21, t22, t23,
+                                           R, T,
+                                           P1, P2);
 
-  if (d < min_distance) {
+  if(d < min_distance)
+  {
     min_distance = d;
 
     p1 = P1;
@@ -576,38 +722,38 @@ void meshConservativeAdvancementOrientedNodeLeafTesting(
     last_tri_id2 = primitive_id2;
   }
 
+
   /// n is the local frame of object 1, pointing from object 1 to object2
   Vector3<S> n = P2 - P1;
   /// turn n into the global frame, pointing from object 1 to object 2
   Quaternion<S> R0;
   motion1->getCurrentRotation(R0);
   Vector3<S> n_transformed = R0 * n;
-  n_transformed.normalize();  // normalized here
+  n_transformed.normalize(); // normalized here
 
-  TriangleMotionBoundVisitor<S> mb_visitor1(t11, t12, t13, n_transformed),
-      mb_visitor2(t21, t22, t23, -n_transformed);
+  TriangleMotionBoundVisitor<S> mb_visitor1(t11, t12, t13, n_transformed), mb_visitor2(t21, t22, t23, -n_transformed);
   S bound1 = motion1->computeMotionBound(mb_visitor1);
   S bound2 = motion2->computeMotionBound(mb_visitor2);
 
   S bound = bound1 + bound2;
 
   S cur_delta_t;
-  if (bound <= d)
-    cur_delta_t = 1;
-  else
-    cur_delta_t = d / bound;
+  if(bound <= d) cur_delta_t = 1;
+  else cur_delta_t = d / bound;
 
-  if (cur_delta_t < delta_t) delta_t = cur_delta_t;
+  if(cur_delta_t < delta_t)
+    delta_t = cur_delta_t;
 }
 
 //==============================================================================
 template <typename BV, typename OrientedDistanceNode>
 bool setupMeshConservativeAdvancementOrientedDistanceNode(
-    OrientedDistanceNode& node, const BVHModel<BV>& model1,
-    const Transform3<typename BV::S>& tf1, const BVHModel<BV>& model2,
-    const Transform3<typename BV::S>& tf2, typename BV::S w) {
-  if (model1.getModelType() != BVH_MODEL_TRIANGLES ||
-      model2.getModelType() != BVH_MODEL_TRIANGLES)
+    OrientedDistanceNode& node,
+    const BVHModel<BV>& model1, const Transform3<typename BV::S>& tf1,
+    const BVHModel<BV>& model2, const Transform3<typename BV::S>& tf2,
+    typename BV::S w)
+{
+  if(model1.getModelType() != BVH_MODEL_TRIANGLES || model2.getModelType() != BVH_MODEL_TRIANGLES)
     return false;
 
   node.model1 = &model1;
@@ -621,32 +767,40 @@ bool setupMeshConservativeAdvancementOrientedDistanceNode(
 
   node.w = w;
 
-  relativeTransform(tf1.linear(), tf1.translation(), tf2.linear(),
-                    tf2.translation(), node.R, node.T);
+  relativeTransform(tf1.linear(), tf1.translation(), tf2.linear(), tf2.translation(), node.R, node.T);
 
   return true;
 }
 
 //==============================================================================
 template <typename S>
-bool initialize(MeshConservativeAdvancementTraversalNodeRSS<S>& node,
-                const BVHModel<RSS<S>>& model1, const Transform3<S>& tf1,
-                const BVHModel<RSS<S>>& model2, const Transform3<S>& tf2, S w) {
+bool initialize(
+    MeshConservativeAdvancementTraversalNodeRSS<S>& node,
+    const BVHModel<RSS<S>>& model1,
+    const Transform3<S>& tf1,
+    const BVHModel<RSS<S>>& model2,
+    const Transform3<S>& tf2,
+    S w)
+{
   return detail::setupMeshConservativeAdvancementOrientedDistanceNode(
-      node, model1, tf1, model2, tf2, w);
+        node, model1, tf1, model2, tf2, w);
 }
 
 //==============================================================================
 template <typename S>
-bool initialize(MeshConservativeAdvancementTraversalNodeOBBRSS<S>& node,
-                const BVHModel<OBBRSS<S>>& model1, const Transform3<S>& tf1,
-                const BVHModel<OBBRSS<S>>& model2, const Transform3<S>& tf2,
-                S w) {
+bool initialize(
+    MeshConservativeAdvancementTraversalNodeOBBRSS<S>& node,
+    const BVHModel<OBBRSS<S>>& model1,
+    const Transform3<S>& tf1,
+    const BVHModel<OBBRSS<S>>& model2,
+    const Transform3<S>& tf2,
+    S w)
+{
   return detail::setupMeshConservativeAdvancementOrientedDistanceNode(
-      node, model1, tf1, model2, tf2, w);
+        node, model1, tf1, model2, tf2, w);
 }
 
-}  // namespace detail
-}  // namespace fcl
+} // namespace detail
+} // namespace fcl
 
 #endif

--- a/include/fcl/narrowphase/detail/traversal/distance/mesh_conservative_advancement_traversal_node-inl.h
+++ b/include/fcl/narrowphase/detail/traversal/distance/mesh_conservative_advancement_traversal_node-inl.h
@@ -38,51 +38,41 @@
 #ifndef FCL_TRAVERSAL_MESHCONSERVATIVEADVANCEMENTTRAVERSALNODE_INL_H
 #define FCL_TRAVERSAL_MESHCONSERVATIVEADVANCEMENTTRAVERSALNODE_INL_H
 
-#include "fcl/narrowphase/detail/traversal/distance/mesh_conservative_advancement_traversal_node.h"
-
 #include "fcl/math/bv/RSS.h"
 #include "fcl/math/motion/triangle_motion_bound_visitor.h"
+#include "fcl/narrowphase/detail/traversal/distance/mesh_conservative_advancement_traversal_node.h"
 
-namespace fcl
-{
+namespace fcl {
 
-namespace detail
-{
-
-//==============================================================================
-extern template
-class FCL_EXPORT MeshConservativeAdvancementTraversalNodeRSS<double>;
+namespace detail {
 
 //==============================================================================
-extern template
-bool initialize(
+extern template class FCL_EXPORT
+    MeshConservativeAdvancementTraversalNodeRSS<double>;
+
+//==============================================================================
+extern template bool initialize(
     MeshConservativeAdvancementTraversalNodeRSS<double>& node,
-    const BVHModel<RSS<double>>& model1,
-    const Transform3<double>& tf1,
-    const BVHModel<RSS<double>>& model2,
-    const Transform3<double>& tf2,
+    const BVHModel<RSS<double>>& model1, const Transform3<double>& tf1,
+    const BVHModel<RSS<double>>& model2, const Transform3<double>& tf2,
     double w);
 
 //==============================================================================
-extern template
-class FCL_EXPORT MeshConservativeAdvancementTraversalNodeOBBRSS<double>;
+extern template class FCL_EXPORT
+    MeshConservativeAdvancementTraversalNodeOBBRSS<double>;
 
 //==============================================================================
-extern template
-bool initialize(
+extern template bool initialize(
     MeshConservativeAdvancementTraversalNodeOBBRSS<double>& node,
-    const BVHModel<OBBRSS<double>>& model1,
-    const Transform3<double>& tf1,
-    const BVHModel<OBBRSS<double>>& model2,
-    const Transform3<double>& tf2,
+    const BVHModel<OBBRSS<double>>& model1, const Transform3<double>& tf1,
+    const BVHModel<OBBRSS<double>>& model2, const Transform3<double>& tf2,
     double w);
 
 //==============================================================================
 template <typename BV>
-MeshConservativeAdvancementTraversalNode<BV>::
-MeshConservativeAdvancementTraversalNode(typename BV::S w_)
-  : MeshDistanceTraversalNode<BV>()
-{
+MeshConservativeAdvancementTraversalNode<
+    BV>::MeshConservativeAdvancementTraversalNode(typename BV::S w_)
+    : MeshDistanceTraversalNode<BV>() {
   delta_t = 1;
   toc = 0;
   t_err = (S)0.00001;
@@ -95,10 +85,9 @@ MeshConservativeAdvancementTraversalNode(typename BV::S w_)
 
 //==============================================================================
 template <typename BV>
-typename BV::S
-MeshConservativeAdvancementTraversalNode<BV>::BVTesting(int b1, int b2) const
-{
-  if(this->enable_statistics) this->num_bv_tests++;
+typename BV::S MeshConservativeAdvancementTraversalNode<BV>::BVTesting(
+    int b1, int b2) const {
+  if (this->enable_statistics) this->num_bv_tests++;
   Vector3<S> P1, P2;
   S d = this->model1->getBV(b1).distance(this->model2->getBV(b2), &P1, &P2);
 
@@ -109,9 +98,9 @@ MeshConservativeAdvancementTraversalNode<BV>::BVTesting(int b1, int b2) const
 
 //==============================================================================
 template <typename BV>
-void MeshConservativeAdvancementTraversalNode<BV>::leafTesting(int b1, int b2) const
-{
-  if(this->enable_statistics) this->num_leaf_tests++;
+void MeshConservativeAdvancementTraversalNode<BV>::leafTesting(int b1,
+                                                               int b2) const {
+  if (this->enable_statistics) this->num_leaf_tests++;
 
   const BVNode<BV>& node1 = this->model1->getBV(b1);
   const BVNode<BV>& node2 = this->model2->getBV(b2);
@@ -133,11 +122,9 @@ void MeshConservativeAdvancementTraversalNode<BV>::leafTesting(int b1, int b2) c
   // nearest point pair
   Vector3<S> P1, P2;
 
-  S d = TriangleDistance<S>::triDistance(p1, p2, p3, q1, q2, q3,
-                                           P1, P2);
+  S d = TriangleDistance<S>::triDistance(p1, p2, p3, q1, q2, q3, P1, P2);
 
-  if(d < this->min_distance)
-  {
+  if (d < this->min_distance) {
     this->min_distance = d;
 
     closest_p1 = P1;
@@ -149,77 +136,77 @@ void MeshConservativeAdvancementTraversalNode<BV>::leafTesting(int b1, int b2) c
 
   Vector3<S> n = P2 - P1;
   n.normalize();
-  // here n is already in global frame as we assume the body is in original configuration (I, 0) for general BVH
-  TriangleMotionBoundVisitor<S> mb_visitor1(p1, p2, p3, n), mb_visitor2(q1, q2, q3, n);
+  // here n is already in global frame as we assume the body is in original
+  // configuration (I, 0) for general BVH
+  TriangleMotionBoundVisitor<S> mb_visitor1(p1, p2, p3, n),
+      mb_visitor2(q1, q2, q3, n);
   S bound1 = motion1->computeMotionBound(mb_visitor1);
   S bound2 = motion2->computeMotionBound(mb_visitor2);
 
-  S bound = bound1 + bound2;
+  S bound = std::abs(bound1) + std::abs(bound2);
 
   S cur_delta_t;
-  if(bound <= d) cur_delta_t = 1;
-  else cur_delta_t = d / bound;
+  if (bound <= d)
+    cur_delta_t = 1;
+  else
+    cur_delta_t = d / bound;
 
-  if(cur_delta_t < delta_t)
-    delta_t = cur_delta_t;
+  if (cur_delta_t < delta_t) delta_t = cur_delta_t;
 }
 
 //==============================================================================
 template <typename S, typename BV>
-struct CanStopImpl
-{
-  static bool run(
-      const MeshConservativeAdvancementTraversalNode<BV>& node, S c)
-  {
-    if((c >= node.w * (node.min_distance - node.abs_err))
-       && (c * (1 + node.rel_err) >= node.w * node.min_distance))
-    {
+struct CanStopImpl {
+  static bool run(const MeshConservativeAdvancementTraversalNode<BV>& node,
+                  S c) {
+    if ((c >= node.w * (node.min_distance - node.abs_err)) &&
+        (c * (1 + node.rel_err) >= node.w * node.min_distance)) {
       const ConservativeAdvancementStackData<S>& data = node.stack.back();
       S d = data.d;
       Vector3<S> n;
       int c1, c2;
 
-      if(d > c)
-      {
-        const ConservativeAdvancementStackData<S>& data2 = node.stack[node.stack.size() - 2];
+      if (d > c) {
+        const ConservativeAdvancementStackData<S>& data2 =
+            node.stack[node.stack.size() - 2];
         d = data2.d;
-        n = data2.P2 - data2.P1; n.normalize();
+        n = data2.P2 - data2.P1;
+        n.normalize();
         c1 = data2.c1;
         c2 = data2.c2;
         node.stack[node.stack.size() - 2] = node.stack[node.stack.size() - 1];
-      }
-      else
-      {
-        n = data.P2 - data.P1; n.normalize();
+      } else {
+        n = data.P2 - data.P1;
+        n.normalize();
         c1 = data.c1;
         c2 = data.c2;
       }
 
       assert(c == d);
 
-      TBVMotionBoundVisitor<BV> mb_visitor1(node.model1->getBV(c1).bv, n), mb_visitor2(node.model2->getBV(c2).bv, n);
+      TBVMotionBoundVisitor<BV> mb_visitor1(node.model1->getBV(c1).bv, n),
+          mb_visitor2(node.model2->getBV(c2).bv, n);
       S bound1 = node.motion1->computeMotionBound(mb_visitor1);
       S bound2 = node.motion2->computeMotionBound(mb_visitor2);
 
       S bound = bound1 + bound2;
 
       S cur_delta_t;
-      if(bound <= c) cur_delta_t = 1;
-      else cur_delta_t = c / bound;
+      if (bound <= c)
+        cur_delta_t = 1;
+      else
+        cur_delta_t = c / bound;
 
-      if(cur_delta_t < node.delta_t)
-        node.delta_t = cur_delta_t;
+      if (cur_delta_t < node.delta_t) node.delta_t = cur_delta_t;
 
       node.stack.pop_back();
 
       return true;
-    }
-    else
-    {
+    } else {
       const ConservativeAdvancementStackData<S>& data = node.stack.back();
       S d = data.d;
 
-      if(d > c)
+      if (d > c)
         node.stack[node.stack.size() - 2] = node.stack[node.stack.size() - 1];
 
       node.stack.pop_back();
@@ -232,105 +219,60 @@ struct CanStopImpl
 //==============================================================================
 template <typename BV>
 bool MeshConservativeAdvancementTraversalNode<BV>::canStop(
-    typename BV::S c) const
-{
+    typename BV::S c) const {
   return CanStopImpl<typename BV::S, BV>::run(*this, c);
 }
 
 //==============================================================================
 template <typename S>
-struct CanStopImpl<S, OBB<S>>
-{
-  static bool run(
-      const MeshConservativeAdvancementTraversalNode<OBB<S>>& node,
-      S c)
-  {
+struct CanStopImpl<S, OBB<S>> {
+  static bool run(const MeshConservativeAdvancementTraversalNode<OBB<S>>& node,
+                  S c) {
     return detail::meshConservativeAdvancementTraversalNodeCanStop(
-          c,
-          node.min_distance,
-          node.abs_err,
-          node.rel_err,
-          node.w,
-          node.model1,
-          node.model2,
-          node.motion1,
-          node.motion2,
-          node.stack,
-          node.delta_t);
+        c, node.min_distance, node.abs_err, node.rel_err, node.w, node.model1,
+        node.model2, node.motion1, node.motion2, node.stack, node.delta_t);
   }
 };
 
 //==============================================================================
 template <typename S>
-struct CanStopImpl<S, RSS<S>>
-{
-  static bool run(
-      const MeshConservativeAdvancementTraversalNode<RSS<S>>& node,
-      S c)
-  {
+struct CanStopImpl<S, RSS<S>> {
+  static bool run(const MeshConservativeAdvancementTraversalNode<RSS<S>>& node,
+                  S c) {
     return detail::meshConservativeAdvancementTraversalNodeCanStop(
-          c,
-          node.min_distance,
-          node.abs_err,
-          node.rel_err,
-          node.w,
-          node.model1,
-          node.model2,
-          node.motion1,
-          node.motion2,
-          node.stack,
-          node.delta_t);
+        c, node.min_distance, node.abs_err, node.rel_err, node.w, node.model1,
+        node.model2, node.motion1, node.motion2, node.stack, node.delta_t);
   }
 };
 
 //==============================================================================
 template <typename S>
-struct CanStopImpl<S, OBBRSS<S>>
-{
+struct CanStopImpl<S, OBBRSS<S>> {
   static bool run(
-      const MeshConservativeAdvancementTraversalNode<OBBRSS<S>>& node,
-      S c)
-  {
+      const MeshConservativeAdvancementTraversalNode<OBBRSS<S>>& node, S c) {
     return detail::meshConservativeAdvancementTraversalNodeCanStop(
-          c,
-          node.min_distance,
-          node.abs_err,
-          node.rel_err,
-          node.w,
-          node.model1,
-          node.model2,
-          node.motion1,
-          node.motion2,
-          node.stack,
-          node.delta_t);
+        c, node.min_distance, node.abs_err, node.rel_err, node.w, node.model1,
+        node.model2, node.motion1, node.motion2, node.stack, node.delta_t);
   }
 };
 
 //==============================================================================
 template <typename BV>
-bool initialize(
-    MeshConservativeAdvancementTraversalNode<BV>& node,
-    BVHModel<BV>& model1,
-    const Transform3<typename BV::S>& tf1,
-    BVHModel<BV>& model2,
-    const Transform3<typename BV::S>& tf2,
-    typename BV::S w,
-    bool use_refit,
-    bool refit_bottomup)
-{
+bool initialize(MeshConservativeAdvancementTraversalNode<BV>& node,
+                BVHModel<BV>& model1, const Transform3<typename BV::S>& tf1,
+                BVHModel<BV>& model2, const Transform3<typename BV::S>& tf2,
+                typename BV::S w, bool use_refit, bool refit_bottomup) {
   using S = typename BV::S;
 
   std::vector<Vector3<S>> vertices_transformed1(model1.num_vertices);
-  for(int i = 0; i < model1.num_vertices; ++i)
-  {
+  for (int i = 0; i < model1.num_vertices; ++i) {
     Vector3<S>& p = model1.vertices[i];
     Vector3<S> new_v = tf1 * p;
     vertices_transformed1[i] = new_v;
   }
 
   std::vector<Vector3<S>> vertices_transformed2(model2.num_vertices);
-  for(int i = 0; i < model2.num_vertices; ++i)
-  {
+  for (int i = 0; i < model2.num_vertices; ++i) {
     Vector3<S>& p = model2.vertices[i];
     Vector3<S> new_v = tf2 * p;
     vertices_transformed2[i] = new_v;
@@ -360,140 +302,82 @@ bool initialize(
 
 //==============================================================================
 template <typename S>
-MeshConservativeAdvancementTraversalNodeRSS<S>::
-MeshConservativeAdvancementTraversalNodeRSS(S w_)
-  : MeshConservativeAdvancementTraversalNode<RSS<S>>(w_)
-{
+MeshConservativeAdvancementTraversalNodeRSS<
+    S>::MeshConservativeAdvancementTraversalNodeRSS(S w_)
+    : MeshConservativeAdvancementTraversalNode<RSS<S>>(w_) {
   R.setIdentity();
 }
 
 //==============================================================================
 template <typename S>
-void MeshConservativeAdvancementTraversalNodeRSS<S>::
-leafTesting(int b1, int b2) const
-{
+void MeshConservativeAdvancementTraversalNodeRSS<S>::leafTesting(int b1,
+                                                                 int b2) const {
   detail::meshConservativeAdvancementOrientedNodeLeafTesting(
-        b1,
-        b2,
-        this->model1,
-        this->model2,
-        this->tri_indices1,
-        this->tri_indices2,
-        this->vertices1,
-        this->vertices2,
-        R,
-        T,
-        this->motion1,
-        this->motion2,
-        this->enable_statistics,
-        this->min_distance,
-        this->closest_p1,
-        this->closest_p2,
-        this->last_tri_id1,
-        this->last_tri_id2,
-        this->delta_t,
-        this->num_leaf_tests);
+      b1, b2, this->model1, this->model2, this->tri_indices1,
+      this->tri_indices2, this->vertices1, this->vertices2, R, T, this->motion1,
+      this->motion2, this->enable_statistics, this->min_distance,
+      this->closest_p1, this->closest_p2, this->last_tri_id1,
+      this->last_tri_id2, this->delta_t, this->num_leaf_tests);
 }
 
 //==============================================================================
 template <typename S>
-bool MeshConservativeAdvancementTraversalNodeRSS<S>::canStop(S c) const
-{
+bool MeshConservativeAdvancementTraversalNodeRSS<S>::canStop(S c) const {
   return detail::meshConservativeAdvancementOrientedNodeCanStop(
-        c,
-        this->min_distance,
-        this->abs_err,
-        this->rel_err,
-        this->w,
-        this->model1,
-        this->model2,
-        this->motion1,
-        this->motion2,
-        this->stack,
-        this->delta_t);
+      c, this->min_distance, this->abs_err, this->rel_err, this->w,
+      this->model1, this->model2, this->motion1, this->motion2, this->stack,
+      this->delta_t);
 }
 
 //==============================================================================
 template <typename S>
-MeshConservativeAdvancementTraversalNodeOBBRSS<S>::
-MeshConservativeAdvancementTraversalNodeOBBRSS(S w_)
-  : MeshConservativeAdvancementTraversalNode<OBBRSS<S>>(w_)
-{
+MeshConservativeAdvancementTraversalNodeOBBRSS<
+    S>::MeshConservativeAdvancementTraversalNodeOBBRSS(S w_)
+    : MeshConservativeAdvancementTraversalNode<OBBRSS<S>>(w_) {
   R.setIdentity();
 }
 
 //==============================================================================
 template <typename S>
-void MeshConservativeAdvancementTraversalNodeOBBRSS<S>::
-leafTesting(int b1, int b2) const
-{
+void MeshConservativeAdvancementTraversalNodeOBBRSS<S>::leafTesting(
+    int b1, int b2) const {
   detail::meshConservativeAdvancementOrientedNodeLeafTesting(
-        b1,
-        b2,
-        this->model1,
-        this->model2,
-        this->tri_indices1,
-        this->tri_indices2,
-        this->vertices1,
-        this->vertices2,
-        this->R,
-        this->T,
-        this->motion1,
-        this->motion2,
-        this->enable_statistics,
-        this->min_distance,
-        this->closest_p1,
-        this->closest_p2,
-        this->last_tri_id1,
-        this->last_tri_id2,
-        this->delta_t,
-        this->num_leaf_tests);
+      b1, b2, this->model1, this->model2, this->tri_indices1,
+      this->tri_indices2, this->vertices1, this->vertices2, this->R, this->T,
+      this->motion1, this->motion2, this->enable_statistics, this->min_distance,
+      this->closest_p1, this->closest_p2, this->last_tri_id1,
+      this->last_tri_id2, this->delta_t, this->num_leaf_tests);
 }
 
 //==============================================================================
 template <typename S>
-bool MeshConservativeAdvancementTraversalNodeOBBRSS<S>::canStop(S c) const
-{
+bool MeshConservativeAdvancementTraversalNodeOBBRSS<S>::canStop(S c) const {
   return detail::meshConservativeAdvancementOrientedNodeCanStop(
-        c,
-        this->min_distance,
-        this->abs_err,
-        this->rel_err,
-        this->w,
-        this->model1,
-        this->model2,
-        this->motion1,
-        this->motion2,
-        this->stack,
-        this->delta_t);
+      c, this->min_distance, this->abs_err, this->rel_err, this->w,
+      this->model1, this->model2, this->motion1, this->motion2, this->stack,
+      this->delta_t);
 }
 
-/// @brief for OBB and RSS, there is local coordinate of BV, so normal need to be transformed
+/// @brief for OBB and RSS, there is local coordinate of BV, so normal need to
+/// be transformed
 
 //==============================================================================
 template <typename S, typename BV>
-struct GetBVAxisImpl
-{
-  const Vector3<S> operator()(const BV& bv, int i)
-  {
-    return bv.axis.col(i);
-  }
+struct GetBVAxisImpl {
+  const Vector3<S> operator()(const BV& bv, int i) { return bv.axis.col(i); }
 };
 
 //==============================================================================
 template <typename BV>
-const Vector3<typename BV::S> getBVAxis(const BV& bv, int i)
-{
+const Vector3<typename BV::S> getBVAxis(const BV& bv, int i) {
   GetBVAxisImpl<typename BV::S, BV> getBVAxisImpl;
   return getBVAxisImpl(bv, i);
 }
 
 //==============================================================================
 template <typename S>
-struct GetBVAxisImpl<S, OBBRSS<S>>
-{
-  const Vector3<S> operator()(const OBBRSS<S>& bv, int i)
-  {
+struct GetBVAxisImpl<S, OBBRSS<S>> {
+  const Vector3<S> operator()(const OBBRSS<S>& bv, int i) {
     return bv.obb.axis.col(i);
   }
 };
@@ -501,74 +385,66 @@ struct GetBVAxisImpl<S, OBBRSS<S>>
 //==============================================================================
 template <typename BV>
 bool meshConservativeAdvancementTraversalNodeCanStop(
-    typename BV::S c,
-    typename BV::S min_distance,
-    typename BV::S abs_err,
-    typename BV::S rel_err,
-    typename BV::S w,
-    const BVHModel<BV>* model1,
-    const BVHModel<BV>* model2,
-    const MotionBase<typename BV::S>* motion1,
+    typename BV::S c, typename BV::S min_distance, typename BV::S abs_err,
+    typename BV::S rel_err, typename BV::S w, const BVHModel<BV>* model1,
+    const BVHModel<BV>* model2, const MotionBase<typename BV::S>* motion1,
     const MotionBase<typename BV::S>* motion2,
     std::vector<ConservativeAdvancementStackData<typename BV::S>>& stack,
-    typename BV::S& delta_t)
-{
+    typename BV::S& delta_t) {
   using S = typename BV::S;
 
-  if((c >= w * (min_distance - abs_err)) && (c * (1 + rel_err) >= w * min_distance))
-  {
+  if ((c >= w * (min_distance - abs_err)) &&
+      (c * (1 + rel_err) >= w * min_distance)) {
     const ConservativeAdvancementStackData<S>& data = stack.back();
     S d = data.d;
     Vector3<S> n;
     int c1, c2;
 
-    if(d > c)
-    {
-      const ConservativeAdvancementStackData<S>& data2 = stack[stack.size() - 2];
+    if (d > c) {
+      const ConservativeAdvancementStackData<S>& data2 =
+          stack[stack.size() - 2];
       d = data2.d;
-      n = data2.P2 - data2.P1; n.normalize();
+      n = data2.P2 - data2.P1;
+      n.normalize();
       c1 = data2.c1;
       c2 = data2.c2;
       stack[stack.size() - 2] = stack[stack.size() - 1];
-    }
-    else
-    {
-      n = data.P2 - data.P1; n.normalize();
+    } else {
+      n = data.P2 - data.P1;
+      n.normalize();
       c1 = data.c1;
       c2 = data.c2;
     }
 
     assert(c == d);
 
-    Vector3<S> n_transformed =
-        getBVAxis(model1->getBV(c1).bv, 0) * n[0] +
-        getBVAxis(model1->getBV(c1).bv, 1) * n[1] +
-        getBVAxis(model1->getBV(c1).bv, 2) * n[2];
+    Vector3<S> n_transformed = getBVAxis(model1->getBV(c1).bv, 0) * n[0] +
+                               getBVAxis(model1->getBV(c1).bv, 1) * n[1] +
+                               getBVAxis(model1->getBV(c1).bv, 2) * n[2];
 
-    TBVMotionBoundVisitor<BV> mb_visitor1(model1->getBV(c1).bv, n_transformed), mb_visitor2(model2->getBV(c2).bv, n_transformed);
+    TBVMotionBoundVisitor<BV> mb_visitor1(model1->getBV(c1).bv, n_transformed),
+        mb_visitor2(model2->getBV(c2).bv, n_transformed);
     S bound1 = motion1->computeMotionBound(mb_visitor1);
     S bound2 = motion2->computeMotionBound(mb_visitor2);
 
     S bound = bound1 + bound2;
 
     S cur_delta_t;
-    if(bound <= c) cur_delta_t = 1;
-    else cur_delta_t = c / bound;
+    if (bound <= c)
+      cur_delta_t = 1;
+    else
+      cur_delta_t = c / bound;
 
-    if(cur_delta_t < delta_t)
-      delta_t = cur_delta_t;
+    if (cur_delta_t < delta_t) delta_t = cur_delta_t;
 
     stack.pop_back();
 
     return true;
-  }
-  else
-  {
+  } else {
     const ConservativeAdvancementStackData<S>& data = stack.back();
     S d = data.d;
 
-    if(d > c)
-      stack[stack.size() - 2] = stack[stack.size() - 1];
+    if (d > c) stack[stack.size() - 2] = stack[stack.size() - 1];
 
     stack.pop_back();
 
@@ -579,39 +455,33 @@ bool meshConservativeAdvancementTraversalNodeCanStop(
 //==============================================================================
 template <typename BV>
 bool meshConservativeAdvancementOrientedNodeCanStop(
-    typename BV::S c,
-    typename BV::S min_distance,
-    typename BV::S abs_err,
-    typename BV::S rel_err,
-    typename BV::S w,
-    const BVHModel<BV>* model1,
-    const BVHModel<BV>* model2,
-    const MotionBase<typename BV::S>* motion1,
+    typename BV::S c, typename BV::S min_distance, typename BV::S abs_err,
+    typename BV::S rel_err, typename BV::S w, const BVHModel<BV>* model1,
+    const BVHModel<BV>* model2, const MotionBase<typename BV::S>* motion1,
     const MotionBase<typename BV::S>* motion2,
     std::vector<ConservativeAdvancementStackData<typename BV::S>>& stack,
-    typename BV::S& delta_t)
-{
+    typename BV::S& delta_t) {
   using S = typename BV::S;
 
-  if((c >= w * (min_distance - abs_err)) && (c * (1 + rel_err) >= w * min_distance))
-  {
+  if ((c >= w * (min_distance - abs_err)) &&
+      (c * (1 + rel_err) >= w * min_distance)) {
     const ConservativeAdvancementStackData<S>& data = stack.back();
     S d = data.d;
     Vector3<S> n;
     int c1, c2;
 
-    if(d > c)
-    {
-      const ConservativeAdvancementStackData<S>& data2 = stack[stack.size() - 2];
+    if (d > c) {
+      const ConservativeAdvancementStackData<S>& data2 =
+          stack[stack.size() - 2];
       d = data2.d;
-      n = data2.P2 - data2.P1; n.normalize();
+      n = data2.P2 - data2.P1;
+      n.normalize();
       c1 = data2.c1;
       c2 = data2.c2;
       stack[stack.size() - 2] = stack[stack.size() - 1];
-    }
-    else
-    {
-      n = data.P2 - data.P1; n.normalize();
+    } else {
+      n = data.P2 - data.P1;
+      n.normalize();
       c1 = data.c1;
       c2 = data.c2;
     }
@@ -619,39 +489,37 @@ bool meshConservativeAdvancementOrientedNodeCanStop(
     assert(c == d);
 
     // n is in local frame of c1, so we need to turn n into the global frame
-    Vector3<S> n_transformed =
-      getBVAxis(model1->getBV(c1).bv, 0) * n[0] +
-      getBVAxis(model1->getBV(c1).bv, 1) * n[1] +
-      getBVAxis(model1->getBV(c1).bv, 2) * n[2];
+    Vector3<S> n_transformed = getBVAxis(model1->getBV(c1).bv, 0) * n[0] +
+                               getBVAxis(model1->getBV(c1).bv, 1) * n[1] +
+                               getBVAxis(model1->getBV(c1).bv, 2) * n[2];
     Quaternion<S> R0;
     motion1->getCurrentRotation(R0);
     n_transformed = R0 * n_transformed;
     n_transformed.normalize();
 
-    TBVMotionBoundVisitor<BV> mb_visitor1(model1->getBV(c1).bv, n_transformed), mb_visitor2(model2->getBV(c2).bv, -n_transformed);
+    TBVMotionBoundVisitor<BV> mb_visitor1(model1->getBV(c1).bv, n_transformed),
+        mb_visitor2(model2->getBV(c2).bv, -n_transformed);
     S bound1 = motion1->computeMotionBound(mb_visitor1);
     S bound2 = motion2->computeMotionBound(mb_visitor2);
 
     S bound = bound1 + bound2;
 
     S cur_delta_t;
-    if(bound <= c) cur_delta_t = 1;
-    else cur_delta_t = c / bound;
+    if (bound <= c)
+      cur_delta_t = 1;
+    else
+      cur_delta_t = c / bound;
 
-    if(cur_delta_t < delta_t)
-      delta_t = cur_delta_t;
+    if (cur_delta_t < delta_t) delta_t = cur_delta_t;
 
     stack.pop_back();
 
     return true;
-  }
-  else
-  {
+  } else {
     const ConservativeAdvancementStackData<S>& data = stack.back();
     S d = data.d;
 
-    if(d > c)
-      stack[stack.size() - 2] = stack[stack.size() - 1];
+    if (d > c) stack[stack.size() - 2] = stack[stack.size() - 1];
 
     stack.pop_back();
 
@@ -662,30 +530,18 @@ bool meshConservativeAdvancementOrientedNodeCanStop(
 //==============================================================================
 template <typename BV>
 void meshConservativeAdvancementOrientedNodeLeafTesting(
-    int b1,
-    int b2,
-    const BVHModel<BV>* model1,
-    const BVHModel<BV>* model2,
-    const Triangle* tri_indices1,
-    const Triangle* tri_indices2,
+    int b1, int b2, const BVHModel<BV>* model1, const BVHModel<BV>* model2,
+    const Triangle* tri_indices1, const Triangle* tri_indices2,
     const Vector3<typename BV::S>* vertices1,
-    const Vector3<typename BV::S>* vertices2,
-    const Matrix3<typename BV::S>& R,
-    const Vector3<typename BV::S>& T,
-    const MotionBase<typename BV::S>* motion1,
-    const MotionBase<typename BV::S>* motion2,
-    bool enable_statistics,
-    typename BV::S& min_distance,
-    Vector3<typename BV::S>& p1,
-    Vector3<typename BV::S>& p2,
-    int& last_tri_id1,
-    int& last_tri_id2,
-    typename BV::S& delta_t,
-    int& num_leaf_tests)
-{
+    const Vector3<typename BV::S>* vertices2, const Matrix3<typename BV::S>& R,
+    const Vector3<typename BV::S>& T, const MotionBase<typename BV::S>* motion1,
+    const MotionBase<typename BV::S>* motion2, bool enable_statistics,
+    typename BV::S& min_distance, Vector3<typename BV::S>& p1,
+    Vector3<typename BV::S>& p2, int& last_tri_id1, int& last_tri_id2,
+    typename BV::S& delta_t, int& num_leaf_tests) {
   using S = typename BV::S;
 
-  if(enable_statistics) num_leaf_tests++;
+  if (enable_statistics) num_leaf_tests++;
 
   const BVNode<BV>& node1 = model1->getBV(b1);
   const BVNode<BV>& node2 = model2->getBV(b2);
@@ -707,12 +563,10 @@ void meshConservativeAdvancementOrientedNodeLeafTesting(
   // nearest point pair
   Vector3<S> P1, P2;
 
-  S d = TriangleDistance<S>::triDistance(t11, t12, t13, t21, t22, t23,
-                                           R, T,
-                                           P1, P2);
+  S d = TriangleDistance<S>::triDistance(t11, t12, t13, t21, t22, t23, R, T, P1,
+                                         P2);
 
-  if(d < min_distance)
-  {
+  if (d < min_distance) {
     min_distance = d;
 
     p1 = P1;
@@ -722,38 +576,38 @@ void meshConservativeAdvancementOrientedNodeLeafTesting(
     last_tri_id2 = primitive_id2;
   }
 
-
   /// n is the local frame of object 1, pointing from object 1 to object2
   Vector3<S> n = P2 - P1;
   /// turn n into the global frame, pointing from object 1 to object 2
   Quaternion<S> R0;
   motion1->getCurrentRotation(R0);
   Vector3<S> n_transformed = R0 * n;
-  n_transformed.normalize(); // normalized here
+  n_transformed.normalize();  // normalized here
 
-  TriangleMotionBoundVisitor<S> mb_visitor1(t11, t12, t13, n_transformed), mb_visitor2(t21, t22, t23, -n_transformed);
+  TriangleMotionBoundVisitor<S> mb_visitor1(t11, t12, t13, n_transformed),
+      mb_visitor2(t21, t22, t23, -n_transformed);
   S bound1 = motion1->computeMotionBound(mb_visitor1);
   S bound2 = motion2->computeMotionBound(mb_visitor2);
 
   S bound = bound1 + bound2;
 
   S cur_delta_t;
-  if(bound <= d) cur_delta_t = 1;
-  else cur_delta_t = d / bound;
+  if (bound <= d)
+    cur_delta_t = 1;
+  else
+    cur_delta_t = d / bound;
 
-  if(cur_delta_t < delta_t)
-    delta_t = cur_delta_t;
+  if (cur_delta_t < delta_t) delta_t = cur_delta_t;
 }
 
 //==============================================================================
 template <typename BV, typename OrientedDistanceNode>
 bool setupMeshConservativeAdvancementOrientedDistanceNode(
-    OrientedDistanceNode& node,
-    const BVHModel<BV>& model1, const Transform3<typename BV::S>& tf1,
-    const BVHModel<BV>& model2, const Transform3<typename BV::S>& tf2,
-    typename BV::S w)
-{
-  if(model1.getModelType() != BVH_MODEL_TRIANGLES || model2.getModelType() != BVH_MODEL_TRIANGLES)
+    OrientedDistanceNode& node, const BVHModel<BV>& model1,
+    const Transform3<typename BV::S>& tf1, const BVHModel<BV>& model2,
+    const Transform3<typename BV::S>& tf2, typename BV::S w) {
+  if (model1.getModelType() != BVH_MODEL_TRIANGLES ||
+      model2.getModelType() != BVH_MODEL_TRIANGLES)
     return false;
 
   node.model1 = &model1;
@@ -767,40 +621,32 @@ bool setupMeshConservativeAdvancementOrientedDistanceNode(
 
   node.w = w;
 
-  relativeTransform(tf1.linear(), tf1.translation(), tf2.linear(), tf2.translation(), node.R, node.T);
+  relativeTransform(tf1.linear(), tf1.translation(), tf2.linear(),
+                    tf2.translation(), node.R, node.T);
 
   return true;
 }
 
 //==============================================================================
 template <typename S>
-bool initialize(
-    MeshConservativeAdvancementTraversalNodeRSS<S>& node,
-    const BVHModel<RSS<S>>& model1,
-    const Transform3<S>& tf1,
-    const BVHModel<RSS<S>>& model2,
-    const Transform3<S>& tf2,
-    S w)
-{
+bool initialize(MeshConservativeAdvancementTraversalNodeRSS<S>& node,
+                const BVHModel<RSS<S>>& model1, const Transform3<S>& tf1,
+                const BVHModel<RSS<S>>& model2, const Transform3<S>& tf2, S w) {
   return detail::setupMeshConservativeAdvancementOrientedDistanceNode(
-        node, model1, tf1, model2, tf2, w);
+      node, model1, tf1, model2, tf2, w);
 }
 
 //==============================================================================
 template <typename S>
-bool initialize(
-    MeshConservativeAdvancementTraversalNodeOBBRSS<S>& node,
-    const BVHModel<OBBRSS<S>>& model1,
-    const Transform3<S>& tf1,
-    const BVHModel<OBBRSS<S>>& model2,
-    const Transform3<S>& tf2,
-    S w)
-{
+bool initialize(MeshConservativeAdvancementTraversalNodeOBBRSS<S>& node,
+                const BVHModel<OBBRSS<S>>& model1, const Transform3<S>& tf1,
+                const BVHModel<OBBRSS<S>>& model2, const Transform3<S>& tf2,
+                S w) {
   return detail::setupMeshConservativeAdvancementOrientedDistanceNode(
-        node, model1, tf1, model2, tf2, w);
+      node, model1, tf1, model2, tf2, w);
 }
 
-} // namespace detail
-} // namespace fcl
+}  // namespace detail
+}  // namespace fcl
 
 #endif


### PR DESCRIPTION
Two boxes translated towards each other fail `continuousCollide`.   When the bounds in `MeshConservativeAdvancementTraversalNode<BV>::leafTesting is computed`, the bounds values are signed.  When summed together, they can offset leaving the value for `cur_delta_t` incorrect.

If their absolute values are summed, the test case below succeeds.

```
#include "fcl/math/bv/utility.h"
#include "fcl/narrowphase/collision.h"
#include "fcl/narrowphase/continuous_collision.h"
#include "fcl/narrowphase/detail/gjk_solver_indep.h"
#include "fcl/narrowphase/detail/gjk_solver_libccd.h"
#include "fcl/narrowphase/detail/traversal/collision_node.h"
#include "fcl_resources/config.h"
#include "test_fcl_utility.h"

using BVHModel = fcl::BVHModel<fcl::OBBRSSd>;
using Vector3 = fcl::Vector3<double>;
using Transform3 = fcl::Transform3<double>;
using CollisionObject = fcl::CollisionObject<double>;
using CollisionRequest = fcl::CollisionRequest<double>;
using CollisionResult = fcl::CollisionResult<double>;
using ContinuousCollisionRequest = fcl::ContinuousCollisionRequest<double>;
using ContinuousCollisionResult = fcl::ContinuousCollisionResult<double>;

int main(int argc, char* argv[]) {
  auto verts1 =
      std::vector<Vector3>{Vector3(-1.0, -1.0, 3.0), Vector3(1.0, -1.0, 3.0),
                           Vector3(-1.0, 1.0, 3.0),  Vector3(1.0, 1.0, 3.0),
                           Vector3(-1.0, -1.0, 4.0), Vector3(1.0, -1.0, 4.0),
                           Vector3(-1.0, 1.0, 4.0),  Vector3(1.0, 1.0, 4.0)};
  auto verts2 = std::vector<Vector3>{
      Vector3(-10.0, -10.0, 0.0), Vector3(10.0, -10.0, 0.0),
      Vector3(-10.0, 10.0, 0.0),  Vector3(10.0, 10.0, 0.0),
      Vector3(-10.0, -10.0, 0.5), Vector3(10.0, -10.0, 0.5),
      Vector3(-10.0, 10.0, 0.5),  Vector3(10.0, 10.0, 0.5)};

  auto faces = std::vector<fcl::Triangle>{
      fcl::Triangle(3, 1, 0), fcl::Triangle(3, 0, 2), fcl::Triangle(0, 1, 5),
      fcl::Triangle(0, 5, 4), fcl::Triangle(1, 3, 7), fcl::Triangle(1, 7, 5),
      fcl::Triangle(3, 2, 6), fcl::Triangle(3, 6, 7), fcl::Triangle(2, 0, 4),
      fcl::Triangle(2, 4, 6), fcl::Triangle(4, 5, 7), fcl::Triangle(4, 7, 6),
  };

  auto bvh1 = std::make_shared<BVHModel>();
  bvh1->beginModel(8, 12);
  bvh1->addSubModel(verts1, faces);
  bvh1->endModel();

  auto bvh2 = std::make_shared<BVHModel>();
  bvh2->beginModel(8, 12);
  bvh2->addSubModel(verts2, faces);
  bvh2->endModel();

  auto tf11 = Transform3();
  tf11.setIdentity();
  tf11.translation()[0] = 1.0;
  tf11.translation()[1] = 0.0;
  tf11.translation()[2] = -1.0;

  auto tf12 = Transform3();
  tf12.setIdentity();
  tf12.translation()[0] = 1.0;
  tf12.translation()[1] = 0.0;
  tf12.translation()[2] = -2.0;

  auto tf21 = Transform3();
  tf21.setIdentity();
  tf21.translation()[0] = -2.0;
  tf21.translation()[1] = 0.0;
  tf21.translation()[2] = 0.0;

  auto tf22 = Transform3();
  tf22.setIdentity();
  tf22.translation()[0] = 2.0;
  tf22.translation()[1] = 0.0;
  tf22.translation()[2] = 1.5;

  const auto* obj1 = new CollisionObject(bvh1, tf11);
  const auto* obj2 = new CollisionObject(bvh2, tf21);

  auto request = ContinuousCollisionRequest(
      100, 1e-4, fcl::CCDMotionType::CCDM_TRANS, fcl::GJKSolverType::GST_INDEP,
      fcl::CCDSolverType::CCDC_CONSERVATIVE_ADVANCEMENT);

  auto result = ContinuousCollisionResult();
  auto ret = fcl::continuousCollide(obj1, tf12, obj2, tf22, request, result);
  std::cout << "is_collide: " << result.is_collide << "\n";
  std::cout << "time_of_contact: " << result.time_of_contact << "\n";

  return 0;
}
```

Master output:

```
is_collide: 0
time_of_contact: 1 
```

This branch's output:

```
is_collide: 1
time_of_contact: 0.6
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/550)
<!-- Reviewable:end -->
