### PR TITLE
Update code to silence modern compiler warnings

### DIFF
--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/box_box-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/box_box-inl.h
@@ -262,7 +262,8 @@ int boxBox2(
   // edge-edge. It is unclear why edge-edge contact receives this 5% penalty.
   // Someone should document this.
   const S fudge_factor = S(1.05);
-  Vector3<S> normalC;
+  // Dummy initialization; either it gets initialized below, or we bail out.
+  Vector3<S> normalC = Vector3<S>::Zero();
   S s, s2, l;
   int invert_normal, code;
 

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/halfspace-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/halfspace-inl.h
@@ -504,8 +504,8 @@ bool convexHalfspaceIntersect(const Convex<S>& s1, const Transform3<S>& tf1,
 {
   Halfspace<S> new_s2 = transform(s2, tf2);
 
-  Vector3<S> v;
   S depth = std::numeric_limits<S>::max();
+  Vector3<S> v = Vector3<S>::Constant(std::numeric_limits<S>::infinity());
 
   // Note: There are two issues with this for loop:
   //  1. We are transforming *every* vertex in the convex. That's a waste.
@@ -550,7 +550,8 @@ bool convexHalfspaceIntersect(const Convex<S>& convex_C,
                               std::vector<ContactPoint<S>>* contacts) {
   Halfspace<S> half_space_C = transform(half_space_H, X_FC.inverse() * X_FH);
 
-  Vector3<S> p_CV_deepest;
+  Vector3<S> p_CV_deepest =
+      Vector3<S>::Constant(std::numeric_limits<S>::infinity());
   S min_signed_distance = std::numeric_limits<S>::max();
 
   // TODO: Once we have an efficient "support vector" implementation for Convex

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/plane-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/plane-inl.h
@@ -645,7 +645,8 @@ bool convexPlaneIntersect(const Convex<S>& s1, const Transform3<S>& tf1,
 {
   Plane<S> new_s2 = transform(s2, tf2);
 
-  Vector3<S> v_min, v_max;
+  Vector3<S> v_min = Vector3<S>::Constant(std::numeric_limits<S>::infinity());
+  Vector3<S> v_max = -v_min;
   S d_min = std::numeric_limits<S>::max(), d_max = -std::numeric_limits<S>::max();
 
   for (const auto& vertex : s1.getVertices())

--- a/include/fcl/narrowphase/detail/primitive_shape_algorithm/sphere_triangle-inl.h
+++ b/include/fcl/narrowphase/detail/primitive_shape_algorithm/sphere_triangle-inl.h
@@ -156,7 +156,8 @@ bool sphereTriangleIntersect(const Sphere<S>& s, const Transform3<S>& tf,
   bool is_inside_contact_plane = (distance_from_plane < radius_with_threshold);
 
   bool has_contact = false;
-  Vector3<S> contact_point;
+  Vector3<S> contact_point =
+      Vector3<S>::Constant(std::numeric_limits<S>::quiet_NaN());
   if(is_inside_contact_plane)
   {
     if(projectInTriangle(P1, P2, P3, normal, center))

--- a/test/narrowphase/detail/primitive_shape_algorithm/test_sphere_box.cpp
+++ b/test/narrowphase/detail/primitive_shape_algorithm/test_sphere_box.cpp
@@ -597,7 +597,7 @@ void QueryWithVaryingWorldFrames(
   auto evaluate_all = [&R_BS, query_eval](
       const std::vector<TestConfiguration<S>>& configs,
       const Transform3<S>& X_FB) {
-    for (const auto config : configs) {
+    for (const auto& config : configs) {
       query_eval(config, X_FB, R_BS, Eps<S>::value());
     }
   };

--- a/test/narrowphase/detail/primitive_shape_algorithm/test_sphere_cylinder.cpp
+++ b/test/narrowphase/detail/primitive_shape_algorithm/test_sphere_cylinder.cpp
@@ -784,7 +784,7 @@ void QueryWithVaryingWorldFrames(
   auto evaluate_all = [&R_CS, query_eval](
       const std::vector<TestConfiguration<S>>& configs,
       const Transform3<S>& X_FC) {
-    for (const auto config : configs) {
+    for (const auto& config : configs) {
       query_eval(config, X_FC, R_CS, Eps<S>::value());
     }
   };

--- a/test/test_fcl_broadphase_distance.cpp
+++ b/test/test_fcl_broadphase_distance.cpp
@@ -443,10 +443,10 @@ void broad_phase_distance_test(S env_scale, std::size_t env_size, std::size_t qu
 
   std::vector<CollisionObject<S>*> query;
 
-  BroadPhaseCollisionManager<S>* manager = new NaiveCollisionManager<S>();
+  NaiveCollisionManager<S> manager;
   for(std::size_t i = 0; i < env.size(); ++i)
-    manager->registerObject(env[i]);
-  manager->setup();
+    manager.registerObject(env[i]);
+  manager.setup();
 
   while(1)
   {
@@ -459,7 +459,7 @@ void broad_phase_distance_test(S env_scale, std::size_t env_size, std::size_t qu
     for(std::size_t i = 0; i < candidates.size(); ++i)
     {
       DefaultCollisionData<S> query_data;
-      manager->collide(candidates[i], &query_data, DefaultCollisionFunction);
+      manager.collide(candidates[i], &query_data, DefaultCollisionFunction);
       if(query_data.result.numContacts() == 0)
         query.push_back(candidates[i]);
       else
@@ -469,8 +469,6 @@ void broad_phase_distance_test(S env_scale, std::size_t env_size, std::size_t qu
 
     if(query.size() == query_size) break;
   }
-
-  delete manager;
 
   std::vector<BroadPhaseCollisionManager<S>*> managers;
 

--- a/test/test_fcl_simple.cpp
+++ b/test/test_fcl_simple.cpp
@@ -106,8 +106,10 @@ void test_Vec_nf_test()
   std::cout << c.transpose() << std::endl;
 
   VectorN<S, 4> upper, lower;
-  for(int i = 0; i < 4; ++i)
+  for(int i = 0; i < 4; ++i) {
     upper[i] = 1;
+    lower[i] = -1;
+  }
 
   VectorN<S, 4> aa = VectorN<S, 4>(1, 2, 1, 2);
   std::cout << aa.transpose() << std::endl;


### PR DESCRIPTION
There were a number of uninitialized warnings (particularly with Eigen vectors). This initializes them so there's no complaints.

There was also some compiler confusion about a polymorphic type (NaiveCollisionManager()). Simply replaced a pointer to the heap with an object on the stack.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/657)
<!-- Reviewable:end -->
