### PR TITLE
Explicitly initialize InterpMotion<S>::reference_p and linear_vel

### DIFF
--- a/include/fcl/math/motion/interp_motion-inl.h
+++ b/include/fcl/math/motion/interp_motion-inl.h
@@ -56,8 +56,10 @@ InterpMotion<S>::InterpMotion()
   angular_vel = 0;
 
   // Default reference point is local zero point
+  reference_p = Vector3<S>::Zero();
 
   // Default linear velocity is zero
+  linear_vel = Vector3<S>::Zero();
 }
 
 //==============================================================================


### PR DESCRIPTION
I recently debugged some code where the `InterpMotion<S>::reference_p` and `linear_vel` member variables were not zero when initialized, though the variables need to be zero (as described by the comments). I've explicitly zeroed these vectors when calling the default constructor which fixed my personal local issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/flexible-collision-library/fcl/662)
<!-- Reviewable:end -->
