### PR TITLE
Minor code corrections

### DIFF
--- a/include/fcl/math/geometry-inl.h
+++ b/include/fcl/math/geometry-inl.h
@@ -480,7 +480,6 @@ void eigen_old(const Matrix3<S>& m, Vector3<S>& dout, Matrix3<S>& vout)
   int n = 3;
   int j, iq, ip, i;
   S tresh, theta, tau, t, sm, s, h, g, c;
-  int nrot;
   S b[3];
   S z[3];
   S v[3][3] = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
@@ -491,8 +490,6 @@ void eigen_old(const Matrix3<S>& m, Vector3<S>& dout, Matrix3<S>& vout)
     b[ip] = d[ip] = R(ip, ip);
     z[ip] = 0;
   }
-
-  nrot = 0;
 
   for(i = 0; i < 50; ++i)
   {
@@ -544,7 +541,6 @@ void eigen_old(const Matrix3<S>& m, Vector3<S>& dout, Matrix3<S>& vout)
           for(j = ip + 1; j < iq; ++j) { g = R(ip, j); h = R(j, iq); R(ip, j) = g - s * (h + g * tau); R(j, iq) = h + s * (g - h * tau); }
           for(j = iq + 1; j < n; ++j) { g = R(ip, j); h = R(iq, j); R(ip, j) = g - s * (h + g * tau); R(iq, j) = h + s * (g - h * tau); }
           for(j = 0; j < n; ++j) { g = v[j][ip]; h = v[j][iq]; v[j][ip] = g - s * (h + g * tau); v[j][iq] = h + s * (g - h * tau); }
-          nrot++;
         }
       }
     }

--- a/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_gjk_initializer.cpp
+++ b/test/narrowphase/detail/convexity_based_algorithm/test_gjk_libccd-inl_gjk_initializer.cpp
@@ -51,7 +51,6 @@ namespace detail {
 namespace {
 
 using std::make_shared;
-using std::move;
 using std::pair;
 using std::vector;
 
@@ -109,8 +108,8 @@ GTEST_TEST(GjkLibccdSupportFunction, ConvexSupport) {
   // clang-format on
   const int kNumFaces = 6;
   const bool kThrowIfInvalid = true;
-  const Convex<double> convex_C(move(vertices), kNumFaces, move(faces),
-                                kThrowIfInvalid);
+  const Convex<double> convex_C(std::move(vertices), kNumFaces,
+                                std::move(faces), kThrowIfInvalid);
 
   /* Collection of arbitrary poses of the convex mesh: identity, translation,
    and rotation. */


### PR DESCRIPTION
1. Remove unused variable
   - a counter that never gets read; modern compilers get angry about it.
2. Misuse of std::move -- we should never do "using std::move".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/660)
<!-- Reviewable:end -->
