### PR TITLE
Update EPA-GJK failure messages

### DIFF
--- a/include/fcl/geometry/shape/box-inl.h
+++ b/include/fcl/geometry/shape/box-inl.h
@@ -38,7 +38,11 @@
 #ifndef FCL_SHAPE_BOX_INL_H
 #define FCL_SHAPE_BOX_INL_H
 
+#include <iomanip>
+#include <sstream>
+
 #include "fcl/geometry/shape/box.h"
+#include "fcl/geometry/shape/representation.h"
 
 namespace fcl
 {
@@ -131,6 +135,17 @@ std::vector<Vector3<S>> Box<S>::getBoundVertices(
   result[7] = tf * Vector3<S>(-a, -b, -c);
 
   return result;
+}
+
+//==============================================================================
+template <typename S>
+std::string Box<S>::representation(int precision) const {
+  const char* S_str = detail::ScalarRepr<S>::value();
+  std::stringstream ss;
+  ss << std::setprecision(precision);
+  ss << "Box<" << S_str << ">(" << side[0] << ", " << side[1] << ", " << side[2]
+     << ");";
+  return ss.str();
 }
 
 } // namespace fcl

--- a/include/fcl/geometry/shape/box.h
+++ b/include/fcl/geometry/shape/box.h
@@ -40,7 +40,8 @@
 
 #include "fcl/geometry/shape/shape_base.h"
 
