### PR TITLE
Directly include cassert wherever we use assert()

### DIFF
--- a/include/fcl/broadphase/default_broadphase_callbacks.h
+++ b/include/fcl/broadphase/default_broadphase_callbacks.h
@@ -47,6 +47,8 @@
 #include "fcl/narrowphase/distance_request.h"
 #include "fcl/narrowphase/distance_result.h"
 
+#include <cassert>
+
 namespace fcl {
 
 /// @brief Collision data for use with the DefaultCollisionFunction. It stores

--- a/include/fcl/geometry/octree/octree-inl.h
+++ b/include/fcl/geometry/octree/octree-inl.h
@@ -44,6 +44,8 @@
 
 #include "fcl/geometry/shape/utility.h"
 
+#include <cassert>
+
 #if FCL_HAVE_OCTOMAP
 
 namespace fcl

--- a/include/fcl/geometry/shape/convex-inl.h
+++ b/include/fcl/geometry/shape/convex-inl.h
@@ -39,6 +39,7 @@
 #ifndef FCL_SHAPE_CONVEX_INL_H
 #define FCL_SHAPE_CONVEX_INL_H
 
+#include <cassert>
 #include <iomanip>
 #include <map>
 #include <set>

--- a/include/fcl/math/motion/taylor_model/taylor_model-inl.h
+++ b/include/fcl/math/motion/taylor_model/taylor_model-inl.h
@@ -43,6 +43,8 @@
 
 #include "fcl/math/motion/taylor_model/taylor_model.h"
 
+#include <cassert>
+
 namespace fcl
 {
 

--- a/include/fcl/math/rng-inl.h
+++ b/include/fcl/math/rng-inl.h
@@ -40,6 +40,8 @@
 
 #include "fcl/math/rng.h"
 
+#include <cassert>
+
 namespace fcl
 {
 

--- a/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
+++ b/include/fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h
@@ -39,6 +39,7 @@
 #define FCL_NARROWPHASE_DETAIL_GJKLIBCCD_INL_H
 
 #include <array>
+#include <cassert>
 #include <iostream>
 #include <sstream>
 #include <string>

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/capsule_capsule-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/capsule_capsule-inl.h
@@ -40,6 +40,8 @@
 
 #include "fcl/narrowphase/detail/primitive_shape_algorithm/capsule_capsule.h"
 
+#include <cassert>
+
 namespace fcl
 {
 

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/plane-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/plane-inl.h
@@ -40,6 +40,8 @@
 
 #include "fcl/narrowphase/detail/primitive_shape_algorithm/plane.h"
 
+#include <cassert>
+
 namespace fcl
 {
 

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/sphere_box-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/sphere_box-inl.h
@@ -39,6 +39,8 @@
 
 #include "fcl/narrowphase/detail/primitive_shape_algorithm/sphere_box.h"
 
+#include <cassert>
+
 namespace fcl {
 namespace detail {
 

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/sphere_cylinder-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/sphere_cylinder-inl.h
@@ -39,6 +39,8 @@
 
 #include "fcl/narrowphase/detail/primitive_shape_algorithm/sphere_cylinder.h"
 
+#include <cassert>
+
 namespace fcl {
 namespace detail {
 

--- a/include/fcl/narrowphase/detail/traversal/distance/mesh_conservative_advancement_traversal_node-inl.h
+++ b/include/fcl/narrowphase/detail/traversal/distance/mesh_conservative_advancement_traversal_node-inl.h
@@ -43,6 +43,8 @@
 #include "fcl/math/bv/RSS.h"
 #include "fcl/math/motion/triangle_motion_bound_visitor.h"
 
+#include <cassert>
+
 namespace fcl
 {
 

--- a/include/fcl/narrowphase/distance-inl.h
+++ b/include/fcl/narrowphase/distance-inl.h
@@ -42,6 +42,8 @@
 
 #include "fcl/narrowphase/collision.h"
 
+#include <cassert>
+
 namespace fcl
 {
 

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_epa.cpp
@@ -42,6 +42,7 @@
 #include "fcl/narrowphase/detail/convexity_based_algorithm/gjk_libccd-inl.h"
 
 #include <array>
+#include <cassert>
 #include <memory>
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
Don’t require on implicit or indirect inclusion of the necessary header.

In Fedora, this is needed in order to successfully compile as C++14, which in turn is needed for compatibility with version 5.x of eigen3.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/649)
<!-- Reviewable:end -->
