### PR TITLE
Add missing cassert include in fcl/common/types.h

### DIFF
--- a/include/fcl/common/types.h
+++ b/include/fcl/common/types.h
@@ -38,6 +38,7 @@
 #ifndef FCL_DATA_TYPES_H
 #define FCL_DATA_TYPES_H
 
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <vector>


### PR DESCRIPTION
Ported from https://github.com/RobotLocomotion/drake/pull/18694, this should ensure that fcl works fine with unreleased Eigen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/620)
<!-- Reviewable:end -->