-#include <iostream>
+#include <ostream>
+#include <string>
 
 namespace fcl
 {
@@ -80,6 +81,13 @@ public:
   /// @brief get the vertices of some convex shape which can bound this shape in
   /// a specific configuration
   std::vector<Vector3<S>> getBoundVertices(const Transform3<S>& tf) const;
+
+  /// @brief Create a string that should be sufficient to recreate this shape.
+  /// This is akin to the repr() implementation in python.
+  /// @param precision The requested digits of precision for the numerical
+  ///                  measures (same semantics as std::setprecision()).
+  /// @return The string representation of this instance.
+  std::string representation(int precision = 20) const;
 
   friend
   std::ostream& operator<<(std::ostream& out, const Box& box) {

--- a/include/fcl/geometry/shape/capsule-inl.h
+++ b/include/fcl/geometry/shape/capsule-inl.h
@@ -38,7 +38,11 @@
 #ifndef FCL_SHAPE_CAPSULE_INL_H
 #define FCL_SHAPE_CAPSULE_INL_H
 
+#include <iomanip>
+#include <sstream>
+
 #include "fcl/geometry/shape/capsule.h"
+#include "fcl/geometry/shape/representation.h"
 
 namespace fcl
 {
@@ -155,6 +159,16 @@ std::vector<Vector3<S>> Capsule<S>::getBoundVertices(
   result[35] = tf * Vector3<S>(c, -d, -hl);
 
   return result;
+}
+
+//==============================================================================
+template <typename S>
+std::string Capsule<S>::representation(int precision) const {
+  const char* S_str = detail::ScalarRepr<S>::value();
+  std::stringstream ss;
+  ss << std::setprecision(precision);
+  ss << "Capsule<" << S_str << ">(" << radius << ", " << lz << ");";
+  return ss.str();
 }
 
 } // namespace fcl

--- a/include/fcl/geometry/shape/capsule.h
+++ b/include/fcl/geometry/shape/capsule.h
@@ -38,7 +38,8 @@
 #ifndef FCL_SHAPE_CAPSULE_H
 #define FCL_SHAPE_CAPSULE_H
 
-#include <iostream>
+#include <ostream>
+#include <string>
 
 #include "fcl/geometry/shape/shape_base.h"
 
@@ -77,6 +78,13 @@ public:
   /// @brief get the vertices of some convex shape which can bound this shape in
   /// a specific configuration
   std::vector<Vector3<S>> getBoundVertices(const Transform3<S>& tf) const;
+
+  /// @brief Create a string that should be sufficient to recreate this shape.
+  /// This is akin to the repr() implementation in python.
+  /// @param precision The requested digits of precision for the numerical
+  ///                  measures (same semantics as std::setprecision()).
+  /// @return The string representation of this instance.
+  std::string representation(int precision = 20) const;
 
   friend
   std::ostream& operator<<(std::ostream& out, const Capsule& capsule) {

--- a/include/fcl/geometry/shape/cone-inl.h
+++ b/include/fcl/geometry/shape/cone-inl.h
@@ -38,7 +38,11 @@
 #ifndef FCL_SHAPE_CONE_INL_H
 #define FCL_SHAPE_CONE_INL_H
 
+#include <iomanip>
+#include <sstream>
+
 #include "fcl/geometry/shape/cone.h"
+#include "fcl/geometry/shape/representation.h"
 
 namespace fcl
 {
@@ -121,6 +125,16 @@ std::vector<Vector3<S>> Cone<S>::getBoundVertices(
   result[6] = tf * Vector3<S>(0, 0, hl);
 
   return result;
+}
+
+//==============================================================================
+template <typename S>
+std::string Cone<S>::representation(int precision) const {
+  const char* S_str = detail::ScalarRepr<S>::value();
+  std::stringstream ss;
+  ss << std::setprecision(precision);
+  ss << "Cone<" << S_str << ">(" << radius << ", " << lz << ");";
+  return ss.str();
 }
 
 } // namespace fcl

--- a/include/fcl/geometry/shape/cone.h
+++ b/include/fcl/geometry/shape/cone.h
@@ -38,7 +38,8 @@
 #ifndef FCL_SHAPE_CONE_H
 #define FCL_SHAPE_CONE_H
 
-#include <iostream>
+#include <ostream>
+#include <string>
 
 #include "fcl/geometry/shape/shape_base.h"
 
@@ -79,6 +80,13 @@ public:
   /// @brief get the vertices of some convex shape which can bound this shape in
   /// a specific configuration
   std::vector<Vector3<S>> getBoundVertices(const Transform3<S>& tf) const;
+
+  /// @brief Create a string that should be sufficient to recreate this shape.
+  /// This is akin to the repr() implementation in python.
+  /// @param precision The requested digits of precision for the numerical
+  ///                  measures (same semantics as std::setprecision()).
+  /// @return The string representation of this instance.
+  std::string representation(int precision = 20) const;
 
   friend
   std::ostream& operator<<(std::ostream& out, const Cone& cone) {

--- a/include/fcl/geometry/shape/convex-inl.h
+++ b/include/fcl/geometry/shape/convex-inl.h
@@ -39,11 +39,14 @@
 #ifndef FCL_SHAPE_CONVEX_INL_H
 #define FCL_SHAPE_CONVEX_INL_H
 
+#include <iomanip>
 #include <map>
 #include <set>
+#include <sstream>
 #include <utility>
 
 #include "fcl/geometry/shape/convex.h"
+#include "fcl/geometry/shape/representation.h"
 
 namespace fcl
 {
@@ -62,6 +65,7 @@ Convex<S>::Convex(
       vertices_(vertices),
       num_faces_(num_faces),
       faces_(faces),
+      throw_if_invalid_(throw_if_invalid),
       find_extreme_via_neighbors_{vertices->size() >
                                   kMinVertCountForEdgeWalking} {
   assert(vertices != nullptr);
@@ -307,6 +311,40 @@ const Vector3<S>& Convex<S>::findExtremeVertex(const Vector3<S>& v_C) const {
     }
   }
   return vertices[extreme_index];
+}
+
+//==============================================================================
+template <typename S>
+std::string Convex<S>::representation(int precision) const {
+  const char* S_str = detail::ScalarRepr<S>::value();
+  std::stringstream ss;
+  ss << std::setprecision(precision);
+  ss << "Convex<" << S_str << ">("
+     << "\n  std::make_shared<std::vector<Vector3<" << S_str << ">>>("
+     << "\n    std::initializer_list<Vector3<" << S_str << ">>{";
+  for (const Vector3<S>& p_GV : *vertices_) {
+    ss << "\n      Vector3<" << S_str << ">(" << p_GV[0] << ", " << p_GV[1]
+       << ", " << p_GV[2] << "),";
+  }
+  ss << "}),";
+  ss << "\n    " << num_faces_ << ",";
+  ss << "\n    std::make_shared<std::vector<int>>("
+     << "\n        std::initializer_list<int>{"
+     << "\n            ";
+  const std::vector<int>& faces = *faces_;
+  int face_index = 0;
+  for (int i = 0; i < num_faces_; ++i) {
+    const int vertex_count = faces[face_index];
+    ss << " " << vertex_count << ",";
+    for (int j = 1; j <= vertex_count; ++j) {
+      ss << " " << faces[face_index + j] << ",";
+    }
+    face_index += vertex_count + 1;
+  }
+  ss << "}),"
+     << "\n    " << std::boolalpha << throw_if_invalid_ << ");";
+
+  return ss.str();
 }
 
 //==============================================================================

--- a/include/fcl/geometry/shape/convex.h
+++ b/include/fcl/geometry/shape/convex.h
@@ -39,8 +39,9 @@
 #ifndef FCL_SHAPE_CONVEX_H
 #define FCL_SHAPE_CONVEX_H
 
-#include <iostream>
+#include <ostream>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "fcl/geometry/shape/shape_base.h"
@@ -175,6 +176,13 @@ public:
   ///         in the  %Convex polytope's set of vertices.
   const Vector3<S>& findExtremeVertex(const Vector3<S>& v_C) const;
 
+  /// @brief Create a string that should be sufficient to recreate this shape.
+  /// This is akin to the repr() implementation in python.
+  /// @param precision The requested digits of precision for the numerical
+  ///                  measures (same semantics as std::setprecision()).
+  /// @return The string representation of this instance.
+  std::string representation(int precision = 20) const;
+
   friend
   std::ostream& operator<<(std::ostream& out, const Convex& convex) {
     out << "Convex(v count: " << convex.vertices_->size() << ", f count: "
@@ -225,6 +233,8 @@ public:
   const std::shared_ptr<const std::vector<Vector3<S>>> vertices_;
   const int num_faces_;
   const std::shared_ptr<const std::vector<int>> faces_;
+  // This is stored to support representation().
+  const bool throw_if_invalid_{};
   Vector3<S> interior_point_;
 
   /* The encoding of vertex adjacency in the mesh. The encoding is as follows:

--- a/include/fcl/geometry/shape/cylinder-inl.h
+++ b/include/fcl/geometry/shape/cylinder-inl.h
@@ -38,7 +38,11 @@
 #ifndef FCL_SHAPE_CYLINDER_INL_H
 #define FCL_SHAPE_CYLINDER_INL_H
 
+#include <iomanip>
+#include <sstream>
+
 #include "fcl/geometry/shape/cylinder.h"
+#include "fcl/geometry/shape/representation.h"
 
 namespace fcl
 {
@@ -119,6 +123,16 @@ std::vector<Vector3<S>> Cylinder<S>::getBoundVertices(
   result[11] = tf * Vector3<S>(a, -b, hl);
 
   return result;
+}
+
+//==============================================================================
+template <typename S>
+std::string Cylinder<S>::representation(int precision) const {
+  const char* S_str = detail::ScalarRepr<S>::value();
+  std::stringstream ss;
+  ss << std::setprecision(precision);
+  ss << "Cylinder<" << S_str << ">(" << radius << ", " << lz << ");";
+  return ss.str();
 }
 
 } // namespace fcl

--- a/include/fcl/geometry/shape/cylinder.h
+++ b/include/fcl/geometry/shape/cylinder.h
@@ -38,7 +38,8 @@
 #ifndef FCL_SHAPE_CYLINDER_H
 #define FCL_SHAPE_CYLINDER_H
 
-#include <iostream>
+#include <ostream>
+#include <string>
 
 #include "fcl/geometry/shape/shape_base.h"
 
@@ -77,6 +78,13 @@ public:
   /// @brief get the vertices of some convex shape which can bound this shape in
   /// a specific configuration
   std::vector<Vector3<S>> getBoundVertices(const Transform3<S>& tf) const;
+
+  /// @brief Create a string that should be sufficient to recreate this shape.
+  /// This is akin to the repr() implementation in python.
+  /// @param precision The requested digits of precision for the numerical
+  ///                  measures (same semantics as std::setprecision()).
+  /// @return The string representation of this instance.
+  std::string representation(int precision = 20) const;
 
   friend
   std::ostream& operator<<(std::ostream& out, const Cylinder& cylinder) {

--- a/include/fcl/geometry/shape/ellipsoid-inl.h
+++ b/include/fcl/geometry/shape/ellipsoid-inl.h
@@ -38,7 +38,11 @@
 #ifndef FCL_SHAPE_ELLIPSOID_INL_H
 #define FCL_SHAPE_ELLIPSOID_INL_H
 
+#include <iomanip>
+#include <sstream>
+
 #include "fcl/geometry/shape/ellipsoid.h"
+#include "fcl/geometry/shape/representation.h"
 
 namespace fcl
 {
@@ -141,6 +145,17 @@ std::vector<Vector3<S>> Ellipsoid<S>::getBoundVertices(
   result[11] = tf * Vector3<S>(-Ab, 0, -Ca);
 
   return result;
+}
+
+//==============================================================================
+template <typename S>
+std::string Ellipsoid<S>::representation(int precision) const {
+  const char* S_str = detail::ScalarRepr<S>::value();
+  std::stringstream ss;
+  ss << std::setprecision(precision);
+  ss << "Ellipsoid<" << S_str << ">(" << radii[0] << ", " << radii[1] << ", "
+     << radii[2] << ");";
+  return ss.str();
 }
 
 } // namespace fcl

--- a/include/fcl/geometry/shape/ellipsoid.h
+++ b/include/fcl/geometry/shape/ellipsoid.h
@@ -38,7 +38,8 @@
 #ifndef FCL_SHAPE_ELLIPSOID_H
 #define FCL_SHAPE_ELLIPSOID_H
 
-#include <iostream>
+#include <ostream>
+#include <string>
 
 #include "fcl/geometry/shape/shape_base.h"
 
@@ -77,6 +78,13 @@ public:
   /// @brief get the vertices of some convex shape which can bound this shape in
   /// a specific configuration
   std::vector<Vector3<S>> getBoundVertices(const Transform3<S>& tf) const;
+
+  /// @brief Create a string that should be sufficient to recreate this shape.
+  /// This is akin to the repr() implementation in python.
+  /// @param precision The requested digits of precision for the numerical
+  ///                  measures (same semantics as std::setprecision()).
+  /// @return The string representation of this instance.
+  std::string representation(int precision = 20) const;
 
   friend
   std::ostream& operator<<(std::ostream& out, const Ellipsoid& ellipsoid) {

--- a/include/fcl/geometry/shape/halfspace-inl.h
+++ b/include/fcl/geometry/shape/halfspace-inl.h
@@ -38,7 +38,11 @@
 #ifndef FCL_SHAPE_HALFSPACE_INL_H
 #define FCL_SHAPE_HALFSPACE_INL_H
 
+#include <iomanip>
+#include <sstream>
+
 #include "fcl/geometry/shape/halfspace.h"
+#include "fcl/geometry/shape/representation.h"
 
 namespace fcl
 {
@@ -128,6 +132,17 @@ template <typename S>
 NODE_TYPE Halfspace<S>::getNodeType() const
 {
   return GEOM_HALFSPACE;
+}
+
+//==============================================================================
+template <typename S>
+std::string Halfspace<S>::representation(int precision) const {
+  const char* S_str = detail::ScalarRepr<S>::value();
+  std::stringstream ss;
+  ss << std::setprecision(precision);
+  ss << "Halfspace<" << S_str << ">(" << n[0] << ", " << n[1] << ", " << n[2]
+     << ", " << d << ");";
+  return ss.str();
 }
 
 //==============================================================================

--- a/include/fcl/geometry/shape/halfspace.h
+++ b/include/fcl/geometry/shape/halfspace.h
@@ -38,7 +38,8 @@
 #ifndef FCL_SHAPE_HALFSPACE_H
 #define FCL_SHAPE_HALFSPACE_H
 
-#include <iostream>
+#include <ostream>
+#include <string>
 
 #include "fcl/geometry/shape/shape_base.h"
 #include "fcl/math/bv/OBB.h"
@@ -85,6 +86,13 @@ public:
   
   /// @brief Planed offset
   S d;
+
+  /// @brief Create a string that should be sufficient to recreate this shape.
+  /// This is akin to the repr() implementation in python.
+  /// @param precision The requested digits of precision for the numerical
+  ///                  measures (same semantics as std::setprecision()).
+  /// @return The string representation of this instance.
+  std::string representation(int precision = 20) const;
 
   friend
   std::ostream& operator<<(std::ostream& out, const Halfspace& halfspace) {

--- a/include/fcl/geometry/shape/plane-inl.h
+++ b/include/fcl/geometry/shape/plane-inl.h
@@ -38,7 +38,11 @@
 #ifndef FCL_SHAPE_PLANE_INL_H
 #define FCL_SHAPE_PLANE_INL_H
 
+#include <iomanip>
+#include <sstream>
+
 #include "fcl/geometry/shape/plane.h"
+#include "fcl/geometry/shape/representation.h"
 
 namespace fcl
 {
@@ -128,6 +132,17 @@ template <typename S>
 NODE_TYPE Plane<S>::getNodeType() const
 {
   return GEOM_PLANE;
+}
+
+//==============================================================================
+template <typename S>
+std::string Plane<S>::representation(int precision) const {
+  const char* S_str = detail::ScalarRepr<S>::value();
+  std::stringstream ss;
+  ss << std::setprecision(precision);
+  ss << "Plane<" << S_str << ">(" << n[0] << ", " << n[1] << ", " << n[2]
+     << ", " << d << ");";
+  return ss.str();
 }
 
 //==============================================================================

--- a/include/fcl/geometry/shape/plane.h
+++ b/include/fcl/geometry/shape/plane.h
@@ -38,7 +38,8 @@
 #ifndef FCL_SHAPE_PLANE_H
 #define FCL_SHAPE_PLANE_H
 
-#include <iostream>
+#include <ostream>
+#include <string>
 
 #include "fcl/geometry/shape/shape_base.h"
 
@@ -76,6 +77,13 @@ public:
 
   /// @brief Plane offset 
   S d;
+
+  /// @brief Create a string that should be sufficient to recreate this shape.
+  /// This is akin to the repr() implementation in python.
+  /// @param precision The requested digits of precision for the numerical
+  ///                  measures (same semantics as std::setprecision()).
+  /// @return The string representation of this instance.
+  std::string representation(int precision = 20) const;
 
   friend
   std::ostream& operator<<(std::ostream& out, const Plane& plane) {

--- a/include/fcl/geometry/shape/representation.h
+++ b/include/fcl/geometry/shape/representation.h
@@ -1,8 +1,7 @@
 /*
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2011-2014, Willow Garage, Inc.
- *  Copyright (c) 2014-2016, Open Source Robotics Foundation
+ *  Copyright (c) 2023, Toyota Research Institute
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -33,65 +32,30 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-/** @author Jia Pan */
+/** @author Sean Curtis */
 
-#ifndef FCL_SHAPE_SPHERE_H
-#define FCL_SHAPE_SPHERE_H
+#ifndef FCL_SHAPE_REPRESENTATION_H
+#define FCL_SHAPE_REPRESENTATION_H
 
-#include "fcl/geometry/shape/shape_base.h"
+namespace fcl {
+namespace detail {
 
-#include <ostream>
-#include <string>
-
-namespace fcl
-{
-
-/// @brief Center at zero point sphere
-template <typename S_>
-class FCL_EXPORT Sphere : public ShapeBase<S_>
-{
-public:
-
-  using S = S_;
-
-  Sphere(S radius);
-
-  /// @brief Radius of the sphere
-  S radius;
-
-  /// @brief Compute AABB<S>
-  void computeLocalAABB() override;
-
-  /// @brief Get node type: a sphere
-  NODE_TYPE getNodeType() const override;
-
-  Matrix3<S> computeMomentofInertia() const override;
-
-  S computeVolume() const override;
-
-  /// @brief get the vertices of some convex shape which can bound this shape in
-  /// a specific configuration
-  std::vector<Vector3<S>> getBoundVertices(const Transform3<S>& tf) const;
-
-  /// @brief Create a string that should be sufficient to recreate this shape.
-  /// This is akin to the repr() implementation in python.
-  /// @param precision The requested digits of precision for the numerical
-  ///                  measures (same semantics as std::setprecision()).
-  /// @return The string representation of this instance.
-  std::string representation(int precision = 20) const;
-
-  friend
-  std::ostream& operator<<(std::ostream& out, const Sphere& sphere) {
-    out << "Sphere(" << sphere.radius << ")";
-    return out;
-  }
+/* A type-traits-like struct for turning scalar types into shape representation
+ strings. By default, it is printed with the FCL-generic scalar template "S". */
+template <typename S>
+struct ScalarRepr {
+  static const char* value() { return "S"; };
 };
 
-using Spheref = Sphere<float>;
-using Sphered = Sphere<double>;
+template <> struct ScalarRepr<double> {
+  static const char* value() { return "double"; };
+};
 
-} // namespace fcl
+template <> struct ScalarRepr<float> {
+  static const char* value() { return "float"; };
+};
 
-#include "fcl/geometry/shape/sphere-inl.h"
+}  // namespace detail
+}  // namespace fcl
 
-#endif
+#endif  // FCL_SHAPE_REPRESENTATION_H

--- a/include/fcl/geometry/shape/sphere-inl.h
+++ b/include/fcl/geometry/shape/sphere-inl.h
@@ -38,7 +38,11 @@
 #ifndef FCL_SHAPE_SPHERE_INL_H
 #define FCL_SHAPE_SPHERE_INL_H
 
+#include <iomanip>
+#include <sstream>
+
 #include "fcl/geometry/shape/sphere.h"
+#include "fcl/geometry/shape/representation.h"
 
 namespace fcl
 {
@@ -113,6 +117,16 @@ std::vector<Vector3<S>> Sphere<S>::getBoundVertices(
   result[11] = tf * Vector3<S>(-b, 0, -a);
 
   return result;
+}
+
+//==============================================================================
+template <typename S>
+std::string Sphere<S>::representation(int precision) const {
+  const char* S_str = detail::ScalarRepr<S>::value();
+  std::stringstream ss;
+  ss << std::setprecision(precision);
+  ss << "Sphere<" << S_str << ">(" << radius << ");";
+  return ss.str();
 }
 
 } // namespace fcl

--- a/include/fcl/narrowphase/detail/failed_at_this_configuration.h
+++ b/include/fcl/narrowphase/detail/failed_at_this_configuration.h
@@ -39,11 +39,12 @@
 
 #include <exception>
 #include <iomanip>
-#include <iostream>
+#include <ostream>
 #include <sstream>
 #include <stdexcept>
 #include <string>
 
+#include "fcl/common/types.h"
 #include "fcl/export.h"
 
 namespace fcl {
@@ -85,6 +86,44 @@ class FCL_EXPORT FailedAtThisConfiguration final
 FCL_EXPORT void ThrowFailedAtThisConfiguration(
     const std::string& message, const char* func, const char* file, int line);
 
+/** Works in conjuction with ThrowDetailedConfiguration() to format the pose
+ in a more python-like repr() way (facilitating error reproduction). In this
+ case, just doing comma-delimited print outs makes copying-and-pasting the
+ error message contents into code easier.
+
+ The intention is that the matrix is printed out as:
+
+      a, b, c, d,
+      e, f, g, h,
+      i, j, k, l,
+      m, n, o, p;
+
+ so, that it can easily be copied and pasted into code like this:
+
+ Transform3<S> X;
+ X.matrix() << a, b, c, d,
+               e, f, g, h,
+               i, j, k, l,
+               m, n, o, p; */
+template <typename S>
+void WriteCommaSeparated(std::stringstream* sstream, const Transform3<S>& p) {
+  const auto& m = p.matrix();
+  std::stringstream& ss = *sstream;
+  for (int row = 0; row < 4; ++row) {
+    for (int col = 0; col < 4; ++col) {
+      ss << m(row, col);
+      if (col < 3) {
+        ss << ", ";
+      }
+    }
+    if (row < 3) {
+      ss << ",\n";
+    } else {
+      ss << ";";
+    }
+  }
+}
+
 /** Helper class for propagating a low-level exception upwards but with
  configuration-specific details appended. The parameters
  
@@ -99,19 +138,22 @@ FCL_EXPORT void ThrowFailedAtThisConfiguration(
  @tparam Solver   The solver type (with scalar type erase).
  @tparam Pose     The pose type (a Transform<S> with scalar type erased).
  */
-template <typename Shape1, typename Shape2, typename Solver, typename Pose>
-void ThrowDetailedConfiguration(const Shape1& s1, const Pose& X_FS1,
-                                const Shape2& s2, const Pose& X_FS2,
+template <typename Shape1, typename Shape2, typename Solver, typename S>
+void ThrowDetailedConfiguration(const Shape1& s1, const Transform3<S>& X_FS1,
+                                const Shape2& s2, const Transform3<S>& X_FS2,
                                 const Solver& solver, const std::exception& e) {
   std::stringstream ss;
-  ss << std::setprecision(20);
+  const int digits = 20;
+  ss << std::setprecision(digits);
   ss << "Error with configuration"
      << "\n  Original error message: " << e.what()
-     << "\n  Shape 1: " << s1
-     << "\n  X_FS1\n" << X_FS1.matrix()
-     << "\n  Shape 2: " << s2
-     << "\n  X_FS2\n" << X_FS2.matrix()
-     << "\n  Solver: " << solver;
+     << "\n  Shape 1:\n" << s1.representation(digits)
+     << "\n  X_FS1\n";
+  WriteCommaSeparated(&ss, X_FS1);
+  ss << "\n  Shape 2:\n" << s2.representation(digits)
+     << "\n  X_FS2\n";
+  WriteCommaSeparated(&ss, X_FS2);
+  ss << "\n  Solver: " << solver;
   throw std::logic_error(ss.str());
 }
 

--- a/src/geometry/shape/representation.cpp
+++ b/src/geometry/shape/representation.cpp
@@ -1,8 +1,7 @@
 /*
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2011-2014, Willow Garage, Inc.
- *  Copyright (c) 2014-2016, Open Source Robotics Foundation
+ *  Copyright (c) 2023, Toyota Research Institute
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -33,65 +32,13 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-/** @author Jia Pan */
+/** @author Sean Curtis */
 
-#ifndef FCL_SHAPE_SPHERE_H
-#define FCL_SHAPE_SPHERE_H
+#include "fcl/geometry/shape/representation.h"
 
-#include "fcl/geometry/shape/shape_base.h"
+namespace fcl {
+namespace detail {
 
-#include <ostream>
-#include <string>
 
-namespace fcl
-{
-
-/// @brief Center at zero point sphere
-template <typename S_>
-class FCL_EXPORT Sphere : public ShapeBase<S_>
-{
-public:
-
-  using S = S_;
-
-  Sphere(S radius);
-
-  /// @brief Radius of the sphere
-  S radius;
-
-  /// @brief Compute AABB<S>
-  void computeLocalAABB() override;
-
-  /// @brief Get node type: a sphere
-  NODE_TYPE getNodeType() const override;
-
-  Matrix3<S> computeMomentofInertia() const override;
-
-  S computeVolume() const override;
-
-  /// @brief get the vertices of some convex shape which can bound this shape in
-  /// a specific configuration
-  std::vector<Vector3<S>> getBoundVertices(const Transform3<S>& tf) const;
-
-  /// @brief Create a string that should be sufficient to recreate this shape.
-  /// This is akin to the repr() implementation in python.
-  /// @param precision The requested digits of precision for the numerical
-  ///                  measures (same semantics as std::setprecision()).
-  /// @return The string representation of this instance.
-  std::string representation(int precision = 20) const;
-
-  friend
-  std::ostream& operator<<(std::ostream& out, const Sphere& sphere) {
-    out << "Sphere(" << sphere.radius << ")";
-    return out;
-  }
-};
-
-using Spheref = Sphere<float>;
-using Sphered = Sphere<double>;
-
-} // namespace fcl
-
-#include "fcl/geometry/shape/sphere-inl.h"
-
-#endif
+}  // namespace detail
+}  // namespace fcl

--- a/test/geometry/shape/CMakeLists.txt
+++ b/test/geometry/shape/CMakeLists.txt
@@ -1,6 +1,13 @@
 set(tests
-        test_convex.cpp
+        test_box.cpp
         test_capsule.cpp
+        test_cone.cpp
+        test_convex.cpp
+        test_cylinder.cpp
+        test_ellipsoid.cpp
+        test_halfspace.cpp
+        test_plane.cpp
+        test_sphere.cpp
         )
 
 # Build all the tests

--- a/test/geometry/shape/representation_util.h
+++ b/test/geometry/shape/representation_util.h
@@ -1,0 +1,116 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023, Toyota Research Institute
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Open Source Robotics Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @author Sean Curtis */
+
+#ifndef FCL_SHAPE_REPRESENTATION_UTIL_H
+#define FCL_SHAPE_REPRESENTATION_UTIL_H
+
+#include <regex>
+
+#include <gtest/gtest.h>
+
+namespace fcl {
+namespace detail {
+
+// For the representation() method we just need to show that it outputs
+// a string that can be used to instantiate the shape. It is sufficient to show
+// that it outputs *a* valid format (and not necessarily the original).
+//
+// It may be that formatting standards change, it's alright to reformulate
+// the code captured here or the representation() method implementation to keep
+// this test passing.
+//
+// To that end, we'll use a code string that gets converted into a string and
+// gets compiled and confirm that it is equal to the string given by
+// representation() (modulo some whitespace artifacts).
+#define INSTANTIATE_AND_SAVE_STRING(code) \
+  const std::string code_string(#code);   \
+  const auto shape = code;
+
+// Given the shape and a string comprising the code that constructs it, confirms
+// two things:
+//
+//   1. With "sufficient" precision, the representation() of the shape matches
+//      the given code string.
+//   2. With "insufficient" precision, they don't match.
+//
+// Note: The parameters for the shape should have *at least* two digits of
+// precision for this test to work (e.g., prefer 1.5 to 1). But within that
+// requirement, things will work best if the values are perfectly represented
+// by floating point values.
+template <typename Shape>
+::testing::AssertionResult ValidateRepresentation(
+    const Shape& shape, const std::string& code_string) {
+  bool success = true;
+  ::testing::AssertionResult failure = ::testing::AssertionFailure();
+  // Normalize whitespace; newlines and blocks of spaces become single spaces.
+  const std::regex whitespace_re("[\\s\\n]+");
+  const std::string expected =
+      std::regex_replace(code_string, whitespace_re, " ");
+
+  // Confirm precision matters. We get an exact match with sufficient precision.
+  // Insufficient precision causes round-off and the strings don't match.
+  {
+    const std::string tested =
+        std::regex_replace(shape.representation(20), whitespace_re, " ");
+    if (tested != expected) {
+        success = false;
+      failure
+          << "Representation string mismatch with sufficient precision:"
+          << "\n  expected: " << expected
+          << "\n  tested: " << tested;
+    }
+  }
+  {
+    const std::string tested =
+        std::regex_replace(shape.representation(1), whitespace_re, " ");
+    if (tested == expected) {
+        success = false;
+      failure
+          << "Representation string still matches with insufficient precision:"
+          << "\n  expected: " << expected
+          << "\n  tested: " << tested;
+    }
+  }
+  if (success) {
+    return ::testing::AssertionSuccess();
+  }
+  return failure;
+}
+
+}  // namespace detail
+}  // namespace fcl
+
+#endif  // FCL_SHAPE_REPRESENTATION_UTIL_H

--- a/test/geometry/shape/test_box.cpp
+++ b/test/geometry/shape/test_box.cpp
@@ -1,0 +1,62 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023. Toyota Research Institute
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of CNRS-LAAS and AIST nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @author Sean Curtis (sean@tri.global) (2023) */
+
+#include "fcl/geometry/shape/box.h"
+
+#include <gtest/gtest.h>
+
+#include "geometry/shape/representation_util.h"
+
+namespace fcl {
+namespace {
+
+// TODO(SeanCurtis-TRI): Test everything in Box's API.
+
+GTEST_TEST(BoxGeometry, Representation) {
+  // This defines the `shape` and `code_string` variables used in the test.
+  INSTANTIATE_AND_SAVE_STRING(Box<double>(1.5, 2.5, 3.5);)
+
+  EXPECT_TRUE(detail::ValidateRepresentation(shape, code_string));
+}
+
+}  // namespace
+}  // namespace fcl
+
+//==============================================================================
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/geometry/shape/test_capsule.cpp
+++ b/test/geometry/shape/test_capsule.cpp
@@ -44,6 +44,7 @@
 #include <gtest/gtest.h>
 
 #include "eigen_matrix_compare.h"
+#include "geometry/shape/representation_util.h"
 
 namespace fcl {
 namespace {
@@ -174,6 +175,13 @@ GTEST_TEST(Capsule, MomentOfInertia_Capsule) {
     Capsulef capsule_f(rf, lf);
     testMomentOfInertiaComputation(capsule_f, 1e-6f);
   }
+}
+
+GTEST_TEST(Capsule, Representation) {
+  // This defines the `shape` and `code_string` variables used in the test.
+  INSTANTIATE_AND_SAVE_STRING(Capsule<double>(2.5, 3.5);)
+
+  EXPECT_TRUE(detail::ValidateRepresentation(shape, code_string));
 }
 
 }  // namespace

--- a/test/geometry/shape/test_cone.cpp
+++ b/test/geometry/shape/test_cone.cpp
@@ -1,0 +1,62 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023. Toyota Research Institute
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of CNRS-LAAS and AIST nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @author Sean Curtis (sean@tri.global) (2023) */
+
+#include "fcl/geometry/shape/cone.h"
+
+#include <gtest/gtest.h>
+
+#include "geometry/shape/representation_util.h"
+
+namespace fcl {
+namespace {
+
+// TODO(SeanCurtis-TRI): Test everything in Cone's API.
+
+GTEST_TEST(ConeGeometry, Representation) {
+  // This defines the `shape` and `code_string` variables used in the test.
+  INSTANTIATE_AND_SAVE_STRING(Cone<double>(2.5, 3.5);)
+
+  EXPECT_TRUE(detail::ValidateRepresentation(shape, code_string));
+}
+
+}  // namespace
+}  // namespace fcl
+
+//==============================================================================
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/geometry/shape/test_convex.cpp
+++ b/test/geometry/shape/test_convex.cpp
@@ -46,6 +46,7 @@
 #include "eigen_matrix_compare.h"
 #include "expect_throws_message.h"
 #include "fcl/common/types.h"
+#include "geometry/shape/representation_util.h"
 
 namespace fcl {
 class ConvexTester {
@@ -870,6 +871,22 @@ GTEST_TEST(ConvexGeometry, UseEdgeWalkingConditions) {
 //   well-known closed-form values for the tensor product. Confirm that as
 //   the tesselation gets finer, that the answer converges to the reference
 //   solution.
+
+GTEST_TEST(ConvexGeometry, Representation) {
+  // This defines the `shape` and `code_string` variables used in the test.
+  INSTANTIATE_AND_SAVE_STRING(
+      Convex<double>(
+          std::make_shared<std::vector<Vector3<double>>>(
+              std::initializer_list<Vector3<double>>{
+                  Vector3<double>(0, 0, 0), Vector3<double>(1.5, 0, 0),
+                  Vector3<double>(0, 1.5, 0), Vector3<double>(1, 1.5, 0),}),
+          2,
+          std::make_shared<std::vector<int>>(
+              std::initializer_list<int>{ 3, 0, 1, 2, 3, 1, 3, 2,}),
+          false);)
+
+  EXPECT_TRUE(detail::ValidateRepresentation(shape, code_string));
+}
 
 }  // namespace
 }  // namespace fcl

--- a/test/geometry/shape/test_cylinder.cpp
+++ b/test/geometry/shape/test_cylinder.cpp
@@ -1,0 +1,62 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023. Toyota Research Institute
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of CNRS-LAAS and AIST nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @author Sean Curtis (sean@tri.global) (2023) */
+
+#include "fcl/geometry/shape/cylinder.h"
+
+#include <gtest/gtest.h>
+
+#include "geometry/shape/representation_util.h"
+
+namespace fcl {
+namespace {
+
+// TODO(SeanCurtis-TRI): Test everything in Cylinder's API.
+
+GTEST_TEST(CylinderGeometry, Representation) {
+  // This defines the `shape` and `code_string` variables used in the test.
+  INSTANTIATE_AND_SAVE_STRING(Cylinder<double>(2.5, 3.5);)
+
+  EXPECT_TRUE(detail::ValidateRepresentation(shape, code_string));
+}
+
+}  // namespace
+}  // namespace fcl
+
+//==============================================================================
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/geometry/shape/test_ellipsoid.cpp
+++ b/test/geometry/shape/test_ellipsoid.cpp
@@ -1,0 +1,62 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023. Toyota Research Institute
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of CNRS-LAAS and AIST nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @author Sean Curtis (sean@tri.global) (2023) */
+
+#include "fcl/geometry/shape/ellipsoid.h"
+
+#include <gtest/gtest.h>
+
+#include "geometry/shape/representation_util.h"
+
+namespace fcl {
+namespace {
+
+// TODO(SeanCurtis-TRI): Test everything in Ellipsoid's API.
+
+GTEST_TEST(EllipsoidGeometry, Representation) {
+  // This defines the `shape` and `code_string` variables used in the test.
+  INSTANTIATE_AND_SAVE_STRING(Ellipsoid<double>(2.5, 3.5, 4.5);)
+
+  EXPECT_TRUE(detail::ValidateRepresentation(shape, code_string));
+}
+
+}  // namespace
+}  // namespace fcl
+
+//==============================================================================
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/geometry/shape/test_halfspace.cpp
+++ b/test/geometry/shape/test_halfspace.cpp
@@ -1,0 +1,65 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023. Toyota Research Institute
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of CNRS-LAAS and AIST nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @author Sean Curtis (sean@tri.global) (2023) */
+
+#include "fcl/geometry/shape/halfspace.h"
+
+#include <gtest/gtest.h>
+
+#include "geometry/shape/representation_util.h"
+
+namespace fcl {
+namespace {
+
+// TODO(SeanCurtis-TRI): Test everything in Halfspace's API.
+
+GTEST_TEST(HalfspaceGeometry, Representation) {
+  // We're using a simple normal (0, 1, 0) because the Halfspace will normalize
+  // itself and the repr string won't match the declaration.
+
+  // This defines the `shape` and `code_string` variables used in the test.
+  INSTANTIATE_AND_SAVE_STRING(Halfspace<double>(0, 1, 0, 4.5);)
+
+  EXPECT_TRUE(detail::ValidateRepresentation(shape, code_string));
+}
+
+}  // namespace
+}  // namespace fcl
+
+//==============================================================================
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/geometry/shape/test_plane.cpp
+++ b/test/geometry/shape/test_plane.cpp
@@ -1,0 +1,65 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023. Toyota Research Institute
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of CNRS-LAAS and AIST nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @author Sean Curtis (sean@tri.global) (2023) */
+
+#include "fcl/geometry/shape/plane.h"
+
+#include <gtest/gtest.h>
+
+#include "geometry/shape/representation_util.h"
+
+namespace fcl {
+namespace {
+
+// TODO(SeanCurtis-TRI): Test everything in Plane's API.
+
+GTEST_TEST(PlaneGeometry, Representation) {
+  // We're using a simple normal (0, 1, 0) because the Plane will normalize
+  // itself and the repr string won't match the declaration.
+
+  // This defines the `shape` and `code_string` variables used in the test.
+  INSTANTIATE_AND_SAVE_STRING(Plane<double>(0, 1, 0, 4.5);)
+
+  EXPECT_TRUE(detail::ValidateRepresentation(shape, code_string));
+}
+
+}  // namespace
+}  // namespace fcl
+
+//==============================================================================
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/geometry/shape/test_sphere.cpp
+++ b/test/geometry/shape/test_sphere.cpp
@@ -1,0 +1,62 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023. Toyota Research Institute
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of CNRS-LAAS and AIST nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @author Sean Curtis (sean@tri.global) (2023) */
+
+#include "fcl/geometry/shape/sphere.h"
+
+#include <gtest/gtest.h>
+
+#include "geometry/shape/representation_util.h"
+
+namespace fcl {
+namespace {
+
+// TODO(SeanCurtis-TRI): Test everything in Sphere's API.
+
+GTEST_TEST(SphereGeometry, Representation) {
+  // This defines the `shape` and `code_string` variables used in the test.
+  INSTANTIATE_AND_SAVE_STRING(Sphere<double>(1.5);)
+
+  EXPECT_TRUE(detail::ValidateRepresentation(shape, code_string));
+}
+
+}  // namespace
+}  // namespace fcl
+
+//==============================================================================
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/narrowphase/detail/CMakeLists.txt
+++ b/test/narrowphase/detail/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(tests
     test_collision_func_matrix.cpp
+    test_failed_at_this_configuration.cpp
     )
 
 # Build all the tests

--- a/test/narrowphase/detail/test_failed_at_this_configuration.cpp
+++ b/test/narrowphase/detail/test_failed_at_this_configuration.cpp
@@ -1,0 +1,93 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023. Toyota Research Institute
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of CNRS-LAAS and AIST nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @author Sean Curtis (sean@tri.global) (2023) */
+
+#include <gtest/gtest.h>
+
+#include <regex>
+
+#include "fcl/geometry/shape/box.h"
+#include "fcl/geometry/shape/sphere.h"
+#include "fcl/narrowphase/detail/failed_at_this_configuration.h"
+#include "fcl/narrowphase/detail/gjk_solver_libccd.h"
+
+namespace fcl {
+namespace detail {
+namespace {
+
+// We're testing for the following:
+//
+//   1. The exception message is included.
+//   2. The shapes have had representation() called on them. We'll use two
+//      different shapes to confirm they get ordered correctly.
+//   3. The first matrix is printed with the first shape, the second with the
+//      second.
+//   4. The matrices have commas.
+GTEST_TEST(ConfigurationFailureTest, ConfirmFormatting) {
+  const Sphered sphere(1.5);
+  const Transform3d X_WS(Translation3d(12, 13, 14));
+  const Boxd box(1, 2, 3);
+  const Transform3d X_WB(Translation3d(17, 18, 19));
+  const GJKSolver_libccd<double> solver;
+  const std::logic_error e("dummy message");
+
+  try {
+    ThrowDetailedConfiguration(sphere, X_WS, box, X_WB, solver, e);
+  } catch (const std::logic_error& e) {
+    EXPECT_TRUE(
+        std::regex_search(e.what(), std::regex("[^]+dummy message[^]+")));
+
+    // Shape<S> is evidence that representation() got called.
+    std::regex ordered_shapes_re("[^]+Sphere<double>[^]+Box<double>[^]+");
+    EXPECT_TRUE(std::regex_search(e.what(), ordered_shapes_re)) << e.what();
+
+    // Commas and order; we're looking for the translation values in order
+    // following commas.
+    std::regex matrices_re(
+        "[^]+X_FS1[^]+, 12,[^]+, 13,[^]+, 14,[^]+, 1;"
+        "[^]+X_FS2[^]+, 17,[^]+, 18,[^]+, 19,[^]+, 1;");
+    EXPECT_TRUE(std::regex_search(e.what(), matrices_re)) << e.what();
+  }
+}
+
+}  // namespace
+}  // namespace detail
+}  // namespace fcl
+
+//==============================================================================
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
The EPA-GJK failure message attempts to dump sufficient state to reproduce the configuration that produced the error. However, when one of the participating shapes is Convex, the information was insufficient; we need to be able to reconstruct the Convex.

Defining operator<< to dump an entire constructor invocation for Convex seems unreasonable. We ape python's repr() API and add a Representation() method to all of the participating shapes.

This also changes the formatting of the poses to smooth the process of creating workable code from the configuration data (comma-separated matrix).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/594)
<!-- Reviewable:end -->
