### PR TITLE
CMake: also check for octomap-static target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,6 +103,8 @@ if(FCL_HAVE_OCTOMAP)
   # available, otherwise fall back to OCTOMAP_INCLUDE_DIRS and OCTOMAP_LIBRARIES
   if(TARGET octomap)
     target_link_libraries(${PROJECT_NAME} PUBLIC octomap)
+  elseif(TARGET octomap-static)
+    target_link_libraries(${PROJECT_NAME} PUBLIC octomap-static)
   elseif(OCTOMAP_INCLUDE_DIRS AND OCTOMAP_LIBRARIES)
     target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC "${OCTOMAP_INCLUDE_DIRS}")
     target_link_libraries(${PROJECT_NAME} PUBLIC "${OCTOMAP_LIBRARIES}")


### PR DESCRIPTION
Depending on whether octomap is static or shared, imported target name is different: `octomap-static` if static, `octomap` if shared. It's more robust to check `octomap-static` before falling back to include and link to `OCTOMAP_INCLUDE_DIRS` and `OCTOMAP_LIBRARIES`.