### PR TITLE
Update octomap to v1.9.4

### DIFF
--- a/.github/workflows/generic_ci.yml
+++ b/.github/workflows/generic_ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Prerequisites
-        run: ${{ format('{0}/ci/{1} {2}', github.workspace, inputs.install-name, inputs.build) }}
+        run: ${{ format('{0}/ci/{1}', github.workspace, inputs.install-name) }}
 
       - name: Create Build Directory
         run: mkdir ${{github.workspace}}/build

--- a/.github/workflows/generic_ci.yml
+++ b/.github/workflows/generic_ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Prerequisites
-        run: ${{ format('{0}/ci/{1}', github.workspace, inputs.install-name) }}
+        run: ${{ format('{0}/ci/{1} {2}', github.workspace, inputs.install-name, inputs.build) }}
 
       - name: Create Build Directory
         run: mkdir ${{github.workspace}}/build

--- a/ci/install_linux.sh
+++ b/ci/install_linux.sh
@@ -5,13 +5,11 @@ sudo apt-get -qq --yes --force-yes install libeigen3-dev
 sudo apt-get -qq --yes --force-yes install libccd-dev
 
 # Octomap
-DEFAULT_BUILD = "Release"
-BUILD_ARG="${1:-$DEFAULT_BUILD}"
 git clone https://github.com/OctoMap/octomap
 cd octomap
 git checkout tags/v1.10.0
 mkdir build
 cd build
-cmake .. -DBUILD_OCTOVIS_SUBPROJECT=off -DCMAKE_BUILD_TYPE=$BUILD_ARG
+cmake .. -DBUILD_OCTOVIS_SUBPROJECT=off
 make
 sudo make install

--- a/ci/install_linux.sh
+++ b/ci/install_linux.sh
@@ -7,9 +7,9 @@ sudo apt-get -qq --yes --force-yes install libccd-dev
 # Octomap
 git clone https://github.com/OctoMap/octomap
 cd octomap
-git checkout tags/v1.8.0
+git checkout tags/v1.9.4
 mkdir build
 cd build
-cmake ..
+cmake .. -DBUILD_OCTOVIS_SUBPROJECT=off
 make
 sudo make install

--- a/ci/install_linux.sh
+++ b/ci/install_linux.sh
@@ -9,7 +9,7 @@ DEFAULT_BUILD = "Release"
 BUILD_ARG="${1:-$DEFAULT_BUILD}"
 git clone https://github.com/OctoMap/octomap
 cd octomap
-git checkout tags/v1.9.4
+git checkout tags/v1.10.0
 mkdir build
 cd build
 cmake .. -DBUILD_OCTOVIS_SUBPROJECT=off -DCMAKE_BUILD_TYPE=$BUILD_ARG

--- a/ci/install_linux.sh
+++ b/ci/install_linux.sh
@@ -5,11 +5,13 @@ sudo apt-get -qq --yes --force-yes install libeigen3-dev
 sudo apt-get -qq --yes --force-yes install libccd-dev
 
 # Octomap
+DEFAULT_BUILD = "Release"
+BUILD_ARG="${1:-$DEFAULT_BUILD}"
 git clone https://github.com/OctoMap/octomap
 cd octomap
 git checkout tags/v1.9.4
 mkdir build
 cd build
-cmake .. -DBUILD_OCTOVIS_SUBPROJECT=off
+cmake .. -DBUILD_OCTOVIS_SUBPROJECT=off -DCMAKE_BUILD_TYPE=$BUILD_ARG
 make
 sudo make install


### PR DESCRIPTION
This is the oldest version that builds happily with noble's (24.04) default compilers. The build is configured to *not* include the visualizer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/655)
<!-- Reviewable:end -->
