### PR TITLE
change parameter type from `double` to `S` to fix compile error

### DIFF
--- a/include/fcl/math/motion/interp_motion-inl.h
+++ b/include/fcl/math/motion/interp_motion-inl.h
@@ -127,7 +127,7 @@ InterpMotion<S>::InterpMotion(
 
 //==============================================================================
 template <typename S>
-bool InterpMotion<S>::integrate(double dt) const
+bool InterpMotion<S>::integrate(S dt) const
 {
   if(dt > 1) dt = 1;
 

--- a/include/fcl/math/motion/interp_motion.h
+++ b/include/fcl/math/motion/interp_motion.h
@@ -76,7 +76,7 @@ public:
 
   /// @brief Integrate the motion from 0 to dt
   /// We compute the current transformation from zero point instead of from last integrate time, for precision.
-  bool integrate(double dt) const;
+  bool integrate(S dt) const;
 
   /// @brief Compute the motion bound for a bounding volume along a given direction n, which is defined in the visitor
   S computeMotionBound(const BVMotionBoundVisitor<S>& mb_visitor) const;

--- a/include/fcl/math/motion/screw_motion-inl.h
+++ b/include/fcl/math/motion/screw_motion-inl.h
@@ -92,7 +92,7 @@ ScrewMotion<S>::ScrewMotion(
 
 //==============================================================================
 template <typename S>
-bool ScrewMotion<S>::integrate(double dt) const
+bool ScrewMotion<S>::integrate(S dt) const
 {
   if(dt > 1) dt = 1;
 

--- a/include/fcl/math/motion/screw_motion.h
+++ b/include/fcl/math/motion/screw_motion.h
@@ -65,7 +65,7 @@ public:
 
   /// @brief Integrate the motion from 0 to dt
   /// We compute the current transformation from zero point instead of from last integrate time, for precision.
-  bool integrate(double dt) const;
+  bool integrate(S dt) const;
 
   /// @brief Compute the motion bound for a bounding volume along a given direction n, which is defined in the visitor
   S computeMotionBound(const BVMotionBoundVisitor<S>& mb_visitor) const;


### PR DESCRIPTION
change parameter type from `double` to `S` in `ScrewMotion<S>::integrate` and `InterpMotion<S>::integrate`
this fixes #538

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/557)
<!-- Reviewable:end -->
