### PR TITLE
[ci] Update macos images to the latest

### DIFF
--- a/.github/workflows/all_ci.yml
+++ b/.github/workflows/all_ci.yml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         compiler: [clang]
         build: [Release, Debug]
-        os: ['macos-11']
+        os: ['macos-14', 'macos-14-large']
     uses: ./.github/workflows/generic_ci.yml
     with:
       install-name: 'install_osx.sh'


### PR DESCRIPTION
`macos-11` was removed a long time ago, and macos-14 (ARM) and macos-14-large (x86) are the latest images:

https://github.com/actions/runner-images?tab=readme-ov-file#available-images
